### PR TITLE
ref(cursor): Share .claude/skills symlink instead of .cursor/skills

### DIFF
--- a/src/agents/definitions/cursor.ts
+++ b/src/agents/definitions/cursor.ts
@@ -20,8 +20,8 @@ const cursor: AgentDefinition = {
   id: "cursor",
   displayName: "Cursor",
   configDir: ".cursor",
-  skillsParentDir: ".cursor",
-  userSkillsParentDirs: [join(homedir(), ".cursor")],
+  skillsParentDir: ".claude",
+  userSkillsParentDirs: [join(homedir(), ".claude")],
   mcp: {
     filePath: ".cursor/mcp.json",
     rootKey: "mcpServers",

--- a/src/agents/paths.test.ts
+++ b/src/agents/paths.test.ts
@@ -59,10 +59,10 @@ describe("skill discovery paths", () => {
     expect(agent.userSkillsParentDirs).toEqual([join(home, ".claude")]);
   });
 
-  it("cursor needs project and user symlinks", () => {
+  it("cursor shares .claude skills symlink", () => {
     const agent = getAgent("cursor")!;
-    expect(agent.skillsParentDir).toBe(".cursor");
-    expect(agent.userSkillsParentDirs).toEqual([join(home, ".cursor")]);
+    expect(agent.skillsParentDir).toBe(".claude");
+    expect(agent.userSkillsParentDirs).toEqual([join(home, ".claude")]);
   });
 
   // Agents that DO read .agents/skills/ natively need no symlinks

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -101,13 +101,13 @@ describe("runInit", () => {
     expect(config.agents).toEqual(["claude", "cursor"]);
   });
 
-  it("creates agent-specific symlinks when --agents is provided", async () => {
+  it("creates agent-specific symlinks when --agents is provided (cursor shares .claude)", async () => {
     await runInit({ scope: resolveScope("project", dir), agents: ["claude", "cursor"] });
 
     const claudeStat = await lstat(join(dir, ".claude", "skills"));
     expect(claudeStat.isSymbolicLink()).toBe(true);
-    const cursorStat = await lstat(join(dir, ".cursor", "skills"));
-    expect(cursorStat.isSymbolicLink()).toBe(true);
+    // Cursor shares .claude/skills — no .cursor/skills symlink created
+    await expect(lstat(join(dir, ".cursor", "skills"))).rejects.toThrow();
   });
 
   it("rejects unknown agent IDs", async () => {


### PR DESCRIPTION
Cursor can read skills from `.claude/skills/` just like Claude Code, so
there's no reason to maintain a separate `.cursor/skills/` symlink. This
changes Cursor's `skillsParentDir` and `userSkillsParentDirs` to point
at `.claude` instead of `.cursor`.

The existing deduplication logic in `install.ts` (via `seenParentDirs` Set)
means that when both Claude Code and Cursor are in the agents list, only
one `.claude/skills/` symlink is created — no duplicate work.


Agent transcript: https://claudescope.sentry.dev/share/GhAgo-61ech-SIKedWR-WHySa1we2W4o7LGb5LIBNE4