### PR TITLE
feat(cli): Auto-bootstrap user scope when not initialized

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -20,6 +20,7 @@ import { ensureCached } from "../../sources/cache.js";
 import { validateTrustedSource, TrustError } from "../../trust/index.js";
 import { runInstall } from "./install.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 /** Parent paths that are standard/expected — no need to show them in the picker */
 const STANDARD_PARENTS = new Set(["", "skills", ".agents/skills", ".claude/skills"]);
@@ -396,6 +397,7 @@ export default async function add(
     const scope = flags?.user
       ? resolveScope("user")
       : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
     const interactive =
       process.stdout.isTTY === true && !names && !values["all"];
     const result = await runAdd({

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -27,6 +27,7 @@ import { writeMcpConfigs, toMcpDeclarations, projectMcpResolver } from "../../ag
 import { writeHookConfigs, toHookDeclarations, projectHookResolver } from "../../agents/hook-writer.js";
 import { userMcpResolver } from "../../agents/paths.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 /** A skill whose source points to its own install location (adopted orphan). */
 function isInPlaceSkill(source: string): boolean {
@@ -320,6 +321,7 @@ export default async function install(args: string[], flags?: { user?: boolean }
 
   try {
     const scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
     if (values["frozen"]) {
       console.log(chalk.yellow("Warning: --frozen is deprecated and will be removed in a future release. Pinning is now managed via agents.toml refs."));
     }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -7,6 +7,7 @@ import { loadLockfile } from "../../lockfile/loader.js";
 import { sourcesMatch } from "../../skills/resolver.js";
 import { existsSync } from "node:fs";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 export interface SkillStatus {
   name: string;
@@ -103,6 +104,7 @@ export default async function list(args: string[], flags?: { user?: boolean }): 
   let scope: ScopeRoot;
   try {
     scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
   } catch (err) {
     if (err instanceof ScopeError) {
       console.error(chalk.red(err.message));

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -7,6 +7,7 @@ import type { AgentsConfig, McpConfig } from "../../config/schema.js";
 import { addMcpToConfig, removeMcpFromConfig } from "../../config/writer.js";
 import { runInstall } from "./install.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 export class McpError extends Error {
   constructor(message: string) {
@@ -335,6 +336,7 @@ export default async function mcp(args: string[], flags?: { user?: boolean }): P
   let scope: ScopeRoot;
   try {
     scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
   } catch (err) {
     if (err instanceof ScopeError) {
       console.error(chalk.red(err.message));

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -11,6 +11,7 @@ import { writeLockfile } from "../../lockfile/writer.js";
 import { writeAgentsGitignore } from "../../gitignore/writer.js";
 import { sourcesMatch } from "../../skills/resolver.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 export class RemoveError extends Error {
   constructor(message: string) {
@@ -113,6 +114,7 @@ export default async function remove(args: string[], flags?: { user?: boolean })
 
   try {
     const scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
     await runRemove({ scope, skillName });
     console.log(chalk.green(`Removed skill: ${skillName}`));
   } catch (err) {

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -15,6 +15,7 @@ import { verifyMcpConfigs, writeMcpConfigs, toMcpDeclarations, projectMcpResolve
 import { verifyHookConfigs, writeHookConfigs, toHookDeclarations, projectHookResolver } from "../../agents/hook-writer.js";
 import { userMcpResolver } from "../../agents/paths.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 /** A skill whose source points to its own install location (adopted orphan). */
 function isInPlaceSkill(source: string): boolean {
@@ -228,6 +229,7 @@ export default async function sync(_args: string[], flags?: { user?: boolean }):
   let scope: ScopeRoot;
   try {
     scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
   } catch (err) {
     if (err instanceof ScopeError) {
       console.error(chalk.red(err.message));

--- a/src/cli/commands/trust.ts
+++ b/src/cli/commands/trust.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../../config/loader.js";
 import type { AgentsConfig } from "../../config/schema.js";
 import { addTrustSource, removeTrustSource } from "../../config/writer.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
+import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
 
 export class TrustCommandError extends Error {
   constructor(message: string) {
@@ -179,6 +180,7 @@ export default async function trust(args: string[], flags?: { user?: boolean }):
   let scope: ScopeRoot;
   try {
     scope = flags?.user ? resolveScope("user") : resolveDefaultScope(resolve("."));
+    await ensureUserScopeBootstrapped(scope);
   } catch (err) {
     if (err instanceof ScopeError) {
       console.error(chalk.red(err.message));

--- a/src/cli/ensure-user-scope.test.ts
+++ b/src/cli/ensure-user-scope.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { existsSync } from "node:fs";
+import { readFile, rm, mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureUserScopeBootstrapped } from "./ensure-user-scope.js";
+import { allAgentIds } from "../agents/registry.js";
+import type { ScopeRoot } from "../scope.js";
+
+describe("ensureUserScopeBootstrapped", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dotagents-user-scope-"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function userScope(home: string): ScopeRoot {
+    return {
+      scope: "user",
+      root: home,
+      agentsDir: home,
+      configPath: join(home, "agents.toml"),
+      lockPath: join(home, "agents.lock"),
+      skillsDir: join(home, "skills"),
+    };
+  }
+
+  it("creates agents.toml and skills/ when user scope is uninitialized", async () => {
+    const scope = userScope(tmpDir);
+    await ensureUserScopeBootstrapped(scope);
+
+    expect(existsSync(scope.configPath)).toBe(true);
+    expect(existsSync(scope.skillsDir)).toBe(true);
+
+    const content = await readFile(scope.configPath, "utf-8");
+    expect(content).toContain("version = 1");
+
+    // Should include all known agents
+    for (const id of allAgentIds()) {
+      expect(content).toContain(`"${id}"`);
+    }
+  });
+
+  it("prints a message when bootstrapping", async () => {
+    const scope = userScope(tmpDir);
+    await ensureUserScopeBootstrapped(scope);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Initialized"),
+    );
+  });
+
+  it("is a no-op when agents.toml already exists", async () => {
+    const scope = userScope(tmpDir);
+
+    // Bootstrap once
+    await ensureUserScopeBootstrapped(scope);
+    const content = await readFile(scope.configPath, "utf-8");
+
+    // Reset mock to track second call
+    vi.mocked(console.error).mockClear();
+
+    // Bootstrap again — should be a no-op
+    await ensureUserScopeBootstrapped(scope);
+    const contentAfter = await readFile(scope.configPath, "utf-8");
+
+    expect(contentAfter).toBe(content);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for project scope", async () => {
+    const scope: ScopeRoot = {
+      scope: "project",
+      root: tmpDir,
+      agentsDir: join(tmpDir, ".agents"),
+      configPath: join(tmpDir, "agents.toml"),
+      lockPath: join(tmpDir, "agents.lock"),
+      skillsDir: join(tmpDir, ".agents", "skills"),
+    };
+
+    await ensureUserScopeBootstrapped(scope);
+
+    expect(existsSync(scope.configPath)).toBe(false);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/ensure-user-scope.ts
+++ b/src/cli/ensure-user-scope.ts
@@ -1,0 +1,26 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import chalk from "chalk";
+import { generateDefaultConfig } from "../config/writer.js";
+import { allAgentIds } from "../agents/registry.js";
+import type { ScopeRoot } from "../scope.js";
+
+/**
+ * Auto-bootstrap user scope if agents.toml doesn't exist yet.
+ *
+ * For user scope, the intent is obvious — create ~/.agents/agents.toml
+ * with sensible defaults so the user can immediately start adding skills
+ * without a separate `dotagents init` step.
+ */
+export async function ensureUserScopeBootstrapped(scope: ScopeRoot): Promise<void> {
+  if (scope.scope !== "user") {return;}
+  if (existsSync(scope.configPath)) {return;}
+
+  await mkdir(scope.skillsDir, { recursive: true });
+  await writeFile(
+    scope.configPath,
+    generateDefaultConfig({ agents: allAgentIds() }),
+    "utf-8",
+  );
+  console.error(chalk.dim("Initialized ~/.agents/agents.toml"));
+}


### PR DESCRIPTION
Running any command with `--user` on a machine where `~/.agents/` was never initialized previously errored with a confusing "Config file not found" message, requiring users to know they need to run `dotagents --user init` first.

For user scope, the right thing to do is obvious — create `~/.agents/agents.toml` with sensible defaults and continue. This makes the first-run experience seamless: `dotagents --user add getsentry/skills --all` just works without a separate init step.

The bootstrap creates a minimal config with all known agents (claude, cursor, codex, vscode, opencode) so that symlinks are created during install and skills are immediately discoverable regardless of which agent is running. `init` and `doctor` are excluded — init IS the explicit bootstrap, and doctor already handles missing config gracefully with a diagnostic check.


Agent transcript: https://claudescope.sentry.dev/share/U0dq7No4bEf0S6KEIXeBxew9vSiRu5Jl5t7rvqsvkx0