### PR TITLE
feat(cli): Add --skill as alias for --name in add command

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -132,9 +132,12 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
     options: {
       ref: { type: "string" },
       name: { type: "string" },
+      skill: { type: "string" },
     },
     strict: true,
   });
+
+  const nameValue = values["name"] ?? values["skill"];
 
   const specifier = positionals[0];
   if (!specifier) {
@@ -149,7 +152,7 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
       scope,
       specifier,
       ref: values["ref"],
-      name: values["name"],
+      name: nameValue,
     });
     console.log(chalk.green(`Added skill: ${name}`));
   } catch (err) {


### PR DESCRIPTION
Add `--skill` as an alias for `--name` in the `dotagents add` command.

When adding a skill from a multi-skill repo, users currently need to use
`--name` to specify which skill to install. `--skill` is a more intuitive
flag name since the value refers to a skill name. Both flags now work
interchangeably, with `--name` taking precedence if both are provided.


Agent transcript: https://claudescope.sentry.dev/share/Z6LSxvqcIPeEOYmojCXW9AZffE_I0s-l5FukiH47X6s