### PR TITLE
feat: hook config generation from [[hooks]] in agents.toml

### DIFF
--- a/src/agents/definitions/claude.ts
+++ b/src/agents/definitions/claude.ts
@@ -1,5 +1,5 @@
 import type { AgentDefinition } from "../types.js";
-import { envRecord, httpServer } from "./helpers.js";
+import { envRecord, httpServer, serializeClaudeHooks } from "./helpers.js";
 
 const claude: AgentDefinition = {
   id: "claude",
@@ -17,6 +17,13 @@ const claude: AgentDefinition = {
     const env = envRecord(s.env, (k) => `\${${k}}`);
     return [s.name, { command: s.command, args: s.args ?? [], ...(env && { env }) }];
   },
+  hooks: {
+    filePath: ".claude/settings.json",
+    rootKey: "hooks",
+    format: "json",
+    shared: true,
+  },
+  serializeHooks: serializeClaudeHooks,
 };
 
 export default claude;

--- a/src/agents/definitions/codex.ts
+++ b/src/agents/definitions/codex.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from "../types.js";
+import { UnsupportedFeature } from "../errors.js";
 import claude from "./claude.js";
 
 const codex: AgentDefinition = {
@@ -12,6 +13,10 @@ const codex: AgentDefinition = {
     rootKey: "mcp_servers",
     format: "toml",
     shared: true,
+  },
+  hooks: undefined,
+  serializeHooks() {
+    throw new UnsupportedFeature("codex", "hooks");
   },
 };
 

--- a/src/agents/definitions/cursor.ts
+++ b/src/agents/definitions/cursor.ts
@@ -1,5 +1,17 @@
-import type { AgentDefinition } from "../types.js";
+import type { AgentDefinition, HookDeclaration } from "../types.js";
+import type { HookEvent } from "../../config/schema.js";
 import claude from "./claude.js";
+
+/**
+ * Maps universal hook events to Cursor event names.
+ * PreToolUse maps to both beforeShellExecution and beforeMCPExecution.
+ */
+const CURSOR_EVENT_MAP: Record<HookEvent, string[]> = {
+  PreToolUse: ["beforeShellExecution", "beforeMCPExecution"],
+  PostToolUse: ["afterFileEdit"],
+  UserPromptSubmit: ["beforeSubmitPrompt"],
+  Stop: ["stop"],
+};
 
 const cursor: AgentDefinition = {
   ...claude,
@@ -12,6 +24,25 @@ const cursor: AgentDefinition = {
     rootKey: "mcpServers",
     format: "json",
     shared: false,
+  },
+  hooks: {
+    filePath: ".cursor/hooks.json",
+    rootKey: "hooks",
+    format: "json",
+    shared: false,
+    extraFields: { version: 1 },
+  },
+  serializeHooks(hooks: HookDeclaration[]) {
+    const result: Record<string, unknown[]> = {};
+    for (const h of hooks) {
+      const cursorEvents = CURSOR_EVENT_MAP[h.event];
+      for (const ce of cursorEvents) {
+        const list = (result[ce] as unknown[]) ?? [];
+        list.push({ command: h.command });
+        result[ce] = list;
+      }
+    }
+    return result;
   },
 };
 

--- a/src/agents/definitions/helpers.ts
+++ b/src/agents/definitions/helpers.ts
@@ -1,4 +1,4 @@
-import type { McpDeclaration } from "../types.js";
+import type { McpDeclaration, HookDeclaration } from "../types.js";
 
 export function envRecord(
   env: string[] | undefined,
@@ -19,4 +19,25 @@ export function httpServer(s: McpDeclaration, type?: string): [string, unknown] 
       ...(s.headers && { headers: s.headers }),
     },
   ];
+}
+
+/**
+ * Serialize hooks into Claude Code / VS Code settings.json format.
+ *
+ * Output shape:
+ * {
+ *   "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "..." }] }],
+ *   "Stop": [{ "hooks": [{ "type": "command", "command": "..." }] }]
+ * }
+ */
+export function serializeClaudeHooks(hooks: HookDeclaration[]): Record<string, unknown> {
+  const result: Record<string, unknown[]> = {};
+  for (const h of hooks) {
+    const entry = {
+      ...(h.matcher && { matcher: h.matcher }),
+      hooks: [{ type: "command", command: h.command }],
+    };
+    (result[h.event] ??= []).push(entry);
+  }
+  return result;
 }

--- a/src/agents/definitions/opencode.ts
+++ b/src/agents/definitions/opencode.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from "../types.js";
+import { UnsupportedFeature } from "../errors.js";
 import { envRecord, httpServer } from "./helpers.js";
 
 const opencode: AgentDefinition = {
@@ -23,6 +24,10 @@ const opencode: AgentDefinition = {
         ...(env && { environment: env }),
       },
     ];
+  },
+  hooks: undefined,
+  serializeHooks() {
+    throw new UnsupportedFeature("opencode", "hooks");
   },
 };
 

--- a/src/agents/definitions/vscode.ts
+++ b/src/agents/definitions/vscode.ts
@@ -1,5 +1,5 @@
 import type { AgentDefinition } from "../types.js";
-import { envRecord, httpServer } from "./helpers.js";
+import { envRecord, httpServer, serializeClaudeHooks } from "./helpers.js";
 
 const vscode: AgentDefinition = {
   id: "vscode",
@@ -20,6 +20,13 @@ const vscode: AgentDefinition = {
       { type: "stdio", command: s.command, args: s.args ?? [], ...(env && { env }) },
     ];
   },
+  hooks: {
+    filePath: ".claude/settings.json",
+    rootKey: "hooks",
+    format: "json",
+    shared: true,
+  },
+  serializeHooks: serializeClaudeHooks,
 };
 
 export default vscode;

--- a/src/agents/errors.ts
+++ b/src/agents/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Thrown when an agent does not support a requested feature (e.g. hooks).
+ */
+export class UnsupportedFeature extends Error {
+  constructor(
+    public readonly agentId: string,
+    public readonly feature: string,
+  ) {
+    super(`Agent "${agentId}" does not support ${feature}`);
+    this.name = "UnsupportedFeature";
+  }
+}

--- a/src/agents/hook-writer.test.ts
+++ b/src/agents/hook-writer.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import { writeHookConfigs, verifyHookConfigs, toHookDeclarations } from "./hook-writer.js";
+import type { HookDeclaration } from "./types.js";
+import type { HookConfig } from "../config/schema.js";
+
+const HOOKS: HookDeclaration[] = [
+  { event: "PreToolUse", matcher: "Bash", command: ".agents/hooks/block-rm.sh" },
+  { event: "Stop", command: ".agents/hooks/check-tests.sh" },
+];
+
+describe("toHookDeclarations", () => {
+  it("converts HookConfig entries to HookDeclarations", () => {
+    const configs: HookConfig[] = [
+      { event: "PreToolUse", matcher: "Bash", command: ".agents/hooks/block-rm.sh" },
+      { event: "Stop", command: ".agents/hooks/check-tests.sh" },
+    ];
+    const decls = toHookDeclarations(configs);
+    expect(decls).toEqual(HOOKS);
+  });
+
+  it("omits matcher when not present", () => {
+    const configs: HookConfig[] = [{ event: "Stop", command: "test.sh" }];
+    const decls = toHookDeclarations(configs);
+    expect(decls[0]).toEqual({ event: "Stop", command: "test.sh" });
+    expect("matcher" in decls[0]!).toBe(false);
+  });
+});
+
+describe("writeHookConfigs", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dotagents-hooks-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true });
+  });
+
+  it("skips when no hooks declared", async () => {
+    const warnings = await writeHookConfigs(dir, ["claude"], []);
+    expect(warnings).toEqual([]);
+    expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(false);
+  });
+
+  it("writes claude .claude/settings.json", async () => {
+    await writeHookConfigs(dir, ["claude"], HOOKS);
+
+    const content = JSON.parse(await readFile(join(dir, ".claude", "settings.json"), "utf-8"));
+    expect(content.hooks.PreToolUse).toEqual([
+      { matcher: "Bash", hooks: [{ type: "command", command: ".agents/hooks/block-rm.sh" }] },
+    ]);
+    expect(content.hooks.Stop).toEqual([
+      { hooks: [{ type: "command", command: ".agents/hooks/check-tests.sh" }] },
+    ]);
+  });
+
+  it("writes cursor .cursor/hooks.json with version field", async () => {
+    await writeHookConfigs(dir, ["cursor"], HOOKS);
+
+    const content = JSON.parse(await readFile(join(dir, ".cursor", "hooks.json"), "utf-8"));
+    expect(content.version).toBe(1);
+    expect(content.hooks.beforeShellExecution).toEqual([
+      { command: ".agents/hooks/block-rm.sh" },
+    ]);
+    expect(content.hooks.beforeMCPExecution).toEqual([
+      { command: ".agents/hooks/block-rm.sh" },
+    ]);
+    expect(content.hooks.stop).toEqual([
+      { command: ".agents/hooks/check-tests.sh" },
+    ]);
+  });
+
+  it("cursor drops matcher", async () => {
+    await writeHookConfigs(dir, ["cursor"], HOOKS);
+
+    const content = JSON.parse(await readFile(join(dir, ".cursor", "hooks.json"), "utf-8"));
+    // Cursor hooks should not contain matcher
+    for (const entries of Object.values(content.hooks) as unknown[][]) {
+      for (const entry of entries) {
+        expect(entry).not.toHaveProperty("matcher");
+      }
+    }
+  });
+
+  it("writes vscode to same .claude/settings.json as claude", async () => {
+    await writeHookConfigs(dir, ["vscode"], HOOKS);
+
+    const content = JSON.parse(await readFile(join(dir, ".claude", "settings.json"), "utf-8"));
+    expect(content.hooks.PreToolUse).toBeDefined();
+  });
+
+  it("deduplicates shared file between claude and vscode", async () => {
+    await writeHookConfigs(dir, ["claude", "vscode"], HOOKS);
+
+    // Should only write once — both target .claude/settings.json
+    const content = JSON.parse(await readFile(join(dir, ".claude", "settings.json"), "utf-8"));
+    expect(content.hooks.PreToolUse).toHaveLength(1);
+  });
+
+  it("returns warnings for unsupported agents", async () => {
+    const warnings = await writeHookConfigs(dir, ["codex", "opencode"], HOOKS);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]!.agent).toBe("codex");
+    expect(warnings[1]!.agent).toBe("opencode");
+    expect(warnings[0]!.message).toContain("does not support");
+  });
+
+  it("writes supported agents and warns for unsupported ones", async () => {
+    const warnings = await writeHookConfigs(dir, ["claude", "codex"], HOOKS);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.agent).toBe("codex");
+    expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(true);
+  });
+
+  it("merges into existing shared config file", async () => {
+    const claudeDir = join(dir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(
+      join(claudeDir, "settings.json"),
+      JSON.stringify({ permissions: { allow: ["Read"] } }, null, 2),
+      "utf-8",
+    );
+
+    await writeHookConfigs(dir, ["claude"], HOOKS);
+
+    const content = JSON.parse(await readFile(join(claudeDir, "settings.json"), "utf-8"));
+    expect(content.permissions).toEqual({ allow: ["Read"] });
+    expect(content.hooks).toBeDefined();
+  });
+
+  it("is idempotent", async () => {
+    await writeHookConfigs(dir, ["claude"], HOOKS);
+    const first = await readFile(join(dir, ".claude", "settings.json"), "utf-8");
+
+    await writeHookConfigs(dir, ["claude"], HOOKS);
+    const second = await readFile(join(dir, ".claude", "settings.json"), "utf-8");
+
+    expect(first).toBe(second);
+  });
+
+  it("handles multiple agents including cursor", async () => {
+    await writeHookConfigs(dir, ["claude", "cursor"], HOOKS);
+
+    expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(dir, ".cursor", "hooks.json"))).toBe(true);
+  });
+});
+
+describe("verifyHookConfigs", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dotagents-hooks-verify-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true });
+  });
+
+  it("returns no issues when configs match", async () => {
+    await writeHookConfigs(dir, ["claude"], HOOKS);
+    const issues = await verifyHookConfigs(dir, ["claude"], HOOKS);
+    expect(issues).toEqual([]);
+  });
+
+  it("reports missing config file", async () => {
+    const issues = await verifyHookConfigs(dir, ["claude"], HOOKS);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.issue).toContain("missing");
+  });
+
+  it("skips unsupported agents without reporting issues", async () => {
+    const issues = await verifyHookConfigs(dir, ["codex"], HOOKS);
+    expect(issues).toEqual([]);
+  });
+
+  it("returns empty when no hooks declared", async () => {
+    const issues = await verifyHookConfigs(dir, ["claude"], []);
+    expect(issues).toEqual([]);
+  });
+
+  it("reports missing hooks key", async () => {
+    const claudeDir = join(dir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(
+      join(claudeDir, "settings.json"),
+      JSON.stringify({ permissions: {} }, null, 2),
+      "utf-8",
+    );
+
+    const issues = await verifyHookConfigs(dir, ["claude"], HOOKS);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.issue).toContain("hooks");
+  });
+});

--- a/src/agents/hook-writer.ts
+++ b/src/agents/hook-writer.ts
@@ -1,0 +1,139 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { existsSync } from "node:fs";
+import { getAgent } from "./registry.js";
+import type { HookDeclaration, HookConfigSpec } from "./types.js";
+import type { HookConfig } from "../config/schema.js";
+
+/**
+ * Convert HookConfig entries (from agents.toml) to universal HookDeclarations.
+ */
+export function toHookDeclarations(configs: HookConfig[]): HookDeclaration[] {
+  return configs.map((h) => ({
+    event: h.event,
+    ...(h.matcher && { matcher: h.matcher }),
+    command: h.command,
+  }));
+}
+
+export interface HookWriteWarning {
+  agent: string;
+  message: string;
+}
+
+/**
+ * Write hook config files for each agent.
+ * - Dedicated files (shared=false): written fresh each time.
+ * - Shared files (shared=true): read existing, merge hooks under the root key, write back.
+ * - Agents that don't support hooks: collected as warnings.
+ */
+export async function writeHookConfigs(
+  projectRoot: string,
+  agentIds: string[],
+  hooks: HookDeclaration[],
+): Promise<HookWriteWarning[]> {
+  const warnings: HookWriteWarning[] = [];
+  if (hooks.length === 0) return warnings;
+
+  const seen = new Set<string>();
+
+  for (const id of agentIds) {
+    const agent = getAgent(id);
+    if (!agent) continue;
+
+    if (!agent.hooks) {
+      warnings.push({ agent: id, message: `Agent "${agent.displayName}" does not support hooks` });
+      continue;
+    }
+
+    const serialized = agent.serializeHooks(hooks);
+    const spec = agent.hooks;
+    if (seen.has(spec.filePath)) continue;
+    seen.add(spec.filePath);
+
+    const filePath = join(projectRoot, spec.filePath);
+    await mkdir(dirname(filePath), { recursive: true });
+
+    if (spec.shared) {
+      await mergeWrite(filePath, spec, serialized);
+    } else {
+      await freshWrite(filePath, spec, serialized);
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Verify hook configs exist and contain expected hook data.
+ * Returns a list of issues found.
+ */
+export async function verifyHookConfigs(
+  projectRoot: string,
+  agentIds: string[],
+  hooks: HookDeclaration[],
+): Promise<{ agent: string; issue: string }[]> {
+  if (hooks.length === 0) return [];
+
+  const issues: { agent: string; issue: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const id of agentIds) {
+    const agent = getAgent(id);
+    if (!agent) continue;
+
+    // Skip agents that don't support hooks
+    if (!agent.hooks) continue;
+
+    const spec = agent.hooks;
+    if (seen.has(spec.filePath)) continue;
+    seen.add(spec.filePath);
+
+    const filePath = join(projectRoot, spec.filePath);
+    if (!existsSync(filePath)) {
+      issues.push({ agent: id, issue: `Hook config missing: ${spec.filePath}` });
+      continue;
+    }
+
+    try {
+      const existing = await readExisting(filePath);
+      const hooksSection = existing[spec.rootKey];
+      if (!hooksSection || typeof hooksSection !== "object") {
+        issues.push({ agent: id, issue: `Hook config missing "${spec.rootKey}" key in ${spec.filePath}` });
+      }
+    } catch {
+      issues.push({ agent: id, issue: `Failed to read hook config: ${spec.filePath}` });
+    }
+  }
+
+  return issues;
+}
+
+// --- Internal helpers ---
+
+async function freshWrite(
+  filePath: string,
+  spec: HookConfigSpec,
+  serialized: unknown,
+): Promise<void> {
+  const doc: Record<string, unknown> = {
+    ...spec.extraFields,
+    [spec.rootKey]: serialized,
+  };
+  await writeFile(filePath, JSON.stringify(doc, null, 2) + "\n", "utf-8");
+}
+
+async function mergeWrite(
+  filePath: string,
+  spec: HookConfigSpec,
+  serialized: unknown,
+): Promise<void> {
+  const existing = existsSync(filePath) ? await readExisting(filePath) : {};
+  existing[spec.rootKey] = serialized;
+  await writeFile(filePath, JSON.stringify(existing, null, 2) + "\n", "utf-8");
+}
+
+async function readExisting(filePath: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(filePath, "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,8 +1,13 @@
 export { getAgent, allAgentIds } from "./registry.js";
 export { writeMcpConfigs, verifyMcpConfigs, toMcpDeclarations } from "./mcp-writer.js";
+export { writeHookConfigs, verifyHookConfigs, toHookDeclarations } from "./hook-writer.js";
+export { UnsupportedFeature } from "./errors.js";
 export type {
   AgentDefinition,
   McpDeclaration,
   McpConfigSpec,
   McpSerializer,
+  HookDeclaration,
+  HookConfigSpec,
+  HookSerializer,
 } from "./types.js";

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,3 +1,5 @@
+import type { HookEvent } from "../config/schema.js";
+
 /**
  * Universal MCP server declaration from agents.toml [[mcp]] sections.
  * Represents either a stdio or HTTP server.
@@ -38,6 +40,40 @@ export interface McpConfigSpec {
 export type McpSerializer = (server: McpDeclaration) => [string, unknown];
 
 /**
+ * Universal hook declaration from agents.toml [[hooks]] sections.
+ */
+export interface HookDeclaration {
+  event: HookEvent;
+  matcher?: string;
+  command: string;
+}
+
+/**
+ * Describes how an agent writes its hook config file.
+ */
+export interface HookConfigSpec {
+  /** Path to the config file, relative to project root */
+  filePath: string;
+  /** Top-level key under which hooks live */
+  rootKey: string;
+  /** File format */
+  format: "json";
+  /**
+   * If true, the config file is shared with other content and must be
+   * read-merge-written. If false, dotagents owns the entire file.
+   */
+  shared: boolean;
+  /** Extra top-level fields to include (e.g. Cursor's {version: 1}) */
+  extraFields?: Record<string, unknown>;
+}
+
+/**
+ * Transforms universal HookDeclarations into the agent-specific shape.
+ * Returns the full value for the rootKey.
+ */
+export type HookSerializer = (hooks: HookDeclaration[]) => unknown;
+
+/**
  * Definition of an agent tool that dotagents manages.
  */
 export interface AgentDefinition {
@@ -51,4 +87,8 @@ export interface AgentDefinition {
   mcp: McpConfigSpec;
   /** Transforms universal MCP declaration to agent-specific format */
   serializeServer: McpSerializer;
+  /** Hook config file specification (undefined if agent doesn't support hooks) */
+  hooks?: HookConfigSpec;
+  /** Transforms universal hook declarations to agent-specific format */
+  serializeHooks: HookSerializer;
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -78,6 +78,23 @@ const mcpSchema = z
 
 export type McpConfig = z.infer<typeof mcpSchema>;
 
+export const hookEventSchema = z.enum([
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "Stop",
+]);
+
+export type HookEvent = z.infer<typeof hookEventSchema>;
+
+const hookSchema = z.object({
+  event: hookEventSchema,
+  matcher: z.string().optional(),
+  command: z.string().min(1, "Hook command is required"),
+});
+
+export type HookConfig = z.infer<typeof hookSchema>;
+
 export const agentsConfigSchema = z.object({
   version: z.literal(1),
   gitignore: z.boolean().default(true),
@@ -86,6 +103,7 @@ export const agentsConfigSchema = z.object({
   agents: z.array(z.string()).default([]),
   skills: z.array(skillDependencySchema).default([]),
   mcp: z.array(mcpSchema).default([]),
+  hooks: z.array(hookSchema).default([]),
 });
 
 export type AgentsConfig = z.infer<typeof agentsConfigSchema>;


### PR DESCRIPTION
Add support for universal `[[hooks]]` declarations in `agents.toml` that generate per-agent hook config files, mirroring the existing `[[mcp]]` pattern.

Three of the five supported agents have JSON-based hook systems:
- **Claude Code / VS Code** → `.claude/settings.json` (shared, merge-write under `"hooks"` key)
- **Cursor** → `.cursor/hooks.json` (event name mapping, drops matcher, includes `{version: 1}`)
- **Codex / OpenCode** → warning surfaced (hooks not yet supported by these agents)

Example `agents.toml`:
```toml
[[hooks]]
event = "PreToolUse"
matcher = "Bash"
command = ".agents/hooks/block-rm.sh"

[[hooks]]
event = "Stop"
command = ".agents/hooks/check-tests.sh"
```

The implementation follows the same architecture as MCP config generation: schema validation in `config/schema.ts`, universal declarations in `agents/types.ts`, per-agent serializers in the agent definitions, and a writer module (`hook-writer.ts`) that handles fresh-write vs merge-write and shared file deduplication.

`install` writes hook configs (step 7) and surfaces warnings for unsupported agents. `sync` verifies and repairs hook configs (step 8).