### PR TITLE
fix(lockfile): Ensure consistent trailing newline in lockfile output

### DIFF
--- a/src/lockfile/writer.test.ts
+++ b/src/lockfile/writer.test.ts
@@ -75,6 +75,23 @@ describe("writeLockfile + loadLockfile", () => {
     expect(keys).toEqual(["a-skill", "z-skill"]);
   });
 
+  it("ends with exactly one trailing newline", async () => {
+    const lockPath = join(dir, "agents.lock");
+    await writeLockfile(lockPath, {
+      version: 1,
+      skills: {
+        "test-skill": {
+          source: "org/repo",
+          integrity: "sha256-abc",
+        },
+      },
+    });
+
+    const { readFile } = await import("node:fs/promises");
+    const content = await readFile(lockPath, "utf-8");
+    expect(content).toMatch(/[^\n]\n$/);
+  });
+
   it("returns null for missing lockfile", async () => {
     const result = await loadLockfile(join(dir, "nope.lock"));
     expect(result).toBeNull();

--- a/src/lockfile/writer.ts
+++ b/src/lockfile/writer.ts
@@ -19,5 +19,5 @@ export async function writeLockfile(
   }
 
   const toml = stringify({ version: lockfile.version, skills: sortedSkills });
-  await writeFile(filePath, HEADER + toml + "\n", "utf-8");
+  await writeFile(filePath, (HEADER + toml).trimEnd() + "\n", "utf-8");
 }


### PR DESCRIPTION
The lockfile writer appended `"\n"` directly to the output of
`smol-toml`'s `stringify`, which may itself include a trailing newline.
This led to inconsistent trailing whitespace in `agents.lock`.

Use `trimEnd() + "\n"` to guarantee exactly one trailing newline,
matching the pattern already used by the config writer.


Agent transcript: https://claudescope.sentry.dev/share/IEbH7ET3ehUDinY9fC1xXlo5r2_zO2RT3m3nw3hc3lQ