### PR TITLE
fix(install): Skip integrity pinning for local skills

### DIFF
--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -593,6 +593,28 @@ describe("runInstall", () => {
     expect(result.installed).toContain("local-skill");
   });
 
+  it("frozen mode handles old lockfile with integrity for local skill", async () => {
+    const skillDir = join(projectRoot, ".agents", "skills", "local-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), SKILL_MD("local-skill"));
+
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\n\n[[skills]]\nname = "local-skill"\nsource = "path:.agents/skills/local-skill"\n`,
+    );
+
+    // Write a lockfile with a stale integrity hash (simulating pre-fix lockfile)
+    await writeFile(
+      join(projectRoot, "agents.lock"),
+      `version = 1\n\n[skills.local-skill]\nsource = "path:.agents/skills/local-skill"\nintegrity = "sha256-stale-hash"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    // Frozen install should succeed — old integrity for local skills is ignored
+    const result = await runInstall({ scope, frozen: true });
+    expect(result.installed).toContain("local-skill");
+  });
+
   it("pin=false with wildcard still prunes stale skills", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -210,7 +210,7 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
       // Local skills are expected to change — don't freeze their content
       const integrity = pin && resolved.type !== "local" ? await hashDirectory(destDir) : undefined;
 
-      if (frozen && pin && locked && locked.integrity && locked.integrity !== integrity) {
+      if (frozen && pin && resolved.type !== "local" && locked && locked.integrity && locked.integrity !== integrity) {
         throw new InstallError(
           `--frozen: integrity mismatch for "${name}". Expected ${locked.integrity}, got ${integrity}.`,
         );


### PR DESCRIPTION
Local skills (path: sources) were getting integrity hashes pinned in the lockfile and validated during `--frozen` installs, just like git-sourced skills. This doesn't make sense — local skills live in the project and are expected to change freely.

Local skills now get `pin=false` semantics regardless of the project's `pin` setting: they still appear in the lockfile for skill-list validation, but never with an `integrity` hash. This means `--frozen` installs validate that local skills are declared in the lockfile but don't reject content changes.


Agent transcript: https://claudescope.sentry.dev/share/VyB438VpahSlYbw0Fo7I5ttLTApvJZhlzrApDUYZp2k