### PR TITLE
feat(cli): Add GitLab source support and gh/gl hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ When a repo has one skill, it's added automatically. When multiple are found and
 
 When adding multiple skills, any that already exist in `agents.toml` are skipped with a warning. The rest are added normally.
 
+Shorthand (`owner/repo`) resolves using `defaultRepositorySource` in `agents.toml` (default: `github`, also supports `gitlab`).
+
 ### remove
 
 ```bash
@@ -188,6 +190,10 @@ source = "getsentry/skills"              # GitHub repo
 [[skills]]
 name = "review"
 source = "getsentry/skills@v1.0.0"       # Pinned to a ref
+
+[[skills]]
+name = "gitlab"
+source = "https://gitlab.com/group/repo" # GitLab URL
 
 [[skills]]
 name = "internal"

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -119,6 +119,7 @@ command = "notify-done"
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `version` | integer | Yes | -- | Schema version. Always `1`. |
+| `defaultRepositorySource` | string | No | `github` | Host used for shorthand `owner/repo` skill sources. Valid values: `github`, `gitlab`. |
 | `agents` | string[] | No | `[]` | Agent tool IDs: `claude`, `cursor`, `codex`, `vscode`, `opencode`. Creates symlinks and config files for each. |
 
 ### Skills
@@ -128,13 +129,15 @@ Each `[[skills]]` entry requires `name` and `source`. Optional fields: `ref` (gi
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Skill name. Pattern: `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`. Use `"*"` for wildcard. |
-| `source` | string | Yes | `owner/repo`, `owner/repo@ref`, `git:<url>`, or `path:<relative>` |
+| `source` | string | Yes | `owner/repo` (resolved via `defaultRepositorySource`), `owner/repo@ref`, `https://github.com/owner/repo`, `https://gitlab.com/group/repo`, `git:<url>`, or `path:<relative>` |
 | `ref` | string | No | Git ref (tag, branch, or SHA). Also supported inline: `owner/repo@ref`. |
 | `path` | string | No | Subdirectory within repo. Only needed when auto-discovery fails. |
 
 Source formats:
-- `owner/repo` -- GitHub (auto-discovers skills by name)
-- `owner/repo@ref` -- GitHub pinned to a tag/branch/commit
+- `owner/repo` -- shorthand resolved by `defaultRepositorySource` (defaults to GitHub)
+- `owner/repo@ref` -- shorthand pinned to a tag/branch/commit
+- `https://github.com/owner/repo` -- explicit GitHub URL
+- `https://gitlab.com/group/repo` -- explicit GitLab URL
 - `git:<url>` -- Non-GitHub git (requires https://, git://, ssh://, git@, file://, or absolute path)
 - `path:<relative>` -- Local filesystem path (relative to project root)
 

--- a/docs/src/app/cli/page.tsx
+++ b/docs/src/app/cli/page.tsx
@@ -127,7 +127,10 @@ export default function CliPage() {
               Add a skill dependency and install it. Auto-discovers skills in
               the repo. When a repo has one skill, it is added automatically.
               When multiple are found, use <code>--name</code> to pick one or{" "}
-              <code>--all</code> to add them all as a wildcard entry.
+              <code>--all</code> to add them all as a wildcard entry. Shorthand{" "}
+              <code>owner/repo</code> resolves via{" "}
+              <code>defaultRepositorySource</code> in{" "}
+              <code>agents.toml</code>.
             </>
           }
           options={[
@@ -154,6 +157,9 @@ export default function CliPage() {
             "",
             "# Pinned to a version",
             "dotagents add getsentry/warden@v1.0.0",
+            "",
+            "# Explicit GitLab URL",
+            "dotagents add https://gitlab.com/group/repo --name find-bugs",
             "",
             "# Non-GitHub git server",
             "dotagents add git:https://git.corp.dev/team/skills --name review",
@@ -430,6 +436,18 @@ dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"
                 <code>opencode</code>
               </td>
             </tr>
+            <tr>
+              <td>
+                <code>defaultRepositorySource</code>
+              </td>
+              <td>string</td>
+              <td>
+                <code>github</code>
+              </td>
+              <td>
+                Host used for shorthand <code>owner/repo</code> sources. Valid values: <code>github</code> or <code>gitlab</code>.
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -462,7 +480,7 @@ dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"
               <td>Yes</td>
               <td>
                 <code>owner/repo</code>, <code>owner/repo@ref</code>,{" "}
-                <code>git:url</code>, or <code>path:relative</code>
+                GitHub/GitLab URL, <code>git:url</code>, or <code>path:relative</code>
               </td>
             </tr>
             <tr>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -178,8 +178,8 @@ export default function Home() {
       <section className="section" id="adding-skills">
         <h2>Adding Skills</h2>
         <p>
-          Use <code>dotagents add</code> to install skills from GitHub repos,
-          git URLs, or local directories.
+          Use <code>dotagents add</code> to install skills from git repos or
+          local directories.
         </p>
         <pre>
           <code>{`# Add a single skill from a GitHub repo
@@ -191,6 +191,9 @@ dotagents add getsentry/skills --all
 # Pin to a specific version
 dotagents add getsentry/warden@v1.0.0
 
+# Add from GitLab
+dotagents add https://gitlab.com/group/repo --name find-bugs
+
 # From a non-GitHub git server
 dotagents add git:https://git.corp.dev/team/skills --name review
 
@@ -201,6 +204,11 @@ dotagents add path:./my-skills/custom`}</code>
           When a repo has one skill, it is added automatically. When multiple
           are found, use <code>--name</code> to pick one or{" "}
           <code>--all</code> to add them all as a wildcard entry.
+        </p>
+        <p>
+          Shorthand <code>owner/repo</code> resolves using{" "}
+          <code>defaultRepositorySource</code> in <code>agents.toml</code>{" "}
+          (default: <code>github</code>).
         </p>
         <p>
           Read the <a href="/guide">Guide</a> for the full setup walkthrough,

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -72,6 +72,7 @@ headers = { Authorization = "Bearer tok" }
 | Field | Required | Description |
 |-------|----------|-------------|
 | `version` | Yes | Schema version. Always `1`. |
+| `defaultRepositorySource` | No | Host used for shorthand `owner/repo` skill sources. Valid values: `github`, `gitlab`. Defaults to `github`. |
 | `agents` | No | Array of agent tool IDs. Valid: `claude`, `cursor`, `codex`, `vscode`, `opencode`. Defaults to `[]`. When set, dotagents creates skills symlinks and MCP config files for each agent. |
 | `project` | No | Project metadata. |
 | `symlinks` | No | Symlink configuration (legacy — prefer `agents` for new projects). |
@@ -128,7 +129,7 @@ Trust is checked before any network work in both `dotagents add` and `dotagents 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Skill name. Must start with alphanumeric and contain only `[a-zA-Z0-9._-]`. |
-| `source` | Yes | Skill source. `owner/repo` for GitHub, `owner/repo@ref` for pinned, `git:<url>` for non-GitHub, `path:<relative>` for local. |
+| `source` | Yes | Skill source. `owner/repo` (resolved via `defaultRepositorySource`), `owner/repo@ref`, `https://github.com/owner/repo`, `https://gitlab.com/group/repo`, `git:<url>`, or `path:<relative>`. |
 | `ref` | No | Git ref (tag, branch, or SHA). Can also be specified inline as `owner/repo@ref`. Defaults to repo's default branch. |
 | `path` | No | Explicit subdirectory path to the skill within the repo. Only needed when automatic discovery fails. |
 
@@ -171,11 +172,11 @@ Each agent has its own MCP config format. dotagents translates the universal `[[
 
 ### Source Types
 
-The source format is inferred from the value. No prefix needed for GitHub repos.
+The source format is inferred from the value. Shorthand `owner/repo` resolves using `defaultRepositorySource` (default: GitHub).
 
-#### `owner/repo` -- GitHub (most common)
+#### `owner/repo` -- shorthand (most common)
 
-Resolves to `https://github.com/<owner>/<repo>.git`. The skill is discovered by scanning the repo for SKILL.md files matching the skill name.
+Resolves to `https://github.com/<owner>/<repo>.git` by default, or `https://gitlab.com/<owner>/<repo>.git` when `defaultRepositorySource = "gitlab"`. The skill is discovered by scanning the repo for SKILL.md files matching the skill name.
 
 ```toml
 [[skills]]
@@ -192,6 +193,10 @@ ref = "v1.0.0"
 ```
 
 Ref pinning can also be inline: `source = "getsentry/warden@v1.0.0"`
+
+#### `https://github.com/...` / `https://gitlab.com/...` -- explicit hosted URL
+
+Use explicit URLs when you want to pin the host per source instead of relying on `defaultRepositorySource`.
 
 #### Skill discovery within a repo
 

--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -35,7 +35,9 @@ describe("runAdd", () => {
     // Create a local git repo with skills
     await mkdir(repoDir, { recursive: true });
     await exec("git", ["init"], { cwd: repoDir });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+    await exec("git", ["config", "user.email", "test@test.com"], {
+      cwd: repoDir,
+    });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
@@ -43,10 +45,16 @@ describe("runAdd", () => {
     await writeFile(join(repoDir, "pdf", "prompt.md"), "Process PDFs");
 
     await mkdir(join(repoDir, "skills", "review"), { recursive: true });
-    await writeFile(join(repoDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
+    await writeFile(
+      join(repoDir, "skills", "review", "SKILL.md"),
+      SKILL_MD("review"),
+    );
 
     await mkdir(join(repoDir, "skills", "commit"), { recursive: true });
-    await writeFile(join(repoDir, "skills", "commit", "SKILL.md"), SKILL_MD("commit"));
+    await writeFile(
+      join(repoDir, "skills", "commit", "SKILL.md"),
+      SKILL_MD("commit"),
+    );
 
     await exec("git", ["add", "."], { cwd: repoDir });
     await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
@@ -174,15 +182,38 @@ describe("runAdd", () => {
     ).rejects.toThrow(AddError);
   });
 
+  it("treats shorthand and expanded GitLab sources as the same wildcard", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\ndefaultRepositorySource = "gitlab"\n\n[[skills]]\nname = "*"\nsource = "getsentry/skills"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    await expect(
+      runAdd({
+        scope,
+        specifier: "getsentry/skills",
+        all: true,
+      }),
+    ).rejects.toThrow(
+      'A wildcard entry for "getsentry/skills" already exists in agents.toml.',
+    );
+  });
+
   it("auto-selects when repo has a single skill", async () => {
     // Create a repo with only one skill
     const singleRepo = join(tmpDir, "single-repo");
     await mkdir(singleRepo, { recursive: true });
     await exec("git", ["init"], { cwd: singleRepo });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: singleRepo });
+    await exec("git", ["config", "user.email", "test@test.com"], {
+      cwd: singleRepo,
+    });
     await exec("git", ["config", "user.name", "Test"], { cwd: singleRepo });
     await mkdir(join(singleRepo, "only-skill"), { recursive: true });
-    await writeFile(join(singleRepo, "only-skill", "SKILL.md"), SKILL_MD("only-skill"));
+    await writeFile(
+      join(singleRepo, "only-skill", "SKILL.md"),
+      SKILL_MD("only-skill"),
+    );
     await exec("git", ["add", "."], { cwd: singleRepo });
     await exec("git", ["commit", "-m", "initial"], { cwd: singleRepo });
 
@@ -231,10 +262,16 @@ describe("runAdd (local sources)", () => {
     await writeFile(join(localSkillsDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
 
     await mkdir(join(localSkillsDir, "skills", "review"), { recursive: true });
-    await writeFile(join(localSkillsDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
+    await writeFile(
+      join(localSkillsDir, "skills", "review", "SKILL.md"),
+      SKILL_MD("review"),
+    );
 
     await mkdir(join(localSkillsDir, "skills", "commit"), { recursive: true });
-    await writeFile(join(localSkillsDir, "skills", "commit", "SKILL.md"), SKILL_MD("commit"));
+    await writeFile(
+      join(localSkillsDir, "skills", "commit", "SKILL.md"),
+      SKILL_MD("commit"),
+    );
   });
 
   afterEach(async () => {
@@ -372,14 +409,19 @@ describe("add() CLI parsing", () => {
     // Create a local git repo with skills
     await mkdir(repoDir, { recursive: true });
     await exec("git", ["init"], { cwd: repoDir });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+    await exec("git", ["config", "user.email", "test@test.com"], {
+      cwd: repoDir,
+    });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
 
     await mkdir(join(repoDir, "skills", "review"), { recursive: true });
-    await writeFile(join(repoDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
+    await writeFile(
+      join(repoDir, "skills", "review", "SKILL.md"),
+      SKILL_MD("review"),
+    );
 
     await exec("git", ["add", "."], { cwd: repoDir });
     await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -5,7 +5,14 @@ import chalk from "chalk";
 import { loadConfig } from "../../config/loader.js";
 import { isWildcardDep } from "../../config/schema.js";
 import { addSkillToConfig, addWildcardToConfig } from "../../config/writer.js";
-import { parseSource, sourcesMatch, VALID_SKILL_NAME } from "../../skills/resolver.js";
+import {
+  applyDefaultRepositorySource,
+  isExplicitSourceSpecifier,
+  parseOwnerRepoShorthand,
+  parseSource,
+  sourcesMatch,
+  VALID_SKILL_NAME,
+} from "../../skills/resolver.js";
 import { discoverAllSkills, discoverSkill } from "../../skills/discovery.js";
 import { resolveLocalSource } from "../../sources/local.js";
 import { loadSkillMd } from "../../skills/loader.js";
@@ -41,7 +48,14 @@ export interface AddOptions {
 }
 
 export async function runAdd(opts: AddOptions): Promise<string | string[]> {
-  const { scope, specifier, ref, names: rawNames, all, interactive } = opts;
+  const {
+    scope,
+    specifier,
+    ref,
+    names: rawNames,
+    all,
+    interactive,
+  } = opts;
   // Deduplicate names to prevent writing duplicate config entries
   const namesOverride = rawNames ? [...new Set(rawNames)] : rawNames;
   const { configPath } = scope;
@@ -49,14 +63,26 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   // Load config early so we can check trust before any network work
   const config = await loadConfig(configPath);
 
-  // Parse the specifier
-  const parsed = parseSource(specifier);
+  // Validate the specifier is a recognized source format
+  if (!isExplicitSourceSpecifier(specifier) && !parseOwnerRepoShorthand(specifier)) {
+    throw new AddError(
+      `Invalid source "${specifier}". ` +
+        `Use owner/repo shorthand, an explicit URL, git:<url>, or path:<relative>.`,
+    );
+  }
 
-  // Preserve original source form (SSH, HTTPS, or shorthand) — strip inline @ref (stored separately)
-  const sourceForStorage =
-    parsed.type === "github" && parsed.ref
-      ? specifier.slice(0, -(parsed.ref.length + 1))
-      : specifier;
+  const hintedSpecifier = applyDefaultRepositorySource(
+    specifier,
+    config.defaultRepositorySource,
+  );
+
+  // Parse the specifier
+  const parsed = parseSource(hintedSpecifier);
+
+  // Store the original source form (shorthand, SSH, HTTPS) — strip inline @ref (stored separately)
+  const sourceForStorage = parsed.ref
+    ? specifier.slice(0, -(parsed.ref.length + 1))
+    : specifier;
 
   // Validate trust against the source
   validateTrustedSource(sourceForStorage, config.trust);
@@ -66,7 +92,12 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   const refOpts = effectiveRef ? { ref: effectiveRef } : {};
 
   async function addWildcard(): Promise<"*"> {
-    if (config.skills.some((s) => isWildcardDep(s) && sourcesMatch(s.source, sourceForStorage))) {
+    if (
+      config.skills.some(
+        (s) =>
+          isWildcardDep(s) && sourcesMatch(s.source, sourceForStorage),
+      )
+    ) {
       throw new AddError(
         `A wildcard entry for "${sourceForStorage}" already exists in agents.toml.`,
       );
@@ -123,14 +154,18 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         const toAdd: string[] = [];
         for (const name of namesOverride) {
           if (config.skills.some((s) => s.name === name)) {
-            console.warn(chalk.yellow(`Skipping "${name}": already exists in agents.toml`));
+            console.warn(
+              chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
+            );
           } else {
             toAdd.push(name);
           }
         }
 
         if (toAdd.length === 0) {
-          throw new AddError("All specified skills already exist in agents.toml.");
+          throw new AddError(
+            "All specified skills already exist in agents.toml.",
+          );
         }
 
         for (const name of toAdd) {
@@ -156,7 +191,11 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         ? `${parsed.owner}/${parsed.repo}`
         : url.replace(/^https?:\/\//, "").replace(/\.git$/, "");
 
-    const cached = await ensureCached({ url: cloneUrl, cacheKey, ref: effectiveRef });
+    const cached = await ensureCached({
+      url: cloneUrl,
+      cacheKey,
+      ref: effectiveRef,
+    });
 
     if (namesOverride?.length) {
       // User specified name(s), verify each exists
@@ -177,14 +216,18 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         const toAdd: string[] = [];
         for (const name of namesOverride) {
           if (config.skills.some((s) => s.name === name)) {
-            console.warn(chalk.yellow(`Skipping "${name}": already exists in agents.toml`));
+            console.warn(
+              chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
+            );
           } else {
             toAdd.push(name);
           }
         }
 
         if (toAdd.length === 0) {
-          throw new AddError("All specified skills already exist in agents.toml.");
+          throw new AddError(
+            "All specified skills already exist in agents.toml.",
+          );
         }
 
         for (const name of toAdd) {
@@ -267,7 +310,9 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
             added.push(name);
           }
           if (added.length === 0) {
-            throw new AddError("All selected skills already exist in agents.toml.");
+            throw new AddError(
+              "All selected skills already exist in agents.toml.",
+            );
           }
           await runInstall({ scope });
           return added;
@@ -302,7 +347,10 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   return skillName;
 }
 
-export default async function add(args: string[], flags?: { user?: boolean }): Promise<void> {
+export default async function add(
+  args: string[],
+  flags?: { user?: boolean },
+): Promise<void> {
   const { positionals, values } = parseArgs({
     args,
     allowPositionals: true,
@@ -318,7 +366,9 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
   const specifier = positionals[0];
   if (!specifier) {
     console.error(
-      chalk.red("Usage: dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]"),
+      chalk.red(
+        "Usage: dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]",
+      ),
     );
     process.exitCode = 1;
     return;
@@ -330,7 +380,9 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
 
   if (positionalNames.length > 0 && flagNames.length > 0) {
     console.error(
-      chalk.red("Cannot mix positional skill names with --skill/--name flags. Use one or the other."),
+      chalk.red(
+        "Cannot mix positional skill names with --skill/--name flags. Use one or the other.",
+      ),
     );
     process.exitCode = 1;
     return;
@@ -340,8 +392,11 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
   const names = rawNames.length > 0 ? [...new Set(rawNames)] : undefined;
 
   try {
-    const scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
-    const interactive = process.stdout.isTTY === true && !names && !values["all"];
+    const scope = flags?.user
+      ? resolveScope("user")
+      : resolveDefaultScope(resolve("."));
+    const interactive =
+      process.stdout.isTTY === true && !names && !values["all"];
     const result = await runAdd({
       scope,
       specifier,
@@ -359,7 +414,11 @@ export default async function add(args: string[], flags?: { user?: boolean }): P
     }
   } catch (err) {
     if (err instanceof AddCancelledError) {return;}
-    if (err instanceof ScopeError || err instanceof AddError || err instanceof TrustError) {
+    if (
+      err instanceof ScopeError ||
+      err instanceof AddError ||
+      err instanceof TrustError
+    ) {
       console.error(chalk.red(err.message));
       process.exitCode = 1;
       return;

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -3,11 +3,21 @@ import { mkdir, rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
 import chalk from "chalk";
 import { loadConfig } from "../../config/loader.js";
-import { isWildcardDep, type SkillDependency } from "../../config/schema.js";
+import {
+  isWildcardDep,
+  type RepositorySource,
+  type SkillDependency,
+} from "../../config/schema.js";
 import { loadLockfile } from "../../lockfile/loader.js";
 import { writeLockfile } from "../../lockfile/writer.js";
 import { type Lockfile, type LockedSkill } from "../../lockfile/schema.js";
-import { resolveSkill, resolveWildcardSkills, sourcesMatch, type ResolvedSkill } from "../../skills/resolver.js";
+import {
+  applyDefaultRepositorySource,
+  resolveSkill,
+  resolveWildcardSkills,
+  sourcesMatch,
+  type ResolvedSkill,
+} from "../../skills/resolver.js";
 import { validateTrustedSource, TrustError } from "../../trust/index.js";
 import { copyDir } from "../../utils/fs.js";
 import { writeAgentsGitignore, checkRootGitignoreEntries } from "../../gitignore/writer.js";
@@ -55,7 +65,11 @@ interface ExpandedSkill {
  * Explicit entries always win over wildcard-discovered skills.
  */
 async function expandSkills(
-  config: { skills: SkillDependency[]; trust?: Parameters<typeof validateTrustedSource>[1] },
+  config: {
+    skills: SkillDependency[];
+    trust?: Parameters<typeof validateTrustedSource>[1];
+    defaultRepositorySource: RepositorySource;
+  },
   lockfile: Lockfile | null,
   opts: { frozen?: boolean; force?: boolean; projectRoot: string },
 ): Promise<ExpandedSkill[]> {
@@ -73,7 +87,11 @@ async function expandSkills(
   // Expand wildcards
   const wildcardNames = new Map<string, string>(); // name → source (for conflict detection)
   for (const wDep of wildcardDeps) {
-    validateTrustedSource(wDep.source, config.trust);
+    const wildcardSourceForTrust = applyDefaultRepositorySource(
+      wDep.source,
+      config.defaultRepositorySource,
+    );
+    validateTrustedSource(wildcardSourceForTrust, config.trust);
     const excludeSet = new Set(wDep.exclude);
 
     if (opts.frozen) {
@@ -90,6 +108,7 @@ async function expandSkills(
       const named = await resolveWildcardSkills(wDep, {
         projectRoot: opts.projectRoot,
         ...(opts.force ? { ttlMs: 0 } : {}),
+        defaultRepositorySource: config.defaultRepositorySource,
       });
       for (const { name, resolved } of named) {
         if (explicitNames.has(name)) {continue;} // explicit wins
@@ -134,7 +153,11 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
     }
 
     const expanded = await expandSkills(
-      { skills: config.skills, trust: config.trust },
+      {
+        skills: config.skills,
+        trust: config.trust,
+        defaultRepositorySource: config.defaultRepositorySource,
+      },
       lockfile,
       { frozen, force, projectRoot: scope.root },
     );
@@ -155,11 +178,16 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
       const { name, dep } = item;
 
       // Validate trust before any network work
-      validateTrustedSource(dep.source, config.trust);
+      const sourceForTrust = applyDefaultRepositorySource(
+        dep.source,
+        config.defaultRepositorySource,
+      );
+      validateTrustedSource(sourceForTrust, config.trust);
 
       const resolveOpts = {
         projectRoot: scope.root,
         ...(force ? { ttlMs: 0 } : {}),
+        defaultRepositorySource: config.defaultRepositorySource,
       };
 
       let resolved: ResolvedSkill;
@@ -202,7 +230,9 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
       const wildcardDeps = config.skills.filter(isWildcardDep);
       for (const [name, locked] of Object.entries(lockfile.skills)) {
         if (newLock.skills[name]) {continue;} // still tracked
-        const fromWildcard = wildcardDeps.some((w) => sourcesMatch(locked.source, w.source));
+        const fromWildcard = wildcardDeps.some((w) =>
+          sourcesMatch(locked.source, w.source),
+        );
         if (fromWildcard) {
           await rm(join(skillsDir, name), { recursive: true, force: true });
           pruned.push(name);

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -75,7 +75,9 @@ export async function runRemove(opts: RemoveOptions): Promise<void> {
   const locked = lockfile?.skills[skillName];
   if (locked) {
     const wildcardDep = config.skills.find(
-      (s) => isWildcardDep(s) && sourcesMatch(s.source, locked.source),
+      (s) =>
+        isWildcardDep(s) &&
+        sourcesMatch(s.source, locked.source),
     );
     if (wildcardDep) {
       throw new WildcardSkillRemoveError(skillName, locked.source);
@@ -119,7 +121,11 @@ export default async function remove(args: string[], flags?: { user?: boolean })
       const shouldExclude = await promptYesNo("Add to exclude list? (y/N) ");
       if (shouldExclude) {
         const scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
-        await addExcludeToWildcard(scope.configPath, err.source, skillName);
+        await addExcludeToWildcard(
+          scope.configPath,
+          err.source,
+          skillName,
+        );
 
         // Delete skill directory and update lockfile
         const skillDir = join(scope.skillsDir, skillName);

--- a/src/cli/commands/sync.test.ts
+++ b/src/cli/commands/sync.test.ts
@@ -127,6 +127,30 @@ describe("runSync", () => {
     expect(result.issues).toHaveLength(0);
   });
 
+  it("matches GitLab wildcard sources using defaultRepositorySource", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\ndefaultRepositorySource = "gitlab"\n\n[[skills]]\nname = "*"\nsource = "group/repo"\n`,
+    );
+    const skillDir = join(projectRoot, ".agents", "skills", "find-bugs");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), SKILL_MD("find-bugs"));
+
+    await writeLockfile(join(projectRoot, "agents.lock"), {
+      version: 1,
+      skills: {
+        "find-bugs": {
+          source: "https://gitlab.com/group/repo",
+          resolved_url: "https://gitlab.com/group/repo.git",
+          resolved_path: "find-bugs",
+        },
+      },
+    });
+
+    const result = await runSync({ scope: resolveScope("project", projectRoot) });
+    expect(result.issues).toHaveLength(0);
+  });
+
   it("repairs broken symlinks", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -53,7 +53,9 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
   if (lockfile) {
     // Add concrete skill names from wildcard sources
     const wildcardSources = new Set(
-      config.skills.filter(isWildcardDep).map((s) => normalizeSource(s.source)),
+      config.skills
+        .filter(isWildcardDep)
+        .map((s) => normalizeSource(s.source)),
     );
     for (const [name, locked] of Object.entries(lockfile.skills)) {
       if (wildcardSources.has(normalizeSource(locked.source))) {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -14,8 +14,28 @@ describe("agentsConfigSchema", () => {
   it("accepts legacy gitignore field for backwards compat", () => {
     const result = agentsConfigSchema.safeParse({ version: 1, gitignore: true });
     expect(result.success).toBe(true);
-    const result2 = agentsConfigSchema.safeParse({ version: 1, gitignore: false });
-    expect(result2.success).toBe(true);
+    if (result.success) {
+      expect("gitignore" in result.data).toBe(false);
+    }
+  });
+
+  it("defaults defaultRepositorySource to github when absent", () => {
+    const result = agentsConfigSchema.safeParse({ version: 1 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaultRepositorySource).toBe("github");
+    }
+  });
+
+  it("accepts defaultRepositorySource = gitlab", () => {
+    const result = agentsConfigSchema.safeParse({
+      version: 1,
+      defaultRepositorySource: "gitlab",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaultRepositorySource).toBe("gitlab");
+    }
   });
 
   it("parses a full config with all fields", () => {
@@ -75,11 +95,15 @@ describe("agentsConfigSchema", () => {
     });
 
     it("accepts git: source with ssh", () => {
-      expect(parseSkill("git:ssh://git@example.com/repo.git").success).toBe(true);
+      expect(parseSkill("git:ssh://git@example.com/repo.git").success).toBe(
+        true,
+      );
     });
 
     it("accepts git: source with git@", () => {
-      expect(parseSkill("git:git@github.com:owner/repo.git").success).toBe(true);
+      expect(parseSkill("git:git@github.com:owner/repo.git").success).toBe(
+        true,
+      );
     });
 
     it("accepts git: source with absolute path", () => {
@@ -119,11 +143,27 @@ describe("agentsConfigSchema", () => {
     });
 
     it("accepts GitHub HTTPS URL with .git suffix", () => {
-      expect(parseSkill("https://github.com/owner/repo.git").success).toBe(true);
+      expect(parseSkill("https://github.com/owner/repo.git").success).toBe(
+        true,
+      );
     });
 
     it("accepts GitHub SSH URL", () => {
       expect(parseSkill("git@github.com:owner/repo.git").success).toBe(true);
+    });
+
+    it("accepts GitLab HTTPS URL", () => {
+      expect(parseSkill("https://gitlab.com/group/repo").success).toBe(true);
+    });
+
+    it("accepts GitLab SSH URL", () => {
+      expect(parseSkill("git@gitlab.com:group/repo.git").success).toBe(true);
+    });
+
+    it("accepts GitLab subgroup URL", () => {
+      expect(parseSkill("https://gitlab.com/group/subgroup/repo").success).toBe(
+        true,
+      );
     });
 
     it("rejects GitHub URL with dash-prefixed owner", () => {
@@ -196,7 +236,13 @@ describe("agentsConfigSchema", () => {
     it("accepts a stdio MCP server", () => {
       const result = agentsConfigSchema.safeParse({
         version: 1,
-        mcp: [{ name: "github", command: "npx", args: ["-y", "@mcp/server-github"] }],
+        mcp: [
+          {
+            name: "github",
+            command: "npx",
+            args: ["-y", "@mcp/server-github"],
+          },
+        ],
       });
       expect(result.success).toBe(true);
       if (result.success) {
@@ -230,7 +276,13 @@ describe("agentsConfigSchema", () => {
     it("accepts MCP server with headers", () => {
       const result = agentsConfigSchema.safeParse({
         version: 1,
-        mcp: [{ name: "r", url: "https://x.com", headers: { Authorization: "Bearer tok" } }],
+        mcp: [
+          {
+            name: "r",
+            url: "https://x.com",
+            headers: { Authorization: "Bearer tok" },
+          },
+        ],
       });
       expect(result.success).toBe(true);
     });
@@ -322,7 +374,6 @@ describe("agentsConfigSchema", () => {
     it("parses config without agents or mcp fields", () => {
       const result = agentsConfigSchema.safeParse({
         version: 1,
-        gitignore: false,
         skills: [{ name: "test", source: "owner/repo" }],
       });
       expect(result.success).toBe(true);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,8 +2,10 @@ import { z } from "zod/v4";
 
 /**
  * Source specifier patterns (inferred from value):
- *   owner/repo          -- GitHub
- *   owner/repo@ref      -- GitHub pinned
+ *   owner/repo          -- shorthand (resolved via defaultRepositorySource)
+ *   owner/repo@ref      -- shorthand pinned
+ *   https://gitlab.com/group/repo[.git][@ref] -- GitLab URL
+ *   git@gitlab.com:group/repo[.git][@ref]     -- GitLab SSH URL
  *   git:https://...     -- non-GitHub git
  *   path:../relative    -- local filesystem
  */
@@ -15,6 +17,12 @@ export const GITHUB_HTTPS_URL =
 /** GitHub SSH URL pattern — owner/repo must start with alphanumeric (no dash prefix). */
 export const GITHUB_SSH_URL =
   /^git@github\.com:([a-zA-Z0-9][^/]*)\/([a-zA-Z0-9][^/@]*?)(?:\.git)?(?:@(.+))?$/;
+/** GitLab HTTPS URL pattern — supports nested groups/subgroups. */
+export const GITLAB_HTTPS_URL =
+  /^https?:\/\/gitlab\.com\/([a-zA-Z0-9][^@]*?)\/([a-zA-Z0-9][^/@]*?)(?:\.git)?(?:\/)?(?:@(.+))?$/;
+/** GitLab SSH URL pattern — supports nested groups/subgroups. */
+export const GITLAB_SSH_URL =
+  /^git@gitlab\.com:([a-zA-Z0-9][^@]*?)\/([a-zA-Z0-9][^/@]*?)(?:\.git)?(?:@(.+))?$/;
 
 const skillSourceSchema = z.string().check(
   z.refine((s) => {
@@ -26,20 +34,28 @@ const skillSourceSchema = z.string().check(
     // GitHub HTTPS or SSH URLs
     if (GITHUB_HTTPS_URL.test(s)) {return true;}
     if (GITHUB_SSH_URL.test(s)) {return true;}
+    // GitLab HTTPS or SSH URLs
+    if (GITLAB_HTTPS_URL.test(s)) {return true;}
+    if (GITLAB_SSH_URL.test(s)) {return true;}
     // owner/repo or owner/repo@ref
     const base = s.includes("@") ? s.slice(0, s.indexOf("@")) : s;
     const parts = base.split("/");
-    return parts.length === 2 && parts.every((p) => p.length > 0 && !p.startsWith("-"));
-  }, "Must be owner/repo, owner/repo@ref, GitHub URL, git:<url> (with https/git/ssh protocol), or path:<relative>"),
+    return (
+      parts.length === 2 &&
+      parts.every((p) => p.length > 0 && !p.startsWith("-"))
+    );
+  }, "Must be owner/repo, owner/repo@ref, GitHub/GitLab URL, git:<url> (with https/git/ssh protocol), or path:<relative>"),
 );
 
 export type SkillSource = z.infer<typeof skillSourceSchema>;
 
 /** Skill names must be safe for use in file paths: alphanumeric, dots, hyphens, underscores. */
-const skillNameSchema = z.string().regex(
-  /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
-  "Skill names must start with alphanumeric and contain only [a-zA-Z0-9._-]",
-);
+const skillNameSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
+    "Skill names must start with alphanumeric and contain only [a-zA-Z0-9._-]",
+  );
 
 const wildcardSkillDependencySchema = z.object({
   name: z.literal("*"),
@@ -60,11 +76,17 @@ const skillDependencySchema = z.union([
   regularSkillDependencySchema,
 ]);
 
-export type WildcardSkillDependency = z.infer<typeof wildcardSkillDependencySchema>;
-export type RegularSkillDependency = z.infer<typeof regularSkillDependencySchema>;
+export type WildcardSkillDependency = z.infer<
+  typeof wildcardSkillDependencySchema
+>;
+export type RegularSkillDependency = z.infer<
+  typeof regularSkillDependencySchema
+>;
 export type SkillDependency = z.infer<typeof skillDependencySchema>;
 
-export function isWildcardDep(dep: SkillDependency): dep is WildcardSkillDependency {
+export function isWildcardDep(
+  dep: SkillDependency,
+): dep is WildcardSkillDependency {
   return dep.name === "*";
 }
 
@@ -94,14 +116,11 @@ const mcpSchema = z
     env: z.array(z.string()).default([]),
   })
   .check(
-    z.refine(
-      (m) => {
-        const hasStdio = !!m.command;
-        const hasHttp = !!m.url;
-        return (hasStdio || hasHttp) && !(hasStdio && hasHttp);
-      },
-      "MCP server must have either command (stdio) or url (http), but not both",
-    ),
+    z.refine((m) => {
+      const hasStdio = !!m.command;
+      const hasHttp = !!m.url;
+      return (hasStdio || hasHttp) && !(hasStdio && hasHttp);
+    }, "MCP server must have either command (stdio) or url (http), but not both"),
   );
 
 export type McpConfig = z.infer<typeof mcpSchema>;
@@ -132,9 +151,12 @@ const trustConfigSchema = z.object({
 
 export type TrustConfig = z.infer<typeof trustConfigSchema>;
 
+const repositorySourceSchema = z.enum(["github", "gitlab"]);
+export type RepositorySource = z.infer<typeof repositorySourceSchema>;
+
 export const agentsConfigSchema = z.object({
   version: z.literal(1),
-  gitignore: z.boolean().default(true),
+  defaultRepositorySource: repositorySourceSchema.default("github"),
   project: projectConfigSchema.optional(),
   symlinks: symlinksConfigSchema.optional(),
   agents: z.array(z.string()).default([]),

--- a/src/config/writer.ts
+++ b/src/config/writer.ts
@@ -1,6 +1,10 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { stringify } from "smol-toml";
-import type { WildcardSkillDependency, TrustConfig, McpConfig } from "./schema.js";
+import type {
+  WildcardSkillDependency,
+  TrustConfig,
+  McpConfig,
+} from "./schema.js";
 import { sourcesMatch } from "../skills/resolver.js";
 
 export interface DefaultConfigOptions {
@@ -94,7 +98,12 @@ export async function addExcludeToWildcard(
       const isWildcard = nameLine?.trim().match(/^name\s*=\s*"\*"/);
       const sourceMatch = sourceLine?.trim().match(/^source\s*=\s*"([^"]+)"/);
 
-      if (isWildcard && sourceMatch && sourcesMatch(sourceMatch[1]!, source) && !found) {
+      if (
+        isWildcard &&
+        sourceMatch &&
+        sourcesMatch(sourceMatch[1]!, source) &&
+        !found
+      ) {
         found = true;
         // Find or create exclude line
         const excludeIdx = blockLines.findIndex((l) => l.trim().startsWith("exclude"));

--- a/src/skills/resolver.test.ts
+++ b/src/skills/resolver.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { parseSource, normalizeSource, sourcesMatch } from "./resolver.js";
+import {
+  applyDefaultRepositorySource,
+  parseSource,
+  normalizeSource,
+  sourcesMatch,
+} from "./resolver.js";
+
+describe("applyDefaultRepositorySource", () => {
+  it("expands shorthand to GitHub by default", () => {
+    expect(applyDefaultRepositorySource("getsentry/skills")).toBe(
+      "https://github.com/getsentry/skills",
+    );
+  });
+
+  it("expands shorthand to GitLab when configured", () => {
+    expect(applyDefaultRepositorySource("getsentry/skills", "gitlab")).toBe(
+      "https://gitlab.com/getsentry/skills",
+    );
+  });
+
+  it("keeps explicit URL unchanged", () => {
+    expect(
+      applyDefaultRepositorySource(
+        "https://gitlab.com/group/repo",
+        "github",
+      ),
+    ).toBe("https://gitlab.com/group/repo");
+  });
+});
 
 describe("parseSource", () => {
   it("parses owner/repo as github", () => {
@@ -18,9 +46,7 @@ describe("parseSource", () => {
     expect(result.owner).toBe("getsentry");
     expect(result.repo).toBe("sentry-skills");
     expect(result.ref).toBe("v1.0.0");
-    expect(result.url).toBe(
-      "https://github.com/getsentry/sentry-skills.git",
-    );
+    expect(result.url).toBe("https://github.com/getsentry/sentry-skills.git");
   });
 
   it("parses owner/repo@sha as github with sha ref", () => {
@@ -30,7 +56,9 @@ describe("parseSource", () => {
   });
 
   it("parses git: prefix as generic git", () => {
-    const result = parseSource("git:https://git.corp.example.com/team/skills.git");
+    const result = parseSource(
+      "git:https://git.corp.example.com/team/skills.git",
+    );
     expect(result.type).toBe("git");
     expect(result.url).toBe("https://git.corp.example.com/team/skills.git");
   });
@@ -121,6 +149,33 @@ describe("parseSource", () => {
     expect(result.url).toBe("https://github.com/vercel/next.js.git");
   });
 
+  it("parses HTTPS GitLab URL", () => {
+    const result = parseSource("https://gitlab.com/group/repo");
+    expect(result.type).toBe("git");
+    expect(result.owner).toBe("group");
+    expect(result.repo).toBe("repo");
+    expect(result.url).toBe("https://gitlab.com/group/repo.git");
+    expect(result.cloneUrl).toBe("https://gitlab.com/group/repo");
+  });
+
+  it("parses HTTPS GitLab URL with subgroup", () => {
+    const result = parseSource("https://gitlab.com/group/subgroup/repo");
+    expect(result.type).toBe("git");
+    expect(result.owner).toBe("group/subgroup");
+    expect(result.repo).toBe("repo");
+    expect(result.url).toBe("https://gitlab.com/group/subgroup/repo.git");
+  });
+
+  it("parses SSH GitLab URL with ref", () => {
+    const result = parseSource("git@gitlab.com:group/repo@v2.0");
+    expect(result.type).toBe("git");
+    expect(result.owner).toBe("group");
+    expect(result.repo).toBe("repo");
+    expect(result.ref).toBe("v2.0");
+    expect(result.url).toBe("https://gitlab.com/group/repo.git");
+    expect(result.cloneUrl).toBe("git@gitlab.com:group/repo");
+  });
+
   it("upgrades http:// to https:// in cloneUrl", () => {
     const result = parseSource("http://github.com/getsentry/skills");
     expect(result.type).toBe("github");
@@ -147,21 +202,41 @@ describe("normalizeSource", () => {
     expect(normalizeSource("getsentry/skills")).toBe("getsentry/skills");
   });
 
-  it("normalizes HTTPS URL to owner/repo", () => {
-    expect(normalizeSource("https://github.com/getsentry/skills")).toBe("getsentry/skills");
+  it("normalizes GitHub HTTPS URL to owner/repo", () => {
+    expect(normalizeSource("https://github.com/getsentry/skills")).toBe(
+      "getsentry/skills",
+    );
   });
 
-  it("normalizes SSH URL to owner/repo", () => {
-    expect(normalizeSource("git@github.com:getsentry/skills.git")).toBe("getsentry/skills");
+  it("normalizes GitHub SSH URL to owner/repo", () => {
+    expect(normalizeSource("git@github.com:getsentry/skills.git")).toBe(
+      "getsentry/skills",
+    );
   });
 
-  it("normalizes HTTPS URL with .git suffix", () => {
-    expect(normalizeSource("https://github.com/getsentry/skills.git")).toBe("getsentry/skills");
+  it("normalizes GitHub HTTPS URL with .git suffix", () => {
+    expect(normalizeSource("https://github.com/getsentry/skills.git")).toBe(
+      "getsentry/skills",
+    );
+  });
+
+  it("normalizes GitLab HTTPS URL to group/repo", () => {
+    expect(normalizeSource("https://gitlab.com/group/repo")).toBe(
+      "group/repo",
+    );
+  });
+
+  it("normalizes GitLab SSH URL to group/repo", () => {
+    expect(normalizeSource("git@gitlab.com:group/repo.git")).toBe(
+      "group/repo",
+    );
   });
 
   it("returns non-github sources unchanged", () => {
     expect(normalizeSource("path:../my-skill")).toBe("path:../my-skill");
-    expect(normalizeSource("git:https://example.com/repo.git")).toBe("git:https://example.com/repo.git");
+    expect(normalizeSource("git:https://example.com/repo.git")).toBe(
+      "git:https://example.com/repo.git",
+    );
   });
 });
 
@@ -171,15 +246,39 @@ describe("sourcesMatch", () => {
   });
 
   it("matches SSH URL with shorthand", () => {
-    expect(sourcesMatch("git@github.com:getsentry/skills.git", "getsentry/skills")).toBe(true);
+    expect(
+      sourcesMatch("git@github.com:getsentry/skills.git", "getsentry/skills"),
+    ).toBe(true);
   });
 
   it("matches HTTPS URL with shorthand", () => {
-    expect(sourcesMatch("https://github.com/getsentry/skills", "getsentry/skills")).toBe(true);
+    expect(
+      sourcesMatch("https://github.com/getsentry/skills", "getsentry/skills"),
+    ).toBe(true);
+  });
+
+  it("matches GitLab URL with shorthand", () => {
+    expect(
+      sourcesMatch("https://gitlab.com/getsentry/skills", "getsentry/skills"),
+    ).toBe(true);
   });
 
   it("matches SSH URL with HTTPS URL", () => {
-    expect(sourcesMatch("git@github.com:getsentry/skills.git", "https://github.com/getsentry/skills")).toBe(true);
+    expect(
+      sourcesMatch(
+        "git@github.com:getsentry/skills.git",
+        "https://github.com/getsentry/skills",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches GitLab SSH URL with GitLab HTTPS URL", () => {
+    expect(
+      sourcesMatch(
+        "git@gitlab.com:group/repo.git",
+        "https://gitlab.com/group/repo",
+      ),
+    ).toBe(true);
   });
 
   it("does not match different repos", () => {

--- a/src/skills/resolver.ts
+++ b/src/skills/resolver.ts
@@ -1,5 +1,12 @@
 import { join } from "node:path";
-import { GITHUB_HTTPS_URL, GITHUB_SSH_URL, type WildcardSkillDependency } from "../config/schema.js";
+import {
+  GITHUB_HTTPS_URL,
+  GITHUB_SSH_URL,
+  GITLAB_HTTPS_URL,
+  GITLAB_SSH_URL,
+  type RepositorySource,
+  type WildcardSkillDependency,
+} from "../config/schema.js";
 import { ensureCached } from "../sources/cache.js";
 import { resolveLocalSource } from "../sources/local.js";
 import { discoverSkill, discoverAllSkills, type DiscoveredSkill } from "./discovery.js";
@@ -36,6 +43,54 @@ export interface ResolvedLocalSkill {
 }
 
 export type ResolvedSkill = ResolvedGitSkill | ResolvedLocalSkill;
+
+export function isExplicitSourceSpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith("path:") ||
+    specifier.startsWith("git:") ||
+    specifier.startsWith("http://") ||
+    specifier.startsWith("https://") ||
+    specifier.startsWith("git@")
+  );
+}
+
+export function parseOwnerRepoShorthand(
+  specifier: string,
+): { owner: string; repo: string; ref?: string } | undefined {
+  if (isExplicitSourceSpecifier(specifier)) {return undefined;}
+
+  const atIdx = specifier.indexOf("@");
+  const base = atIdx >= 0 ? specifier.slice(0, atIdx) : specifier;
+  const ref = atIdx >= 0 ? specifier.slice(atIdx + 1) : undefined;
+  const parts = base.split("/");
+  if (parts.length !== 2) {return undefined;}
+
+  const [owner, repo] = parts;
+  if (!owner || !repo || owner.startsWith("-") || repo.startsWith("-")) {
+    return undefined;
+  }
+
+  return { owner, repo, ref };
+}
+
+/**
+ * Expand owner/repo shorthand according to defaultRepositorySource.
+ * Returns input unchanged for explicit sources or non-shorthand values.
+ */
+export function applyDefaultRepositorySource(
+  specifier: string,
+  defaultRepositorySource: RepositorySource = "github",
+): string {
+  if (isExplicitSourceSpecifier(specifier)) {return specifier;}
+
+  const shorthand = parseOwnerRepoShorthand(specifier);
+  if (!shorthand) {return specifier;}
+
+  const host =
+    defaultRepositorySource === "gitlab" ? "gitlab.com" : "github.com";
+  const refSuffix = shorthand.ref ? `@${shorthand.ref}` : "";
+  return `https://${host}/${shorthand.owner}/${shorthand.repo}${refSuffix}`;
+}
 
 /**
  * Parse a source string into its components.
@@ -76,6 +131,24 @@ export function parseSource(source: string): {
     };
   }
 
+  // GitLab HTTPS or SSH URL
+  const gitlabUrlMatch =
+    source.match(GITLAB_HTTPS_URL) || source.match(GITLAB_SSH_URL);
+  if (gitlabUrlMatch) {
+    const [, owner, repo, ref] = gitlabUrlMatch;
+    // Strip @ref suffix using known ref length, upgrade http:// to https:// (no-op for SSH URLs)
+    const withoutRef = ref ? source.slice(0, -(ref.length + 1)) : source;
+    const cloneUrl = withoutRef.replace(/^http:\/\//i, "https://");
+    return {
+      type: "git",
+      owner,
+      repo,
+      ref,
+      url: `https://gitlab.com/${owner}/${repo}.git`,
+      cloneUrl,
+    };
+  }
+
   // owner/repo or owner/repo@ref — shorthand, no cloneUrl
   const atIdx = source.indexOf("@");
   const base = atIdx === -1 ? source : source.slice(0, atIdx);
@@ -91,14 +164,16 @@ export function parseSource(source: string): {
   };
 }
 
-/** Normalize any GitHub source to owner/repo canonical form for comparison/dedup. */
+/** Normalize hosted sources to canonical owner/repo form for comparison/dedup. */
 export function normalizeSource(source: string): string {
   const parsed = parseSource(source);
-  if (parsed.type === "github") {return `${parsed.owner}/${parsed.repo}`;}
+  if (parsed.owner && parsed.repo) {
+    return `${parsed.owner}/${parsed.repo}`;
+  }
   return source;
 }
 
-/** Compare two source strings for equivalence (normalizes GitHub URLs to owner/repo). */
+/** Compare two source strings for equivalence (normalizes hosted URLs to owner/repo). */
 export function sourcesMatch(a: string, b: string): boolean {
   return normalizeSource(a) === normalizeSource(b);
 }
@@ -111,11 +186,16 @@ export async function resolveSkill(
   dep: { source: string; ref?: string; path?: string },
   opts?: {
     projectRoot?: string;
+    defaultRepositorySource?: RepositorySource;
     /** Override cache TTL (pass 0 to force refresh) */
     ttlMs?: number;
   },
 ): Promise<ResolvedSkill> {
-  const parsed = parseSource(dep.source);
+  const sourceForResolve = applyDefaultRepositorySource(
+    dep.source,
+    opts?.defaultRepositorySource,
+  );
+  const parsed = parseSource(sourceForResolve);
 
   if (parsed.type === "local") {
     const projectRoot = opts?.projectRoot || process.cwd();
@@ -183,11 +263,16 @@ export async function resolveWildcardSkills(
   dep: Pick<WildcardSkillDependency, "source" | "ref" | "exclude">,
   opts?: {
     projectRoot?: string;
+    defaultRepositorySource?: RepositorySource;
     /** Override cache TTL (pass 0 to force refresh) */
     ttlMs?: number;
   },
 ): Promise<NamedResolvedSkill[]> {
-  const parsed = parseSource(dep.source);
+  const sourceForResolve = applyDefaultRepositorySource(
+    dep.source,
+    opts?.defaultRepositorySource,
+  );
+  const parsed = parseSource(sourceForResolve);
   const excludeSet = new Set(dep.exclude);
 
   if (parsed.type === "local") {
@@ -195,10 +280,17 @@ export async function resolveWildcardSkills(
     const skillDir = await resolveLocalSource(projectRoot, parsed.path!);
     const discovered = await discoverAllSkills(skillDir);
     return discovered
-      .filter((d) => !excludeSet.has(d.meta.name) && VALID_SKILL_NAME.test(d.meta.name))
+      .filter(
+        (d) =>
+          !excludeSet.has(d.meta.name) && VALID_SKILL_NAME.test(d.meta.name),
+      )
       .map((d) => ({
         name: d.meta.name,
-        resolved: { type: "local" as const, source: dep.source, skillDir: join(skillDir, d.path) },
+        resolved: {
+          type: "local" as const,
+          source: dep.source,
+          skillDir: join(skillDir, d.path),
+        },
       }));
   }
 
@@ -221,7 +313,9 @@ export async function resolveWildcardSkills(
   const discovered = await discoverAllSkills(cached.repoDir);
 
   return discovered
-    .filter((d) => !excludeSet.has(d.meta.name) && VALID_SKILL_NAME.test(d.meta.name))
+    .filter(
+      (d) => !excludeSet.has(d.meta.name) && VALID_SKILL_NAME.test(d.meta.name),
+    )
     .map((d) => ({
       name: d.meta.name,
       resolved: {

--- a/src/sources/git.ts
+++ b/src/sources/git.ts
@@ -1,6 +1,20 @@
 import { exec, ExecError } from "../utils/exec.js";
 import { existsSync } from "node:fs";
 
+function toSshCloneUrl(url: string): string | undefined {
+  const hostedMatch = url.match(
+    /^https?:\/\/(github\.com|gitlab\.com)\/(.+)$/i,
+  );
+  if (!hostedMatch) {return undefined;}
+
+  const host = hostedMatch[1]!;
+  const rawPath = hostedMatch[2]!;
+  let path = rawPath;
+  while (path.endsWith("/")) {path = path.slice(0, -1);}
+
+  return `git@${host.toLowerCase()}:${path.endsWith(".git") ? path : `${path}.git`}`;
+}
+
 export class GitError extends Error {
   constructor(message: string) {
     super(message);
@@ -28,15 +42,12 @@ export async function clone(
   } catch (err) {
     if (err instanceof ExecError) {
       const stderr = err.stderr;
+      const sshUrl = toSshCloneUrl(url);
       if (
-        url.startsWith("https://github.com/") &&
+        sshUrl &&
         (/terminal prompts disabled/i.test(stderr) ||
           /could not read Username/i.test(stderr))
       ) {
-        // Convert https://github.com/org/repo[.git][/] → git@github.com:org/repo.git
-        let path = url.slice("https://github.com/".length);
-        while (path.endsWith("/")) {path = path.slice(0, -1);}
-        const sshUrl = `git@github.com:${path.endsWith(".git") ? path : `${path}.git`}`;
         throw new GitError(
           `Failed to clone ${url}: authentication required.\n` +
             `Hint: for private repos, use the SSH URL instead:\n` +
@@ -69,11 +80,15 @@ export async function fetchAndReset(repoDir: string): Promise<void> {
  */
 export async function fetchRef(repoDir: string, ref: string): Promise<void> {
   try {
-    await exec("git", ["fetch", "--depth=1", "--", "origin", ref], { cwd: repoDir });
+    await exec("git", ["fetch", "--depth=1", "--", "origin", ref], {
+      cwd: repoDir,
+    });
     await exec("git", ["checkout", "FETCH_HEAD"], { cwd: repoDir });
   } catch (err) {
     if (err instanceof ExecError) {
-      throw new GitError(`Failed to fetch ref ${ref} in ${repoDir}: ${err.stderr}`);
+      throw new GitError(
+        `Failed to fetch ref ${ref} in ${repoDir}: ${err.stderr}`,
+      );
     }
     throw err;
   }

--- a/src/trust/validator.test.ts
+++ b/src/trust/validator.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateTrustedSource, extractDomain, TrustError } from "./validator.js";
+import {
+  validateTrustedSource,
+  extractDomain,
+  TrustError,
+} from "./validator.js";
 import type { TrustConfig } from "../config/schema.js";
 
 function makeTrust(overrides: Partial<TrustConfig> = {}): TrustConfig {
@@ -15,14 +19,20 @@ function makeTrust(overrides: Partial<TrustConfig> = {}): TrustConfig {
 describe("validateTrustedSource", () => {
   it("allows everything when trust config is undefined", () => {
     expect(() => validateTrustedSource("evil/repo")).not.toThrow();
-    expect(() => validateTrustedSource("git:https://evil.com/repo.git")).not.toThrow();
-    expect(() => validateTrustedSource("path:../local")).not.toThrow();
+    expect(() =>
+      validateTrustedSource("git:https://evil.com/repo.git"),
+    ).not.toThrow();
+    expect(() =>
+      validateTrustedSource("path:../local"),
+    ).not.toThrow();
   });
 
   it("allows everything when allow_all is true", () => {
     const trust = makeTrust({ allow_all: true });
     expect(() => validateTrustedSource("evil/repo", trust)).not.toThrow();
-    expect(() => validateTrustedSource("git:https://evil.com/repo.git", trust)).not.toThrow();
+    expect(() =>
+      validateTrustedSource("git:https://evil.com/repo.git", trust),
+    ).not.toThrow();
   });
 
   it("allows everything when allow_all is true even with other rules", () => {
@@ -34,17 +44,27 @@ describe("validateTrustedSource", () => {
     const trust = makeTrust({ github_orgs: ["getsentry", "anthropics"] });
 
     it("allows matching orgs", () => {
-      expect(() => validateTrustedSource("getsentry/skills", trust)).not.toThrow();
-      expect(() => validateTrustedSource("anthropics/tools", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("getsentry/skills", trust),
+      ).not.toThrow();
+      expect(() =>
+        validateTrustedSource("anthropics/tools", trust),
+      ).not.toThrow();
     });
 
     it("rejects non-matching orgs", () => {
-      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(TrustError);
+      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(
+        TrustError,
+      );
     });
 
     it("strips @ref before checking", () => {
-      expect(() => validateTrustedSource("getsentry/skills@v1.0.0", trust)).not.toThrow();
-      expect(() => validateTrustedSource("evil/repo@main", trust)).toThrow(TrustError);
+      expect(() =>
+        validateTrustedSource("getsentry/skills@v1.0.0", trust),
+      ).not.toThrow();
+      expect(() => validateTrustedSource("evil/repo@main", trust)).toThrow(
+        TrustError,
+      );
     });
   });
 
@@ -52,19 +72,27 @@ describe("validateTrustedSource", () => {
     const trust = makeTrust({ github_repos: ["external-org/one-approved"] });
 
     it("allows exact repo matches", () => {
-      expect(() => validateTrustedSource("external-org/one-approved", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("external-org/one-approved", trust),
+      ).not.toThrow();
     });
 
     it("rejects same-org different-repo", () => {
-      expect(() => validateTrustedSource("external-org/other-repo", trust)).toThrow(TrustError);
+      expect(() =>
+        validateTrustedSource("external-org/other-repo", trust),
+      ).toThrow(TrustError);
     });
 
     it("rejects different-org same-repo", () => {
-      expect(() => validateTrustedSource("other-org/one-approved", trust)).toThrow(TrustError);
+      expect(() =>
+        validateTrustedSource("other-org/one-approved", trust),
+      ).toThrow(TrustError);
     });
 
     it("strips @ref before checking", () => {
-      expect(() => validateTrustedSource("external-org/one-approved@v2", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("external-org/one-approved@v2", trust),
+      ).not.toThrow();
     });
   });
 
@@ -73,19 +101,28 @@ describe("validateTrustedSource", () => {
 
     it("allows matching domains (https)", () => {
       expect(() =>
-        validateTrustedSource("git:https://git.corp.example.com/team/repo.git", trust),
+        validateTrustedSource(
+          "git:https://git.corp.example.com/team/repo.git",
+          trust,
+        ),
       ).not.toThrow();
     });
 
     it("allows matching domains (ssh)", () => {
       expect(() =>
-        validateTrustedSource("git:ssh://git.corp.example.com/team/repo.git", trust),
+        validateTrustedSource(
+          "git:ssh://git.corp.example.com/team/repo.git",
+          trust,
+        ),
       ).not.toThrow();
     });
 
     it("allows matching domains (scp-style)", () => {
       expect(() =>
-        validateTrustedSource("git:git@git.corp.example.com:team/repo.git", trust),
+        validateTrustedSource(
+          "git:git@git.corp.example.com:team/repo.git",
+          trust,
+        ),
       ).not.toThrow();
     });
 
@@ -94,12 +131,21 @@ describe("validateTrustedSource", () => {
         validateTrustedSource("git:https://evil.com/repo.git", trust),
       ).toThrow(TrustError);
     });
+
+    it("allows direct GitLab URLs when domain is trusted", () => {
+      const gitlabTrust = makeTrust({ git_domains: ["gitlab.com"] });
+      expect(() =>
+        validateTrustedSource("https://gitlab.com/group/repo", gitlabTrust),
+      ).not.toThrow();
+    });
   });
 
   describe("local sources", () => {
     it("always allows path: sources even with restrictive trust", () => {
       const trust = makeTrust({ github_orgs: ["getsentry"] });
-      expect(() => validateTrustedSource("path:../local-skill", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("path:../local-skill", trust),
+      ).not.toThrow();
     });
   });
 
@@ -111,11 +157,15 @@ describe("validateTrustedSource", () => {
     });
 
     it("allows source matching org rule", () => {
-      expect(() => validateTrustedSource("getsentry/anything", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("getsentry/anything", trust),
+      ).not.toThrow();
     });
 
     it("allows source matching repo rule", () => {
-      expect(() => validateTrustedSource("external/approved", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("external/approved", trust),
+      ).not.toThrow();
     });
 
     it("allows source matching domain rule", () => {
@@ -125,15 +175,21 @@ describe("validateTrustedSource", () => {
     });
 
     it("rejects source matching none", () => {
-      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(TrustError);
+      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(
+        TrustError,
+      );
     });
   });
 
   describe("case-insensitive matching", () => {
     it("matches GitHub orgs case-insensitively", () => {
       const trust = makeTrust({ github_orgs: ["getsentry"] });
-      expect(() => validateTrustedSource("GetSentry/repo", trust)).not.toThrow();
-      expect(() => validateTrustedSource("GETSENTRY/repo", trust)).not.toThrow();
+      expect(() =>
+        validateTrustedSource("GetSentry/repo", trust),
+      ).not.toThrow();
+      expect(() =>
+        validateTrustedSource("GETSENTRY/repo", trust),
+      ).not.toThrow();
     });
 
     it("matches GitHub repos case-insensitively", () => {
@@ -145,7 +201,10 @@ describe("validateTrustedSource", () => {
     it("matches git domains case-insensitively", () => {
       const trust = makeTrust({ git_domains: ["git.corp.example.com"] });
       expect(() =>
-        validateTrustedSource("git:https://Git.Corp.Example.COM/repo.git", trust),
+        validateTrustedSource(
+          "git:https://Git.Corp.Example.COM/repo.git",
+          trust,
+        ),
       ).not.toThrow();
     });
   });
@@ -153,13 +212,22 @@ describe("validateTrustedSource", () => {
   describe("error messages", () => {
     it("includes the rejected source", () => {
       const trust = makeTrust({ github_orgs: ["getsentry"] });
-      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(/evil\/repo/);
+      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(
+        /evil\/repo/,
+      );
     });
 
     it("includes allowed alternatives", () => {
-      const trust = makeTrust({ github_orgs: ["getsentry"], github_repos: ["ext/one"] });
-      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(/getsentry/);
-      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(/ext\/one/);
+      const trust = makeTrust({
+        github_orgs: ["getsentry"],
+        github_repos: ["ext/one"],
+      });
+      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(
+        /getsentry/,
+      );
+      expect(() => validateTrustedSource("evil/repo", trust)).toThrow(
+        /ext\/one/,
+      );
     });
 
     it("suggests dotagents trust add for GitHub sources", () => {
@@ -183,15 +251,21 @@ describe("validateTrustedSource", () => {
 
 describe("extractDomain", () => {
   it("extracts from https URL", () => {
-    expect(extractDomain("https://git.corp.com/team/repo.git")).toBe("git.corp.com");
+    expect(extractDomain("https://git.corp.com/team/repo.git")).toBe(
+      "git.corp.com",
+    );
   });
 
   it("extracts from ssh URL", () => {
-    expect(extractDomain("ssh://git.corp.com/team/repo.git")).toBe("git.corp.com");
+    expect(extractDomain("ssh://git.corp.com/team/repo.git")).toBe(
+      "git.corp.com",
+    );
   });
 
   it("extracts from git:// URL", () => {
-    expect(extractDomain("git://git.corp.com/team/repo.git")).toBe("git.corp.com");
+    expect(extractDomain("git://git.corp.com/team/repo.git")).toBe(
+      "git.corp.com",
+    );
   });
 
   it("extracts from scp-style URL", () => {


### PR DESCRIPTION
Add GitLab repository URL support in skill source parsing and validation, and extend `dotagents add` with optional source hints so shorthand can still be used explicitly (`gh owner/repo` and `gl owner/repo`).

The motivation is to support multiple hosted git providers without silently inferring GitHub for shorthand. The first commit made source hosts explicit and added GitLab support; the second commit introduces opt-in host hinting to preserve shorthand ergonomics where desired.

I considered keeping shorthand permanently disabled and requiring explicit URLs everywhere. That is stricter and simpler, but it removes a workflow many users are already used to. The hint approach keeps host selection explicit while restoring concise commands.

Additional context:
- `add` now accepts `dotagents add [gh|gl] <source> ...`
- shorthand without a hint remains rejected
- docs/examples are updated for explicit URLs and hint-based shorthand
- tests cover GitLab parsing and `gh`/`gl` hint expansion behavior

Question for maintainers: do you want to support this hinted shorthand mode long-term, or would you prefer we keep only explicit hosted URLs and remove the hinting path?
