### PR TITLE
fix(cli): Defer update check to avoid --version/--help hang

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,8 +31,6 @@ Options:
 }
 
 async function main(): Promise<void> {
-  const updateMessage = checkForUpdate(version);
-
   const args = process.argv.slice(2);
 
   // Extract --user flag before command dispatch
@@ -42,7 +40,7 @@ async function main(): Promise<void> {
 
   const first = args[0];
 
-  // Handle top-level flags before any command
+  // Handle top-level flags before any command (no update check needed)
   if (!first || first === "--help" || first === "-h") {
     printUsage();
     return;
@@ -59,6 +57,9 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
+
+  // Start update check in background (only for actual commands)
+  const updateMessage = checkForUpdate(version);
 
   // Pass remaining args (after command name) to the subcommand
   const mod = await import(`./commands/${first}.js`);


### PR DESCRIPTION
Move `checkForUpdate()` call to after early-return flag handling so the
network request isn't initiated for `--version`, `--help`, or unknown
commands.

When the update-check cache is stale (>24h), `checkForUpdate` fires a
fetch to npm with a 3-second timeout. Previously this was called at the
top of `main()`, before flag handling. For `--version` and `--help`, the
function returns early without awaiting the promise, but the in-flight
fetch keeps the Node.js event loop alive — causing a visible 1-3 second
hang after output.

The fix moves the call to after the early returns, so the update check
only runs for actual subcommands (`install`, `add`, etc.) where we
already `await` the result before exiting.

Found by Sentry bugbot on #15.


Agent transcript: https://claudescope.sentry.dev/share/2qMjnyPu2OxSMd_pvKJcWHmgaT2E9IACgp2LVC36pP8