### PR TITLE
fix(agents): Add type: http to MCP HTTP server configs

### DIFF
--- a/src/agents/definitions/claude.ts
+++ b/src/agents/definitions/claude.ts
@@ -16,7 +16,7 @@ const claude: AgentDefinition = {
     shared: false,
   },
   serializeServer(s) {
-    if (s.url) return httpServer(s);
+    if (s.url) return httpServer(s, "http");
     const env = envRecord(s.env, (k) => `\${${k}}`);
     return [s.name, { command: s.command, args: s.args ?? [], ...(env && { env }) }];
   },

--- a/src/agents/definitions/codex.ts
+++ b/src/agents/definitions/codex.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from "../types.js";
 import { UnsupportedFeature } from "../errors.js";
 import claude from "./claude.js";
+import { envRecord } from "./helpers.js";
 
 const codex: AgentDefinition = {
   ...claude,
@@ -15,6 +16,13 @@ const codex: AgentDefinition = {
     rootKey: "mcp_servers",
     format: "toml",
     shared: true,
+  },
+  serializeServer(s) {
+    if (s.url) {
+      return [s.name, { url: s.url, ...(s.headers && { http_headers: s.headers }) }];
+    }
+    const env = envRecord(s.env, (k) => `\${${k}}`);
+    return [s.name, { command: s.command, args: s.args ?? [], ...(env && { env }) }];
   },
   hooks: undefined,
   serializeHooks() {

--- a/src/agents/definitions/vscode.ts
+++ b/src/agents/definitions/vscode.ts
@@ -13,7 +13,7 @@ const vscode: AgentDefinition = {
     shared: false,
   },
   serializeServer(s) {
-    if (s.url) return httpServer(s, "sse");
+    if (s.url) return httpServer(s, "http");
     const env = envRecord(s.env, (k) => `\${input:${k}}`);
     return [
       s.name,

--- a/src/agents/registry.test.ts
+++ b/src/agents/registry.test.ts
@@ -56,6 +56,7 @@ describe("claude serializer", () => {
     const [name, config] = agent.serializeServer(HTTP_SERVER);
     expect(name).toBe("remote-api");
     expect(config).toEqual({
+      type: "http",
       url: "https://mcp.example.com/sse",
       headers: { Authorization: "Bearer tok" },
     });
@@ -90,6 +91,15 @@ describe("codex serializer", () => {
     });
   });
 
+  it("serializes http server with http_headers and no type", () => {
+    const [name, config] = agent.serializeServer(HTTP_SERVER);
+    expect(name).toBe("remote-api");
+    expect(config).toEqual({
+      url: "https://mcp.example.com/sse",
+      http_headers: { Authorization: "Bearer tok" },
+    });
+  });
+
   it("has toml format and shared flag", () => {
     expect(agent.mcp.format).toBe("toml");
     expect(agent.mcp.shared).toBe(true);
@@ -110,11 +120,11 @@ describe("vscode serializer", () => {
     });
   });
 
-  it("serializes http server with sse type", () => {
+  it("serializes http server with http type", () => {
     const [name, config] = agent.serializeServer(HTTP_SERVER);
     expect(name).toBe("remote-api");
     expect(config).toEqual({
-      type: "sse",
+      type: "http",
       url: "https://mcp.example.com/sse",
       headers: { Authorization: "Bearer tok" },
     });


### PR DESCRIPTION
Claude Code requires `type: "http"` for remote MCP servers, but dotagents omitted this field — causing Claude to reject the config as malformed. Auditing all 5 agent serializers revealed additional issues:

- **Claude**: missing `type` field entirely — config rejected as malformed
- **Cursor**: inherited Claude's broken output (also missing `type`)
- **VS Code**: emitted deprecated `type: "sse"` instead of `type: "http"`
- **Codex**: inherited Claude's `headers` key instead of Codex's expected `http_headers`
- **OpenCode**: already correct (`type: "remote"`)

Fixes all three broken agents by adding `type: "http"` to Claude (inherited by Cursor), updating VS Code from `"sse"` to `"http"`, and giving Codex its own serializer that maps `headers` → `http_headers` and omits `type`.

Also adds HTTP server e2e tests for every agent in `mcp-writer.test.ts` to catch this class of bug going forward.

Co-Authored-By: Claude <noreply@anthropic.com>


Agent transcript: https://claudescope.sentry.dev/share/sp-UeENVVXGpFReEmk6k7mczIHjWq3GcBaW3GKrWGeg