### PR TITLE
feat(cli): Add update notifier and fix hardcoded version

### DIFF
--- a/src/cli/update-notifier.test.ts
+++ b/src/cli/update-notifier.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { compareSemver, formatUpdateMessage, checkForUpdate } from "./update-notifier.js";
+
+describe("compareSemver", () => {
+  it("returns positive when b is newer", () => {
+    expect(compareSemver("0.7.0", "0.8.0")).toBeGreaterThan(0);
+    expect(compareSemver("1.0.0", "2.0.0")).toBeGreaterThan(0);
+    expect(compareSemver("1.2.3", "1.2.4")).toBeGreaterThan(0);
+    expect(compareSemver("0.1.0", "0.2.0")).toBeGreaterThan(0);
+  });
+
+  it("returns negative when a is newer", () => {
+    expect(compareSemver("0.8.0", "0.7.0")).toBeLessThan(0);
+    expect(compareSemver("2.0.0", "1.0.0")).toBeLessThan(0);
+  });
+
+  it("returns zero when versions are equal", () => {
+    expect(compareSemver("1.0.0", "1.0.0")).toBe(0);
+    expect(compareSemver("0.7.0", "0.7.0")).toBe(0);
+  });
+
+  it("compares major before minor before patch", () => {
+    expect(compareSemver("1.9.9", "2.0.0")).toBeGreaterThan(0);
+    expect(compareSemver("1.0.9", "1.1.0")).toBeGreaterThan(0);
+  });
+});
+
+describe("formatUpdateMessage", () => {
+  it("includes both versions and upgrade command", () => {
+    const msg = formatUpdateMessage("0.7.0", "0.8.0");
+    expect(msg).toContain("0.7.0");
+    expect(msg).toContain("0.8.0");
+    expect(msg).toContain("npm install -g @sentry/dotagents");
+  });
+
+  it("contains the arrow separator", () => {
+    const msg = formatUpdateMessage("1.0.0", "2.0.0");
+    expect(msg).toContain("\u2192");
+  });
+});
+
+describe("checkForUpdate", () => {
+  let cacheDir: string;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), "dotagents-update-"));
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(cacheDir, { recursive: true });
+  });
+
+  it("returns null when fetch fails", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch returns non-ok status", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when already on the latest version", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "0.7.0" }),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when on a newer version than registry", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "0.6.0" }),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it("returns a message when a newer version exists", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "0.8.0" }),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).not.toBeNull();
+    expect(result).toContain("0.7.0");
+    expect(result).toContain("0.8.0");
+  });
+
+  it("returns null when registry returns invalid json shape", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "no-version-field" }),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it("uses cached version when cache is fresh", async () => {
+    // Write a fresh cache file
+    await writeFile(
+      join(cacheDir, "update-check.json"),
+      JSON.stringify({ lastCheck: Date.now(), latestVersion: "0.9.0" }),
+    );
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toContain("0.9.0");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches when cache is stale", async () => {
+    // Write a stale cache (> 24h old)
+    await writeFile(
+      join(cacheDir, "update-check.json"),
+      JSON.stringify({ lastCheck: Date.now() - 25 * 60 * 60 * 1000, latestVersion: "0.8.0" }),
+    );
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "0.9.0" }),
+    } as Response);
+    const result = await checkForUpdate("0.7.0", { cacheDir });
+    expect(result).toContain("0.9.0");
+    expect(fetch).toHaveBeenCalled();
+  });
+});

--- a/src/cli/update-notifier.ts
+++ b/src/cli/update-notifier.ts
@@ -1,0 +1,102 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_CACHE_DIR = join(homedir(), ".dotagents");
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const REGISTRY_URL = "https://registry.npmjs.org/@sentry/dotagents/latest";
+const FETCH_TIMEOUT_MS = 3000;
+
+interface CacheData {
+  lastCheck: number;
+  latestVersion: string;
+}
+
+/**
+ * Compare two semver strings (x.y.z only).
+ * Returns positive if b > a, negative if a > b, 0 if equal.
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function readCache(cacheFile: string): Promise<CacheData | null> {
+  try {
+    const data = JSON.parse(await readFile(cacheFile, "utf-8"));
+    if (typeof data?.lastCheck === "number" && typeof data?.latestVersion === "string") {
+      return { lastCheck: data.lastCheck, latestVersion: data.latestVersion };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(cacheDir: string, data: CacheData): Promise<void> {
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(join(cacheDir, "update-check.json"), JSON.stringify(data), "utf-8");
+  } catch {
+    // Silently ignore write failures
+  }
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(REGISTRY_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { version?: unknown };
+    return typeof data.version === "string" ? data.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatUpdateMessage(
+  currentVersion: string,
+  latestVersion: string,
+): string {
+  return `Update available: ${currentVersion} \u2192 ${latestVersion}\nRun \`npm install -g @sentry/dotagents\` to upgrade`;
+}
+
+/**
+ * Check if a newer version of the package is available.
+ * Returns a formatted message string if an update exists, or null otherwise.
+ * Never throws — all failures silently return null.
+ */
+export async function checkForUpdate(
+  currentVersion: string,
+  options?: { cacheDir?: string },
+): Promise<string | null> {
+  try {
+    const cacheDir = options?.cacheDir ?? DEFAULT_CACHE_DIR;
+    const cache = await readCache(join(cacheDir, "update-check.json"));
+    const now = Date.now();
+
+    let latestVersion: string | null = null;
+
+    if (cache && now - cache.lastCheck < ONE_DAY_MS) {
+      latestVersion = cache.latestVersion;
+    } else {
+      latestVersion = await fetchLatestVersion();
+      if (latestVersion) {
+        await writeCache(cacheDir, { lastCheck: now, latestVersion });
+      }
+    }
+
+    if (!latestVersion) return null;
+    if (compareSemver(currentVersion, latestVersion) <= 0) return null;
+
+    return formatUpdateMessage(currentVersion, latestVersion);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Add a non-blocking update notifier so users of the globally-installed CLI
know when a newer version is available.

On every command invocation the CLI fires a background check against the
npm registry (`@sentry/dotagents/latest`). Results are cached in
`~/.dotagents/update-check.json` for 24 hours to avoid repeated network
calls. The fetch has a 3-second timeout and all failures silently return
null — the notifier never interrupts normal CLI operation. After the
command completes, a notice is printed to stderr if an update exists:

```
Update available: 0.7.0 → 0.8.0
Run `npm install -g @sentry/dotagents` to upgrade
```

Also fixes `--version` which was hardcoded to `"0.1.0"` — it now reads
the actual version from `package.json` via `createRequire`.


Agent transcript: https://claudescope.sentry.dev/share/_cLM72xAX5rJYp5Jyk5T4QyEZNvJrta3tqcxiAxN07U