### PR TITLE
feat(cli): Add interactive skill picker for `dotagents add`

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -163,15 +163,20 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
           skillName = selected[0]!;
         } else {
           // Multiple (but not all) selected — add each individually
+          const added: string[] = [];
           for (const name of selected) {
             if (config.skills.some((s) => s.name === name)) continue;
             await addSkillToConfig(configPath, name, {
               source: sourceForStorage,
               ...refOpts,
             });
+            added.push(name);
+          }
+          if (added.length === 0) {
+            throw new AddError("All selected skills already exist in agents.toml.");
           }
           await runInstall({ scope });
-          return selected;
+          return added;
         }
       } else {
         // Non-interactive — list them and ask user to re-run with --name or --all


### PR DESCRIPTION
When a repo contains multiple skills and the user hasn't specified `--name` or `--all`, present an interactive multiselect prompt so they can pick which skills to add. Non-TTY environments (CI, piped output) retain the current error-with-suggestions behavior.

Uses `@clack/prompts` `multiselect()` (already a dependency) following the same pattern as the interactive `init` command. Selecting all skills adds a wildcard entry, selecting one or more adds them individually.


Agent transcript: https://claudescope.sentry.dev/share/a7zMsQbGvgNK2JqarFg_J6DiDOUOy5IKTD6GWXNnjNo