### PR TITLE
feat(cli): Add `dotagents mcp add|remove|list` subcommands

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -284,6 +284,39 @@ dotagents sync
 
 Reconcile project state: adopt orphaned skills (installed but not declared), regenerate `.agents/.gitignore`, check for missing skills, verify integrity hashes, repair symlinks, verify/repair MCP and hook configs. Reports issues as warnings or errors.
 
+### mcp add
+
+```
+dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]
+dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
+```
+
+Add an MCP server declaration to `agents.toml` and run `install` to generate agent configs. Specify exactly one transport: `--command` for stdio or `--url` for HTTP.
+
+| Flag | Description |
+|------|-------------|
+| `--command <cmd>` | Command to execute (stdio transport) |
+| `--args <arg>` | Command argument (repeatable) |
+| `--url <url>` | Server URL (HTTP transport) |
+| `--header <Key:Value>` | HTTP header (repeatable, url servers only) |
+| `--env <VAR>` | Environment variable name to pass through (repeatable) |
+
+### mcp remove
+
+```
+dotagents mcp remove <name>
+```
+
+Remove an MCP server declaration from `agents.toml` and run `install` to regenerate agent configs.
+
+### mcp list
+
+```
+dotagents mcp list [--json]
+```
+
+Show declared MCP servers. Use `--json` for machine-readable output.
+
 ### list
 
 ```

--- a/docs/src/app/cli/page.tsx
+++ b/docs/src/app/cli/page.tsx
@@ -200,6 +200,77 @@ export default function CliPage() {
         />
 
         <CliCommand
+          name="mcp add"
+          synopsis="dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]
+dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"
+          description={
+            <>
+              Add an MCP server declaration to <code>agents.toml</code> and run{" "}
+              <code>install</code> to generate agent configs. Specify exactly one
+              transport: <code>--command</code> for stdio or <code>--url</code>{" "}
+              for HTTP.
+            </>
+          }
+          options={[
+            {
+              flag: "--command <cmd>",
+              description: "Command to execute (stdio transport)",
+            },
+            {
+              flag: "--args <arg>",
+              description: "Command argument (repeatable)",
+            },
+            {
+              flag: "--url <url>",
+              description: "Server URL (HTTP transport)",
+            },
+            {
+              flag: "--header <Key:Value>",
+              description: "HTTP header (repeatable, url servers only)",
+            },
+            {
+              flag: "--env <VAR>",
+              description:
+                "Environment variable name to pass through (repeatable)",
+            },
+          ]}
+          examples={[
+            "# Stdio server",
+            "dotagents mcp add github --command npx --args -y --args @modelcontextprotocol/server-github --env GITHUB_TOKEN",
+            "",
+            "# HTTP server with auth header",
+            "dotagents mcp add remote --url https://mcp.example.com/sse --header Authorization:Bearer\\ tok",
+          ]}
+        />
+
+        <CliCommand
+          name="mcp remove"
+          synopsis="dotagents mcp remove <name>"
+          description={
+            <>
+              Remove an MCP server declaration from <code>agents.toml</code> and
+              run <code>install</code> to regenerate agent configs.
+            </>
+          }
+          examples={["dotagents mcp remove github"]}
+        />
+
+        <CliCommand
+          name="mcp list"
+          synopsis="dotagents mcp list [--json]"
+          description={
+            <>
+              Show declared MCP servers. Use <code>--json</code> for
+              machine-readable output.
+            </>
+          }
+          examples={[
+            "dotagents mcp list",
+            "dotagents mcp list --json",
+          ]}
+        />
+
+        <CliCommand
           name="list"
           synopsis="dotagents list [--json]"
           description={

--- a/src/cli/commands/mcp.test.ts
+++ b/src/cli/commands/mcp.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runMcpAdd, runMcpRemove, getMcpList, McpError, validateMcpName, parseHeader } from "./mcp.js";
+import { loadConfig } from "../../config/loader.js";
+import type { ScopeRoot } from "../../scope.js";
+
+describe("mcp", () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let projectRoot: string;
+  let scope: ScopeRoot;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dotagents-mcp-"));
+    stateDir = join(tmpDir, "state");
+    projectRoot = join(tmpDir, "project");
+
+    process.env["DOTAGENTS_STATE_DIR"] = stateDir;
+
+    await mkdir(join(projectRoot, ".agents", "skills"), { recursive: true });
+    await writeFile(join(projectRoot, "agents.toml"), "version = 1\n");
+
+    scope = {
+      scope: "project",
+      root: projectRoot,
+      agentsDir: join(projectRoot, ".agents"),
+      skillsDir: join(projectRoot, ".agents", "skills"),
+      configPath: join(projectRoot, "agents.toml"),
+      lockPath: join(projectRoot, "agents.lock"),
+    };
+  });
+
+  afterEach(async () => {
+    delete process.env["DOTAGENTS_STATE_DIR"];
+    await rm(tmpDir, { recursive: true });
+  });
+
+  describe("validateMcpName", () => {
+    it("accepts valid names", () => {
+      expect(() => validateMcpName("github")).not.toThrow();
+      expect(() => validateMcpName("my-server")).not.toThrow();
+      expect(() => validateMcpName("server.v2")).not.toThrow();
+      expect(() => validateMcpName("MCP_Server")).not.toThrow();
+    });
+
+    it("rejects invalid names", () => {
+      expect(() => validateMcpName("")).toThrow(McpError);
+      expect(() => validateMcpName("-bad")).toThrow(McpError);
+      expect(() => validateMcpName(".bad")).toThrow(McpError);
+      expect(() => validateMcpName("has space")).toThrow(McpError);
+    });
+  });
+
+  describe("parseHeader", () => {
+    it("splits on first colon", () => {
+      expect(parseHeader("Authorization:Bearer tok")).toEqual(["Authorization", "Bearer tok"]);
+    });
+
+    it("handles colons in value", () => {
+      expect(parseHeader("X-Key:val:ue")).toEqual(["X-Key", "val:ue"]);
+    });
+
+    it("throws on malformed header", () => {
+      expect(() => parseHeader("no-colon")).toThrow(McpError);
+      expect(() => parseHeader(":no-key")).toThrow(McpError);
+    });
+  });
+
+  describe("runMcpAdd", () => {
+    it("adds a stdio server", async () => {
+      await runMcpAdd({
+        scope,
+        name: "github",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-github"],
+        env: ["GITHUB_TOKEN"],
+      });
+
+      const config = await loadConfig(scope.configPath);
+      expect(config.mcp).toHaveLength(1);
+      expect(config.mcp[0]!.name).toBe("github");
+      expect(config.mcp[0]!.command).toBe("npx");
+      expect(config.mcp[0]!.args).toEqual(["-y", "@modelcontextprotocol/server-github"]);
+      expect(config.mcp[0]!.env).toEqual(["GITHUB_TOKEN"]);
+    });
+
+    it("adds an http server", async () => {
+      await runMcpAdd({
+        scope,
+        name: "remote",
+        url: "https://mcp.example.com/sse",
+        headers: ["Authorization:Bearer tok"],
+        env: ["API_KEY"],
+      });
+
+      const config = await loadConfig(scope.configPath);
+      expect(config.mcp).toHaveLength(1);
+      expect(config.mcp[0]!.url).toBe("https://mcp.example.com/sse");
+      expect(config.mcp[0]!.headers).toEqual({ Authorization: "Bearer tok" });
+    });
+
+    it("rejects duplicate name", async () => {
+      await runMcpAdd({ scope, name: "github", command: "npx" });
+      await expect(
+        runMcpAdd({ scope, name: "github", command: "other" }),
+      ).rejects.toThrow(/already exists/);
+    });
+
+    it("rejects both --command and --url", async () => {
+      await expect(
+        runMcpAdd({ scope, name: "bad", command: "npx", url: "https://example.com" }),
+      ).rejects.toThrow(/Cannot specify both/);
+    });
+
+    it("rejects neither --command nor --url", async () => {
+      await expect(
+        runMcpAdd({ scope, name: "bad" }),
+      ).rejects.toThrow(/Must specify either/);
+    });
+
+    it("rejects invalid name", async () => {
+      await expect(
+        runMcpAdd({ scope, name: "-bad", command: "npx" }),
+      ).rejects.toThrow(McpError);
+    });
+  });
+
+  describe("runMcpRemove", () => {
+    it("removes an existing server", async () => {
+      await runMcpAdd({ scope, name: "github", command: "npx" });
+      await runMcpRemove({ scope, name: "github" });
+
+      const config = await loadConfig(scope.configPath);
+      expect(config.mcp).toHaveLength(0);
+    });
+
+    it("throws for non-existent server", async () => {
+      await expect(
+        runMcpRemove({ scope, name: "nope" }),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("preserves other servers", async () => {
+      await runMcpAdd({ scope, name: "a", command: "cmd-a" });
+      await runMcpAdd({ scope, name: "b", command: "cmd-b" });
+      await runMcpRemove({ scope, name: "a" });
+
+      const config = await loadConfig(scope.configPath);
+      expect(config.mcp).toHaveLength(1);
+      expect(config.mcp[0]!.name).toBe("b");
+    });
+  });
+
+  describe("getMcpList", () => {
+    it("returns empty for no servers", async () => {
+      const config = await loadConfig(scope.configPath);
+      expect(getMcpList(config)).toEqual([]);
+    });
+
+    it("returns stdio entries", async () => {
+      await runMcpAdd({ scope, name: "github", command: "npx", env: ["TOKEN"] });
+      const config = await loadConfig(scope.configPath);
+      const list = getMcpList(config);
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual({
+        name: "github",
+        transport: "stdio",
+        target: "npx",
+        env: ["TOKEN"],
+      });
+    });
+
+    it("returns http entries", async () => {
+      await runMcpAdd({ scope, name: "remote", url: "https://example.com/mcp" });
+      const config = await loadConfig(scope.configPath);
+      const list = getMcpList(config);
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual({
+        name: "remote",
+        transport: "http",
+        target: "https://example.com/mcp",
+        env: [],
+      });
+    });
+  });
+});

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,0 +1,260 @@
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import chalk from "chalk";
+import { loadConfig } from "../../config/loader.js";
+import type { AgentsConfig, McpConfig } from "../../config/schema.js";
+import { addMcpToConfig, removeMcpFromConfig } from "../../config/writer.js";
+import { runInstall } from "./install.js";
+import { resolveScope, resolveDefaultScope, ScopeError } from "../../scope.js";
+import type { ScopeRoot } from "../../scope.js";
+
+export class McpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpError";
+  }
+}
+
+const MCP_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+export function validateMcpName(name: string): void {
+  if (!MCP_NAME_RE.test(name)) {
+    throw new McpError(
+      `Invalid MCP server name "${name}". Names must start with alphanumeric and contain only [a-zA-Z0-9._-].`,
+    );
+  }
+}
+
+export function parseHeader(raw: string): [string, string] {
+  const idx = raw.indexOf(":");
+  if (idx < 1) {
+    throw new McpError(`Invalid header format: "${raw}". Expected "Key:Value".`);
+  }
+  return [raw.slice(0, idx), raw.slice(idx + 1)];
+}
+
+export interface McpAddOptions {
+  scope: ScopeRoot;
+  name: string;
+  command?: string;
+  args?: string[];
+  url?: string;
+  headers?: string[];
+  env?: string[];
+}
+
+export async function runMcpAdd(opts: McpAddOptions): Promise<void> {
+  const { scope, name, command, url } = opts;
+
+  validateMcpName(name);
+
+  if (command && url) {
+    throw new McpError("Cannot specify both --command and --url.");
+  }
+  if (!command && !url) {
+    throw new McpError("Must specify either --command or --url.");
+  }
+
+  const config = await loadConfig(scope.configPath);
+
+  if (config.mcp.some((m) => m.name === name)) {
+    throw new McpError(`MCP server "${name}" already exists in agents.toml. Remove it first.`);
+  }
+
+  const entry: McpConfig = {
+    name,
+    ...(command ? { command, args: opts.args } : {}),
+    ...(url ? { url, headers: buildHeaders(opts.headers) } : {}),
+    env: opts.env ?? [],
+  };
+
+  await addMcpToConfig(scope.configPath, entry);
+  await runInstall({ scope });
+}
+
+function buildHeaders(raw?: string[]): Record<string, string> | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const headers: Record<string, string> = {};
+  for (const h of raw) {
+    const [key, value] = parseHeader(h);
+    headers[key] = value;
+  }
+  return headers;
+}
+
+export interface McpRemoveOptions {
+  scope: ScopeRoot;
+  name: string;
+}
+
+export async function runMcpRemove(opts: McpRemoveOptions): Promise<void> {
+  const { scope, name } = opts;
+  const config = await loadConfig(scope.configPath);
+
+  if (!config.mcp.some((m) => m.name === name)) {
+    throw new McpError(`MCP server "${name}" not found in agents.toml.`);
+  }
+
+  await removeMcpFromConfig(scope.configPath, name);
+  await runInstall({ scope });
+}
+
+export interface McpListEntry {
+  name: string;
+  transport: "stdio" | "http";
+  target: string;
+  env: string[];
+}
+
+export function getMcpList(config: AgentsConfig): McpListEntry[] {
+  return config.mcp.map((m) => ({
+    name: m.name,
+    transport: m.command ? "stdio" : "http",
+    target: (m.command ?? m.url)!,
+    env: m.env,
+  }));
+}
+
+// --- CLI wrappers ---
+
+async function mcpAdd(args: string[], scope: ScopeRoot): Promise<void> {
+  const { positionals, values } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      command: { type: "string" },
+      args: { type: "string", multiple: true },
+      url: { type: "string" },
+      header: { type: "string", multiple: true },
+      env: { type: "string", multiple: true },
+    },
+    strict: true,
+  });
+
+  const name = positionals[0];
+  if (!name) {
+    console.error(
+      chalk.red("Usage: dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]"),
+    );
+    console.error(
+      chalk.red("       dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  await runMcpAdd({
+    scope,
+    name,
+    command: values["command"],
+    args: values["args"],
+    url: values["url"],
+    headers: values["header"],
+    env: values["env"],
+  });
+  console.log(chalk.green(`Added MCP server: ${name}`));
+}
+
+async function mcpRemove(args: string[], scope: ScopeRoot): Promise<void> {
+  const { positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: true,
+  });
+
+  const name = positionals[0];
+  if (!name) {
+    console.error(chalk.red("Usage: dotagents mcp remove <name>"));
+    process.exitCode = 1;
+    return;
+  }
+
+  await runMcpRemove({ scope, name });
+  console.log(chalk.green(`Removed MCP server: ${name}`));
+}
+
+async function mcpList(args: string[], scope: ScopeRoot): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      json: { type: "boolean" },
+    },
+    strict: true,
+  });
+
+  const config = await loadConfig(scope.configPath);
+  const entries = getMcpList(config);
+
+  if (entries.length === 0) {
+    console.log(chalk.dim("No MCP servers declared in agents.toml."));
+    return;
+  }
+
+  if (values["json"]) {
+    console.log(JSON.stringify(entries, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold("MCP servers:"));
+  for (const e of entries) {
+    const env = e.env.length > 0 ? chalk.dim(` env=[${e.env.join(",")}]`) : "";
+    console.log(`  ${e.name}  ${chalk.dim(e.transport)}  ${chalk.dim(e.target)}${env}`);
+  }
+}
+
+function printMcpUsage(): void {
+  console.error(`Usage: dotagents mcp <subcommand>
+
+Subcommands:
+  add      Add an MCP server declaration
+  remove   Remove an MCP server declaration
+  list     Show declared MCP servers`);
+}
+
+export default async function mcp(args: string[], flags?: { user?: boolean }): Promise<void> {
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    printMcpUsage();
+    return;
+  }
+
+  let scope: ScopeRoot;
+  try {
+    scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+  } catch (err) {
+    if (err instanceof ScopeError) {
+      console.error(chalk.red(err.message));
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+
+  const subArgs = args.slice(1);
+
+  try {
+    switch (sub) {
+      case "add":
+        await mcpAdd(subArgs, scope);
+        break;
+      case "remove":
+        await mcpRemove(subArgs, scope);
+        break;
+      case "list":
+        await mcpList(subArgs, scope);
+        break;
+      default:
+        console.error(chalk.red(`Unknown mcp subcommand: ${sub}`));
+        printMcpUsage();
+        process.exitCode = 1;
+    }
+  } catch (err) {
+    if (err instanceof ScopeError || err instanceof McpError) {
+      console.error(chalk.red(err.message));
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ const require = createRequire(import.meta.url);
 const { version } = require("../../package.json") as { version: string };
 export { version };
 
-const COMMANDS = ["init", "install", "add", "remove", "update", "sync", "list"] as const;
+const COMMANDS = ["init", "install", "add", "remove", "update", "sync", "list", "mcp"] as const;
 type Command = (typeof COMMANDS)[number];
 
 function printUsage(): void {
@@ -23,6 +23,7 @@ Commands:
   update      Update skills to latest versions
   sync        Reconcile gitignore, symlinks, verify state
   list        Show installed skills
+  mcp         Manage MCP server declarations
 
 Options:
   --user      Operate on user-scope (~/.agents/) instead of project


### PR DESCRIPTION
MCP servers were previously only configurable by hand-editing
`agents.toml`. This adds `dotagents mcp add|remove|list` CLI
subcommands matching the ergonomics of `dotagents add` /
`dotagents remove` for skills.

**Commands:**

```
dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]
dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
dotagents mcp remove <name>
dotagents mcp list [--json]
```

**Changes:**

- New `src/cli/commands/mcp.ts` with sub-subcommand dispatch for
  add/remove/list, validation, and error handling
- Refactored `removeBlockByName` → `removeBlockByHeader` in
  `src/config/writer.ts` to support both `[[skills]]` and `[[mcp]]`
  block types (zero behavior change for skills)
- Added `addMcpToConfig` / `removeMcpFromConfig` writer functions
- Registered `mcp` in CLI command index
- Updated CLI docs page and `llms.txt`
- 17 new integration tests for the mcp command, 8 new writer tests


Agent transcript: https://claudescope.sentry.dev/share/FwNRv0iBbvB8cTtCO3O-ws_MdOXK4ZqOwDhsG7lep1c