### PR TITLE
fix(install): Prune stale wildcard skills during install

### DIFF
--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -495,6 +495,30 @@ describe("runInstall", () => {
     expect(existsSync(join(projectRoot, ".agents", "skills", "review"))).toBe(false);
   });
 
+  it("does not prune in frozen mode", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\n\n[[skills]]\nname = "*"\nsource = "git:${repoDir}"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+
+    // First install — gets both "pdf" and "review"
+    await runInstall({ scope });
+
+    // Add "review" to the exclude list
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\n\n[[skills]]\nname = "*"\nsource = "git:${repoDir}"\nexclude = ["review"]\n`,
+    );
+
+    // Frozen install should NOT prune (would create disk/lockfile inconsistency)
+    const result = await runInstall({ scope, frozen: true });
+    expect(result.pruned).toHaveLength(0);
+    // Directory should still exist
+    expect(existsSync(join(projectRoot, ".agents", "skills", "review", "SKILL.md"))).toBe(true);
+  });
+
   it("wildcard with all skills excluded installs nothing from that source", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -231,8 +231,8 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
       installed.push(name);
     }
 
-    // Prune stale wildcard-sourced skills
-    if (lockfile) {
+    // Prune stale wildcard-sourced skills (skip in frozen mode to avoid disk/lockfile inconsistency)
+    if (!frozen && lockfile) {
       const wildcardDeps = config.skills.filter(isWildcardDep);
       for (const [name, locked] of Object.entries(lockfile.skills)) {
         if (newLock.skills[name]) continue; // still tracked


### PR DESCRIPTION
When a skill is removed from a wildcard source (e.g. deleted upstream or added to the exclude list), `dotagents install` rebuilds the lockfile and gitignore correctly but leaves the stale skill directory on disk. This causes confusing untracked files in git.

`dotagents update` already handles this via `updateWildcardSource()`. This brings the same cleanup logic to `install` by comparing the old lockfile against the new one after the install loop and deleting skill directories whose source matches a current wildcard dep but are no longer discovered.

Changes:
- Compare old vs new lockfile entries after install, prune directories for wildcard-sourced skills that are no longer tracked
- Add `pruned: string[]` to `InstallResult` and surface pruned skills in CLI output
- Three new tests covering: stale skill pruning, non-wildcard skills left untouched, exclude-list pruning


Agent transcript: https://claudescope.sentry.dev/share/LIGeQkdXDtUr_2eQkXa9MCE-HWzB-3st4gTwUZQl0NA