### PR TITLE
fix(trust): Validate trust against expanded source, not shorthand

### DIFF
--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import add, { runAdd, AddError } from "./add.js";
+import { TrustError } from "../../trust/index.js";
 import { exec } from "../../utils/exec.js";
 import { resolveScope } from "../../scope.js";
 
@@ -198,6 +199,32 @@ describe("runAdd", () => {
     ).rejects.toThrow(
       'A wildcard entry for "getsentry/skills" already exists in agents.toml.',
     );
+  });
+
+  it("validates trust against expanded source, not raw shorthand", async () => {
+    // When defaultRepositorySource=gitlab, a shorthand like "getsentry/skills"
+    // should be validated as a GitLab source, not a GitHub source.
+    // github_orgs=["getsentry"] should NOT allow it — the clone targets GitLab.
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      [
+        "version = 1",
+        'defaultRepositorySource = "gitlab"',
+        "",
+        "[trust]",
+        'github_orgs = ["getsentry"]',
+        "",
+      ].join("\n"),
+    );
+
+    const scope = resolveScope("project", projectRoot);
+    await expect(
+      runAdd({
+        scope,
+        specifier: "getsentry/skills",
+        names: ["pdf"],
+      }),
+    ).rejects.toThrow(TrustError);
   });
 
   it("auto-selects when repo has a single skill", async () => {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -84,8 +84,9 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     ? specifier.slice(0, -(parsed.ref.length + 1))
     : specifier;
 
-  // Validate trust against the source
-  validateTrustedSource(sourceForStorage, config.trust);
+  // Validate trust against the expanded source (not the shorthand) so that
+  // defaultRepositorySource=gitlab doesn't bypass trust checks
+  validateTrustedSource(hintedSpecifier, config.trust);
 
   // Determine ref (flag overrides inline @ref)
   const effectiveRef = ref ?? parsed.ref;


### PR DESCRIPTION
When `defaultRepositorySource = "gitlab"`, the `add` command validated trust against the raw shorthand (e.g. `getsentry/skills`). `parseSource` treats bare shorthands as `type: "github"`, so `github_orgs = ["getsentry"]` would incorrectly allow sources that actually resolve to GitLab.

Fix: validate against the expanded URL (`hintedSpecifier`) which has already been computed via `applyDefaultRepositorySource`.

Flagged by sentry-bot and cursor-bot on #32.


Agent transcript: https://claudescope.sentry.dev/share/oFuIc5A1eVnEFJmqSWKCwHEtGB0pf4cooK_wqq2zGZg