### PR TITLE
fix(cli): Require at least one agent during interactive init

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -159,9 +159,9 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
 
   const selectedAgents = prompt(
     await clack.multiselect({
-      message: "Which agents do you use?",
+      message: "Which agents do you use? (space to select, enter to confirm)",
       options: allAgents().map((a) => ({ label: a.displayName, value: a.id })),
-      required: false,
+      required: true,
     }),
   );
 
@@ -208,7 +208,7 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
   await runInit({
     scope,
     force,
-    agents: selectedAgents.length > 0 ? selectedAgents : undefined,
+    agents: selectedAgents,
     gitignore,
     trust,
   });


### PR DESCRIPTION
The interactive `dotagents init` allowed users to proceed without selecting
any agents via the multiselect prompt (`required: false`). This produced a
valid but useless `agents.toml` with no agents configured.

Set `required: true` on the clack multiselect so it validates that at least
one agent is checked before continuing. Also added a usage hint to the prompt
message ("space to select, enter to confirm") since the multiselect controls
aren't obvious to all users.

Fixes #18


Agent transcript: https://claudescope.sentry.dev/share/bc10FwLJbeH3hwLSb03YC1Qz-su_jZklcKsPnJPhHMc