### PR TITLE
fix(ci): use find-bugs from getsentry/skills in warden config

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -6,7 +6,8 @@ reportOn = "medium"
 ignorePaths = ["dist/**"]
 
 [[skills]]
-name = "notseer"
+name = "find-bugs"
+remote = "getsentry/skills"
 paths = ["src/**/*.ts"]
 ignorePaths = ["src/**/*.test.ts"]
 


### PR DESCRIPTION
Replace `notseer` with `find-bugs` from `getsentry/skills` in `warden.toml`. The notseer skill doesn't exist; find-bugs is the correct skill for bug detection in PR reviews.