### PR TITLE
ref(cli): Accept full command string in mcp add --command

### DIFF
--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -144,7 +144,7 @@ async function mcpAdd(args: string[], scope: ScopeRoot): Promise<void> {
   let command: string | undefined;
   let commandArgs: string[] | undefined;
   if (values["command"]) {
-    const parts = values["command"].split(/\s+/);
+    const parts = values["command"].trim().split(/\s+/).filter(Boolean);
     command = parts[0];
     commandArgs = parts.length > 1 ? parts.slice(1) : undefined;
   }


### PR DESCRIPTION
Replace the `--args` flag with parsing `--command` as a full command string.

Previously adding a stdio MCP server required repeating `--args` for each argument, which was shell-hostile and error-prone (ambiguous when args start with dashes, breaks on line wraps):

```bash
# Before — broken UX
dotagents mcp add xcodebuildmcp --command npx --args=-y --args=xcodebuildmcp@latest --args=mcp
```

Now `--command` accepts the entire command as a quoted string, splits on whitespace internally:

```bash
# After
dotagents mcp add xcodebuildmcp --command "npx -y xcodebuildmcp@latest mcp"
```

First token becomes the command, the rest becomes args.


Agent transcript: https://claudescope.sentry.dev/share/8kdJ8WN-md3ffojXSz6cnxvvYnqHAabS5RHq4TddCNQ