### PR TITLE
fix(cli): Handle leading @ in owner/repo specifiers

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -11,6 +11,7 @@ import {
   parseOwnerRepoShorthand,
   parseSource,
   sourcesMatch,
+  stripLeadingAt,
   VALID_SKILL_NAME,
 } from "../../skills/resolver.js";
 import { discoverAllSkills, discoverSkill } from "../../skills/discovery.js";
@@ -51,12 +52,14 @@ export interface AddOptions {
 export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   const {
     scope,
-    specifier,
+    specifier: rawSpecifier,
     ref,
     names: rawNames,
     all,
     interactive,
   } = opts;
+  // Strip npm-style leading @ (e.g. @getsentry/skills → getsentry/skills)
+  const specifier = stripLeadingAt(rawSpecifier);
   // Deduplicate names to prevent writing duplicate config entries
   const namesOverride = rawNames ? [...new Set(rawNames)] : rawNames;
   const { configPath } = scope;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -37,8 +37,9 @@ const skillSourceSchema = z.string().check(
     // GitLab HTTPS or SSH URLs
     if (GITLAB_HTTPS_URL.test(s)) {return true;}
     if (GITLAB_SSH_URL.test(s)) {return true;}
-    // owner/repo or owner/repo@ref
-    const base = s.includes("@") ? s.slice(0, s.indexOf("@")) : s;
+    // owner/repo or owner/repo@ref (strip npm-style leading @)
+    const stripped = s.startsWith("@") ? s.slice(1) : s;
+    const base = stripped.includes("@") ? stripped.slice(0, stripped.indexOf("@")) : stripped;
     const parts = base.split("/");
     return (
       parts.length === 2 &&

--- a/src/skills/resolver.test.ts
+++ b/src/skills/resolver.test.ts
@@ -1,10 +1,40 @@
 import { describe, it, expect } from "vitest";
 import {
   applyDefaultRepositorySource,
+  parseOwnerRepoShorthand,
   parseSource,
   normalizeSource,
   sourcesMatch,
 } from "./resolver.js";
+
+describe("parseOwnerRepoShorthand", () => {
+  it("parses owner/repo", () => {
+    expect(parseOwnerRepoShorthand("getsentry/skills")).toEqual({
+      owner: "getsentry",
+      repo: "skills",
+    });
+  });
+
+  it("parses @owner/repo (strips leading @)", () => {
+    expect(parseOwnerRepoShorthand("@getsentry/skills")).toEqual({
+      owner: "getsentry",
+      repo: "skills",
+    });
+  });
+
+  it("parses @owner/repo@ref (strips leading @, preserves ref)", () => {
+    expect(parseOwnerRepoShorthand("@getsentry/skills@v1.0.0")).toEqual({
+      owner: "getsentry",
+      repo: "skills",
+      ref: "v1.0.0",
+    });
+  });
+
+  it("returns undefined for explicit URLs", () => {
+    expect(parseOwnerRepoShorthand("https://github.com/o/r")).toBeUndefined();
+    expect(parseOwnerRepoShorthand("git@github.com:o/r")).toBeUndefined();
+  });
+});
 
 describe("applyDefaultRepositorySource", () => {
   it("expands shorthand to GitHub by default", () => {
@@ -38,6 +68,23 @@ describe("parseSource", () => {
     expect(result.url).toBe("https://github.com/anthropics/skills.git");
     expect(result.cloneUrl).toBeUndefined();
     expect(result.ref).toBeUndefined();
+  });
+
+  it("parses @owner/repo as github (strips leading @)", () => {
+    const result = parseSource("@getsentry/skills");
+    expect(result.type).toBe("github");
+    expect(result.owner).toBe("getsentry");
+    expect(result.repo).toBe("skills");
+    expect(result.url).toBe("https://github.com/getsentry/skills.git");
+    expect(result.ref).toBeUndefined();
+  });
+
+  it("parses @owner/repo@ref as github with ref", () => {
+    const result = parseSource("@getsentry/skills@v2.0");
+    expect(result.type).toBe("github");
+    expect(result.owner).toBe("getsentry");
+    expect(result.repo).toBe("skills");
+    expect(result.ref).toBe("v2.0");
   });
 
   it("parses owner/repo@ref as github with ref", () => {

--- a/src/skills/resolver.ts
+++ b/src/skills/resolver.ts
@@ -54,14 +54,20 @@ export function isExplicitSourceSpecifier(specifier: string): boolean {
   );
 }
 
+/** Strip a leading `@` from npm-style scoped specifiers (e.g. `@owner/repo` → `owner/repo`). */
+export function stripLeadingAt(specifier: string): string {
+  return specifier.startsWith("@") ? specifier.slice(1) : specifier;
+}
+
 export function parseOwnerRepoShorthand(
   specifier: string,
 ): { owner: string; repo: string; ref?: string } | undefined {
   if (isExplicitSourceSpecifier(specifier)) {return undefined;}
 
-  const atIdx = specifier.indexOf("@");
-  const base = atIdx >= 0 ? specifier.slice(0, atIdx) : specifier;
-  const ref = atIdx >= 0 ? specifier.slice(atIdx + 1) : undefined;
+  const stripped = stripLeadingAt(specifier);
+  const atIdx = stripped.indexOf("@");
+  const base = atIdx >= 0 ? stripped.slice(0, atIdx) : stripped;
+  const ref = atIdx >= 0 ? stripped.slice(atIdx + 1) : undefined;
   const parts = base.split("/");
   if (parts.length !== 2) {return undefined;}
 
@@ -150,9 +156,10 @@ export function parseSource(source: string): {
   }
 
   // owner/repo or owner/repo@ref — shorthand, no cloneUrl
-  const atIdx = source.indexOf("@");
-  const base = atIdx === -1 ? source : source.slice(0, atIdx);
-  const ref = atIdx === -1 ? undefined : source.slice(atIdx + 1);
+  const stripped = stripLeadingAt(source);
+  const atIdx = stripped.indexOf("@");
+  const base = atIdx === -1 ? stripped : stripped.slice(0, atIdx);
+  const ref = atIdx === -1 ? undefined : stripped.slice(atIdx + 1);
   const [owner, repo] = base.split("/");
 
   return {


### PR DESCRIPTION
The `@` character in specifiers like `@getsentry/skills` was being treated as a ref separator (the same `@` used in `owner/repo@v1.0.0`). This caused `@getsentry/skills` to parse as `base=""`, `ref="getsentry/skills"` — failing validation and producing malformed GitHub URLs.

Strip the npm-style leading `@` before owner/repo parsing in `parseOwnerRepoShorthand`, `parseSource`, the Zod schema validator, and the `add` command (so `getsentry/skills` is stored in `agents.toml`, not `@getsentry/skills`).


Agent transcript: https://claudescope.sentry.dev/share/z8_rzzmFUABNZXimzrzafq4Fwkj7DOog23Uy5S5lT9E