### PR TITLE
feat(config): Add global `pin` option to disable version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A package manager for `.agents` directories. Declare agent skill dependencies in
 
 **One source of truth.** Skills live in `.agents/skills/` and symlink into `.claude/skills/`, `.cursor/skills/`, or wherever your tools expect them. No copy-pasting between directories.
 
-**Reproducible.** `agents.lock` pins exact commits and integrity hashes. `dotagents install --frozen` in CI guarantees everyone runs the same skills.
+**Reproducible.** `agents.lock` pins exact commits and integrity hashes. `dotagents install --frozen` in CI guarantees everyone runs the same skills. Set `pin = false` to always fetch latest instead.
 
 **Shareable.** Skills are just directories with a `SKILL.md`. Host them in any git repo, discover them automatically, install with one command.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -38,7 +38,7 @@ name = "find-bugs"
 source = "getsentry/skills"
 ```
 
-And a lockfile (`agents.lock`) pinning the exact commit and SHA-256 integrity hash.
+And a lockfile (`agents.lock`) pinning the exact commit and SHA-256 integrity hash. Set `pin = false` to always fetch the latest version instead of locking commits.
 
 ## How It Works
 
@@ -122,6 +122,7 @@ command = "notify-done"
 |-------|------|----------|---------|-------------|
 | `version` | integer | Yes | -- | Schema version. Always `1`. |
 | `gitignore` | boolean | No | `true` | When `true`, generates `.agents/.gitignore` to exclude managed skills. When `false`, skills are checked into git. `init` sets this to `false`. |
+| `pin` | boolean | No | `true` | When `true`, lockfile pins exact commit SHAs and integrity hashes. When `false`, lockfile tracks skill names only; `install` always fetches latest. Skills with explicit `ref` still respect that ref. |
 | `agents` | string[] | No | `[]` | Agent tool IDs: `claude`, `cursor`, `codex`, `vscode`, `opencode`. Creates symlinks and config files for each. |
 
 ### Skills
@@ -424,8 +425,8 @@ integrity = "sha256-FWmCLdOj+x+XffiEg7Bx19drylVypeKz8me9OA757js="
 | `resolved_url` | Git sources | Resolved git clone URL |
 | `resolved_path` | Git sources | Subdirectory within repo where skill was found |
 | `resolved_ref` | Git sources (optional) | Resolved ref name (omitted for default branch) |
-| `commit` | Git sources | Full 40-char SHA |
-| `integrity` | All | `sha256-` prefixed base64 content hash |
+| `commit` | Git sources (when `pin = true`) | Full 40-char SHA. Omitted when `pin = false`. |
+| `integrity` | All (when `pin = true`) | `sha256-` prefixed base64 content hash. Omitted when `pin = false`. |
 
 Local `path:` skills have `source` and `integrity` only.
 
@@ -442,8 +443,10 @@ Local `path:` skills have `source` and `integrity` only.
 `dotagents install --frozen` (for CI):
 - Fails if `agents.lock` does not exist
 - Fails if any skill in `agents.toml` is missing from the lockfile
-- Fails if integrity hashes don't match after install
+- Fails if integrity hashes don't match after install (when `pin = true`)
 - Does not modify the lockfile
+
+When `pin = false`, frozen mode validates the skill list but fetches latest content.
 
 ## Caching
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -74,6 +74,7 @@ headers = { Authorization = "Bearer tok" }
 |-------|----------|-------------|
 | `version` | Yes | Schema version. Always `1`. |
 | `gitignore` | No | When `true` (default), generates `.agents/.gitignore` to exclude managed skills. When `false`, skills are checked into git. `dotagents init` sets this to `false`. |
+| `pin` | No | When `true` (default), lockfile pins exact commit SHAs and integrity hashes for reproducible installs. When `false`, lockfile tracks skill names and sources only; `install` always fetches latest. Skills with an explicit `ref` still respect that ref. |
 | `agents` | No | Array of agent tool IDs. Valid: `claude`, `cursor`, `codex`, `vscode`, `opencode`. Defaults to `[]`. When set, dotagents creates skills symlinks and MCP config files for each agent. |
 | `project` | No | Project metadata. |
 | `symlinks` | No | Symlink configuration (legacy — prefer `agents` for new projects). |
@@ -278,8 +279,8 @@ integrity = "sha256-No6eAmT2pIsOz0uQ1yBcWj=="
 | `resolved_url` | Git sources | Resolved git clone URL. |
 | `resolved_path` | Git sources | Subdirectory within the repo where the skill was discovered. |
 | `resolved_ref` | Git sources (optional) | The ref that was resolved (tag/branch name). Omitted when using default branch. |
-| `commit` | Git sources | Full 40-char SHA of the resolved commit. This is the reproducibility guarantee. |
-| `integrity` | All | SHA-256 content hash of the installed skill directory. |
+| `commit` | Git sources (when `pin = true`) | Full 40-char SHA of the resolved commit. Omitted when `pin = false`. |
+| `integrity` | All (when `pin = true`) | SHA-256 content hash of the installed skill directory. Omitted when `pin = false`. |
 
 ### Integrity Hashing
 
@@ -297,8 +298,10 @@ The integrity hash is computed deterministically:
 
 - Fails if `agents.lock` does not exist
 - Fails if any skill in `agents.toml` is missing from the lockfile
-- Fails if integrity hashes don't match after install
+- Fails if integrity hashes don't match after install (when `pin = true`)
 - Does NOT modify the lockfile
+
+When `pin = false`, frozen mode validates the skill list matches the lockfile but fetches latest content (no integrity check).
 
 ---
 
@@ -417,13 +420,14 @@ dotagents update find-bugs    # one skill
 ```
 
 **Behavior:**
-1. For each skill:
+1. If `pin = false`: no-op (skills always fetch latest on `install`)
+2. For each skill:
    - Re-resolve from source (ignoring locked commit)
    - If ref is a 40-char SHA: skip (immutable)
    - Otherwise: fetch latest and compare commits
-2. Copy updated skill directories
-3. Update `agents.lock` with new commits and integrity hashes
-4. Print changelog (old commit -> new commit)
+3. Copy updated skill directories
+4. Update `agents.lock` with new commits and integrity hashes
+5. Print changelog (old commit -> new commit)
 
 ### `dotagents sync`
 

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -222,4 +222,18 @@ describe("runInit", () => {
     const config = await loadConfig(join(dir, "agents.toml"));
     expect(config.trust?.github_repos).not.toContain("getsentry/dotagents");
   });
+
+  it("generates config with pin = false when requested", async () => {
+    await runInit({ scope: resolveScope("project", dir), pin: false, skills: [] });
+
+    const config = await loadConfig(join(dir, "agents.toml"));
+    expect(config.pin).toBe(false);
+  });
+
+  it("defaults pin to true in generated config", async () => {
+    await runInit({ scope: resolveScope("project", dir), skills: [] });
+
+    const config = await loadConfig(join(dir, "agents.toml"));
+    expect(config.pin).toBe(true);
+  });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -19,6 +19,7 @@ export interface InitOptions {
   force?: boolean;
   agents?: string[];
   gitignore?: boolean;
+  pin?: boolean;
   trust?: TrustConfig;
   skills?: Array<{ name: string; source: string }>;
   scope: ScopeRoot;
@@ -58,7 +59,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   // For user scope, default gitignore to false and skip gitignore comments
   const effectiveGitignore = scope.scope === "user" ? false : gitignore;
   await mkdir(agentsDir, { recursive: true });
-  await writeFile(configPath, generateDefaultConfig({ agents, gitignore: effectiveGitignore, trust, skills }), "utf-8");
+  await writeFile(configPath, generateDefaultConfig({ agents, gitignore: effectiveGitignore, pin: opts.pin, trust, skills }), "utf-8");
   await mkdir(skillsDir, { recursive: true });
 
   // Set up gitignore and symlinks based on config
@@ -234,11 +235,19 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
     trust = { allow_all: false, github_orgs, github_repos, git_domains: [] };
   }
 
+  const pinSkills = prompt(
+    await clack.confirm({
+      message: "Pin skill versions in the lockfile? (Recommended for teams)",
+      initialValue: true,
+    }),
+  );
+
   await runInit({
     scope,
     force,
     agents: selectedAgents,
     gitignore,
+    pin: pinSkills,
     trust,
   });
 

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -529,4 +529,74 @@ describe("runInstall", () => {
     const result = await runInstall({ scope });
     expect(result.installed).toHaveLength(0);
   });
+
+  it("pin=false omits commit and integrity from lockfile", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    const result = await runInstall({ scope });
+    expect(result.installed).toContain("pdf");
+
+    const lockfile = await loadLockfile(join(projectRoot, "agents.lock"));
+    expect(lockfile).not.toBeNull();
+    const pdfLock = lockfile!.skills["pdf"]!;
+    expect(pdfLock.source).toBeDefined();
+    expect("resolved_url" in pdfLock).toBe(true);
+    expect("commit" in pdfLock).toBe(false);
+    expect("integrity" in pdfLock).toBe(false);
+  });
+
+  it("pin=false frozen mode validates skill list but not integrity", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    await runInstall({ scope });
+
+    // Frozen install should succeed (no integrity to check)
+    const result = await runInstall({ scope, frozen: true });
+    expect(result.installed).toContain("pdf");
+  });
+
+  it("pin=false frozen mode fails when skill missing from lockfile", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+    const scope = resolveScope("project", projectRoot);
+    await runInstall({ scope });
+
+    // Add review to config but lockfile still has only pdf
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n\n[[skills]]\nname = "review"\nsource = "git:${repoDir}"\n`,
+    );
+
+    await expect(runInstall({ scope, frozen: true })).rejects.toThrow(InstallError);
+  });
+
+  it("pin=false with wildcard still prunes stale skills", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "*"\nsource = "git:${repoDir}"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    const first = await runInstall({ scope });
+    expect(first.installed).toContain("pdf");
+    expect(first.installed).toContain("review");
+
+    // Remove "review" from upstream
+    await exec("git", ["rm", "-rf", "skills/review"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "remove review"], { cwd: repoDir });
+    await rm(stateDir, { recursive: true });
+
+    const second = await runInstall({ scope });
+    expect(second.pruned).toContain("review");
+  });
 });

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -61,10 +61,11 @@ interface ExpandedSkill {
  * Explicit entries always win over wildcard-discovered skills.
  */
 async function expandSkills(
-  config: { skills: SkillDependency[]; trust?: Parameters<typeof validateTrustedSource>[1] },
+  config: { skills: SkillDependency[]; trust?: Parameters<typeof validateTrustedSource>[1]; pin: boolean },
   lockfile: Lockfile | null,
   opts: { frozen?: boolean; force?: boolean; projectRoot: string },
 ): Promise<ExpandedSkill[]> {
+  const { pin } = config;
   const regularDeps = config.skills.filter((d) => !isWildcardDep(d));
   const wildcardDeps = config.skills.filter(isWildcardDep);
   const explicitNames = new Set(regularDeps.map((d) => d.name));
@@ -75,7 +76,9 @@ async function expandSkills(
   for (const dep of regularDeps) {
     const locked = lockfile?.skills[dep.name];
     const lockedCommit =
-      !opts.force && locked && isGitLocked(locked) ? locked.commit : undefined;
+      pin && !opts.force && locked && isGitLocked(locked) && locked.commit
+        ? locked.commit
+        : undefined;
     expanded.push({ name: dep.name, dep, lockedCommit });
   }
 
@@ -93,12 +96,16 @@ async function expandSkills(
         if (explicitNames.has(name)) continue;
         if (excludeSet.has(name)) continue;
 
-        const lockedCommit = isGitLocked(locked) ? locked.commit : undefined;
+        const lockedCommit =
+          pin && isGitLocked(locked) && locked.commit ? locked.commit : undefined;
         expanded.push({ name, dep: wDep, lockedCommit });
       }
     } else {
       // resolveWildcardSkills already filters by exclude list
-      const named = await resolveWildcardSkills(wDep, { projectRoot: opts.projectRoot });
+      const named = await resolveWildcardSkills(wDep, {
+        projectRoot: opts.projectRoot,
+        ttlMs: pin ? undefined : 0,
+      });
       for (const { name, resolved } of named) {
         if (explicitNames.has(name)) continue; // explicit wins
 
@@ -114,7 +121,9 @@ async function expandSkills(
 
         const locked = lockfile?.skills[name];
         const lockedCommit =
-          !opts.force && locked && isGitLocked(locked) ? locked.commit : undefined;
+          pin && !opts.force && locked && isGitLocked(locked) && locked.commit
+            ? locked.commit
+            : undefined;
         expanded.push({ name, dep: wDep, lockedCommit, resolved });
       }
     }
@@ -129,6 +138,7 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
 
   // 1. Read config
   const config = await loadConfig(configPath);
+  const { pin } = config;
   const installed: string[] = [];
   const skipped: string[] = [];
   const pruned: string[] = [];
@@ -144,11 +154,11 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
       throw new InstallError("--frozen requires agents.lock to exist.");
     }
 
-    const expanded = await expandSkills(config, lockfile, {
-      frozen,
-      force,
-      projectRoot: scope.root,
-    });
+    const expanded = await expandSkills(
+      { skills: config.skills, trust: config.trust, pin },
+      lockfile,
+      { frozen, force, projectRoot: scope.root },
+    );
 
     if (frozen) {
       for (const { name } of expanded) {
@@ -170,24 +180,24 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
 
       const locked = lockfile?.skills[name];
 
+      const resolveOpts = {
+        projectRoot: scope.root,
+        lockedCommit,
+        ttlMs: pin ? undefined : 0,
+      };
+
       let resolved: ResolvedSkill;
       if (item.resolved) {
         // Already resolved during wildcard expansion (use locked commit if available and unchanged)
         if (lockedCommit && item.resolved.type === "git" && item.resolved.commit !== lockedCommit) {
           // Re-resolve with locked commit for cache hit
-          resolved = await resolveSkill(name, dep, {
-            projectRoot: scope.root,
-            lockedCommit,
-          });
+          resolved = await resolveSkill(name, dep, resolveOpts);
         } else {
           resolved = item.resolved;
         }
       } else {
         try {
-          resolved = await resolveSkill(name, dep, {
-            projectRoot: scope.root,
-            lockedCommit,
-          });
+          resolved = await resolveSkill(name, dep, resolveOpts);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           throw new InstallError(`Failed to resolve skill "${name}": ${msg}`);
@@ -201,9 +211,9 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
         await copyDir(resolved.skillDir, destDir);
       }
 
-      const integrity = await hashDirectory(destDir);
+      const integrity = pin ? await hashDirectory(destDir) : undefined;
 
-      if (frozen && locked) {
+      if (frozen && pin && locked && locked.integrity) {
         if (locked.integrity !== integrity) {
           throw new InstallError(
             `--frozen: integrity mismatch for "${name}". ` +
@@ -219,12 +229,11 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
               resolved_url: resolved.resolvedUrl,
               resolved_path: resolved.resolvedPath,
               ...(resolved.resolvedRef ? { resolved_ref: resolved.resolvedRef } : {}),
-              commit: resolved.commit,
-              integrity,
+              ...(pin ? { commit: resolved.commit, integrity } : {}),
             }
           : {
               source: dep.source,
-              integrity,
+              ...(pin ? { integrity } : {}),
             };
 
       newLock.skills[name] = lockEntry;

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -75,15 +75,11 @@ export async function runList(opts: ListOptions): Promise<SkillStatus[]> {
       continue;
     }
 
-    // Check integrity
-    const integrity = await hashDirectory(installed);
-    const commit = isGitLocked(locked) ? locked.commit.slice(0, 8) : undefined;
+    // Check integrity (skip when not available, e.g. pin = false)
+    const commit = isGitLocked(locked) && locked.commit ? locked.commit.slice(0, 8) : undefined;
 
-    if (integrity !== locked.integrity) {
-      results.push({ name, source: entry.source, commit, status: "modified", wildcard: entry.wildcard });
-    } else {
-      results.push({ name, source: entry.source, commit, status: "ok", wildcard: entry.wildcard });
-    }
+    const modified = locked.integrity && (await hashDirectory(installed)) !== locked.integrity;
+    results.push({ name, source: entry.source, commit, status: modified ? "modified" : "ok", wildcard: entry.wildcard });
   }
 
   return results;

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -68,7 +68,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
 
   // 1. Adopt orphaned skills (installed but not in agents.toml)
   if (existsSync(skillsDir)) {
-    const adoptedLockEntries: Record<string, { source: string; integrity: string }> = {};
+    const adoptedLockEntries: Record<string, { source: string; integrity?: string }> = {};
     const entries = await readdir(skillsDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
@@ -79,8 +79,11 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
       await addSkillToConfig(configPath, entry.name, { source });
       declaredNames.add(entry.name);
 
-      const integrity = await hashDirectory(join(skillsDir, entry.name));
-      adoptedLockEntries[entry.name] = { source, integrity };
+      const integrity = config.pin ? await hashDirectory(join(skillsDir, entry.name)) : undefined;
+      adoptedLockEntries[entry.name] = {
+        source,
+        ...(integrity !== undefined ? { integrity } : {}),
+      };
       adopted.push(entry.name);
     }
 
@@ -122,11 +125,12 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
     }
   }
 
-  // 4. Verify integrity hashes against lockfile
+  // 4. Verify integrity hashes against lockfile (skip entries without integrity, e.g. pin = false)
   if (lockfile) {
     for (const [name, locked] of Object.entries(lockfile.skills)) {
       const installed = join(skillsDir, name);
       if (!existsSync(installed)) continue;
+      if (!locked.integrity) continue;
 
       const integrity = await hashDirectory(installed);
       if (integrity !== locked.integrity) {

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -247,4 +247,16 @@ describe("runUpdate", () => {
     expect(result.updated.some((u) => u.name === "pdf")).toBe(true);
     expect(result.updated.some((u) => u.name === "review")).toBe(true);
   });
+
+  it("returns unpinned=true when pin=false", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\npin = false\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+    await runInstall({ scope: resolveScope("project", projectRoot) });
+
+    const result = await runUpdate({ scope: resolveScope("project", projectRoot) });
+    expect(result.unpinned).toBe(true);
+    expect(result.updated).toHaveLength(0);
+  });
 });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -43,6 +43,7 @@ export interface UpdatedSkill {
 export interface UpdateResult {
   updated: UpdatedSkill[];
   removed: string[];
+  unpinned?: boolean;
 }
 
 export async function runUpdate(opts: UpdateOptions): Promise<UpdateResult> {
@@ -50,6 +51,11 @@ export async function runUpdate(opts: UpdateOptions): Promise<UpdateResult> {
   const { configPath, lockPath, agentsDir, skillsDir } = scope;
 
   const config = await loadConfig(configPath);
+
+  if (!config.pin) {
+    return { updated: [], removed: [], unpinned: true };
+  }
+
   const lockfile = await loadLockfile(lockPath);
 
   if (!lockfile) {
@@ -134,7 +140,7 @@ async function updateRegularSkill(
   const resolved = await resolveSkill(name, dep, { projectRoot: scope.root });
   if (resolved.type !== "git") return null;
 
-  const oldCommit = locked.commit;
+  const oldCommit = locked.commit ?? "";
   const newCommit = resolved.commit;
   if (oldCommit === newCommit) return null;
 
@@ -250,6 +256,14 @@ export default async function update(args: string[], flags?: { user?: boolean })
       scope,
       skillName: positionals[0],
     });
+
+    if (result.unpinned) {
+      console.log(
+        chalk.dim("Pinning is disabled (pin = false). Skills always fetch the latest version."),
+      );
+      console.log(chalk.dim("Run 'dotagents install' to refresh all skills."));
+      return;
+    }
 
     if (result.updated.length === 0 && result.removed.length === 0) {
       console.log(chalk.dim("All skills are up to date."));

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -36,6 +36,30 @@ describe("agentsConfigSchema", () => {
     }
   });
 
+  it("defaults pin to true when absent", () => {
+    const result = agentsConfigSchema.safeParse({ version: 1 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pin).toBe(true);
+    }
+  });
+
+  it("parses pin = true", () => {
+    const result = agentsConfigSchema.safeParse({ version: 1, pin: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pin).toBe(true);
+    }
+  });
+
+  it("parses pin = false", () => {
+    const result = agentsConfigSchema.safeParse({ version: 1, pin: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pin).toBe(false);
+    }
+  });
+
   it("parses a full config with all fields", () => {
     const result = agentsConfigSchema.safeParse({
       version: 1,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,6 +135,7 @@ export type TrustConfig = z.infer<typeof trustConfigSchema>;
 export const agentsConfigSchema = z.object({
   version: z.literal(1),
   gitignore: z.boolean().default(true),
+  pin: z.boolean().default(true),
   project: projectConfigSchema.optional(),
   symlinks: symlinksConfigSchema.optional(),
   agents: z.array(z.string()).default([]),

--- a/src/config/writer.test.ts
+++ b/src/config/writer.test.ts
@@ -50,6 +50,23 @@ describe("writer", () => {
       expect(content).toContain("gitignore = true");
     });
 
+    it("does not contain pin when using defaults", () => {
+      const content = generateDefaultConfig();
+      expect(content).not.toContain("pin");
+    });
+
+    it("contains pin = false when requested", () => {
+      const content = generateDefaultConfig({ pin: false });
+      expect(content).toContain("pin = false");
+    });
+
+    it("round-trips pin = false through loadConfig", async () => {
+      const content = generateDefaultConfig({ pin: false });
+      await writeFile(configPath, content);
+      const config = await loadConfig(configPath);
+      expect(config.pin).toBe(false);
+    });
+
     it("includes agents when provided via options object", () => {
       const content = generateDefaultConfig({ agents: ["claude", "cursor"] });
       expect(content).toContain('agents = ["claude", "cursor"]');

--- a/src/config/writer.ts
+++ b/src/config/writer.ts
@@ -6,6 +6,7 @@ import { sourcesMatch } from "../skills/resolver.js";
 export interface DefaultConfigOptions {
   agents?: string[];
   gitignore?: boolean;
+  pin?: boolean;
   trust?: TrustConfig;
   skills?: Array<{ name: string; source: string; ref?: string; path?: string }>;
 }
@@ -225,6 +226,10 @@ export function generateDefaultConfig(opts?: DefaultConfigOptions | string[]): s
     config += `# Managed skills are gitignored; collaborators must run 'dotagents install'.\ngitignore = true\n`;
   } else {
     config += `# Check skills into git so collaborators get them without running 'dotagents install'.\n# Set to true (or remove) to gitignore managed skills instead.\ngitignore = false\n`;
+  }
+
+  if (options.pin === false) {
+    config += `# Skills always fetch the latest version; lockfile tracks names only.\npin = false\n`;
   }
 
   if (options.agents && options.agents.length > 0) {

--- a/src/lockfile/schema.test.ts
+++ b/src/lockfile/schema.test.ts
@@ -43,6 +43,32 @@ describe("lockfileSchema", () => {
   it("rejects invalid version", () => {
     expect(lockfileSchema.safeParse({ version: 2 }).success).toBe(false);
   });
+
+  it("parses unpinned git skills (no commit/integrity)", () => {
+    const result = lockfileSchema.safeParse({
+      version: 1,
+      skills: {
+        "my-skill": {
+          source: "org/repo",
+          resolved_url: "https://github.com/org/repo.git",
+          resolved_path: "my-skill",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses unpinned local skills (no integrity)", () => {
+    const result = lockfileSchema.safeParse({
+      version: 1,
+      skills: {
+        local: {
+          source: "path:../local",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("isGitLocked", () => {
@@ -58,11 +84,29 @@ describe("isGitLocked", () => {
     ).toBe(true);
   });
 
+  it("returns true for unpinned git-locked skills (no commit)", () => {
+    expect(
+      isGitLocked({
+        source: "org/repo",
+        resolved_url: "https://github.com/org/repo.git",
+        resolved_path: "my-skill",
+      }),
+    ).toBe(true);
+  });
+
   it("returns false for local-locked skills", () => {
     expect(
       isGitLocked({
         source: "path:../shared/my-skill",
         integrity: "sha256-test",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for unpinned local-locked skills", () => {
+    expect(
+      isGitLocked({
+        source: "path:../shared/my-skill",
       }),
     ).toBe(false);
   });

--- a/src/lockfile/schema.ts
+++ b/src/lockfile/schema.ts
@@ -5,13 +5,13 @@ const lockedGitSkillSchema = z.object({
   resolved_url: z.string(),
   resolved_path: z.string(),
   resolved_ref: z.string().optional(),
-  commit: z.string(),
-  integrity: z.string(),
+  commit: z.string().optional(),
+  integrity: z.string().optional(),
 });
 
 const lockedLocalSkillSchema = z.object({
   source: z.string(),
-  integrity: z.string(),
+  integrity: z.string().optional(),
 });
 
 const lockedSkillSchema = z.union([lockedGitSkillSchema, lockedLocalSkillSchema]);
@@ -29,5 +29,5 @@ export type Lockfile = z.infer<typeof lockfileSchema>;
  * Type guard: is this a git-based locked skill?
  */
 export function isGitLocked(skill: LockedSkill): skill is z.infer<typeof lockedGitSkillSchema> {
-  return "commit" in skill && "resolved_url" in skill;
+  return "resolved_url" in skill;
 }

--- a/src/skills/resolver.ts
+++ b/src/skills/resolver.ts
@@ -114,6 +114,8 @@ export async function resolveSkill(
     projectRoot?: string;
     /** Locked commit from agents.lock — skip resolution, use this exact commit */
     lockedCommit?: string;
+    /** Override cache TTL (pass 0 to force refresh) */
+    ttlMs?: number;
   },
 ): Promise<ResolvedSkill> {
   const parsed = parseSource(dep.source);
@@ -138,6 +140,7 @@ export async function resolveSkill(
     cacheKey,
     ref,
     pinnedCommit: opts?.lockedCommit,
+    ttlMs: opts?.ttlMs,
   });
 
   // Discover the skill within the repo
@@ -186,6 +189,8 @@ export async function resolveWildcardSkills(
   opts?: {
     projectRoot?: string;
     lockedCommit?: string;
+    /** Override cache TTL (pass 0 to force refresh) */
+    ttlMs?: number;
   },
 ): Promise<NamedResolvedSkill[]> {
   const parsed = parseSource(dep.source);
@@ -217,6 +222,7 @@ export async function resolveWildcardSkills(
     cacheKey,
     ref,
     pinnedCommit: opts?.lockedCommit,
+    ttlMs: opts?.ttlMs,
   });
 
   const discovered = await discoverAllSkills(cached.repoDir);


### PR DESCRIPTION
Add `pin = false` to `agents.toml` for repositories that want skills to always fetch the latest version without requiring lockfile update commits.

The lockfile currently serves two purposes: **version pinning** (commit SHA + integrity hash) and **skill tracking** (names, sources, resolved paths for wildcard pruning). The naive approach of removing the lockfile entirely breaks wildcard imports (`name = "*"`) because the lockfile is used to track which concrete skills exist for pruning stale ones. This PR decouples the two concerns by making `commit` and `integrity` optional on lockfile entries.

When `pin = false`:
- Lockfile still tracks skill names/sources/paths (wildcard pruning works)
- Lockfile omits `commit` and `integrity` fields
- `install` always fetches latest (bypasses cache TTL)
- `update` becomes a no-op ("skills are always current")
- `sync` skips integrity checks for unpinned entries
- `list` handles optional commit/integrity gracefully
- Skills with explicit `ref` still resolve that ref (escape hatch)
- `--frozen` validates the skill list but fetches latest content

The `init` interactive flow now includes a prompt for the pin preference. Default remains `true` (current behavior preserved).

**Areas worth reviewing:**
- `install.ts` has the largest change surface — conditional lockfile entry construction and TTL bypass
- `lockfile/schema.ts` — `isGitLocked` discriminator changed from `"commit" in skill` to `"resolved_url" in skill` to work for unpinned git entries


Agent transcript: https://claudescope.sentry.dev/share/Snjvc6JoFEdRaQFXdooLZNeh_DuU2A8d5_8d06S7mkM