### PR TITLE
fix(cli): Standardize command references to use npx @sentry/dotagents

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -44,7 +44,7 @@ And a lockfile (`agents.lock`) tracking which skills are managed. Both `agents.l
 1. Declare skill dependencies in `agents.toml` at the project root (or `~/.agents/agents.toml` for user scope)
 2. `install` clones repos (always fetching latest), discovers skills by convention, and copies them into `.agents/skills/`
 3. `agents.lock` tracks which skills are managed (gitignored automatically)
-4. Managed skills are gitignored. Collaborators run `dotagents install` after cloning. Custom skills in `.agents/skills/` are tracked by git normally.
+4. Managed skills are gitignored. Collaborators run `npx @sentry/dotagents install` after cloning. Custom skills in `.agents/skills/` are tracked by git normally.
 5. Symlinks connect `.agents/skills/` to each agent's expected location (`.claude/skills/`, `.cursor/skills/`, etc.)
 6. MCP and hook configs are generated for each declared agent
 
@@ -224,10 +224,10 @@ Global flags (before command name):
 ### init
 
 ```
-dotagents init [--force] [--agents claude,cursor]
+npx @sentry/dotagents init [--force] [--agents claude,cursor]
 ```
 
-Create `agents.toml` and `.agents/skills/` directory. Automatically includes the `dotagents` skill from `getsentry/dotagents` for CLI guidance. Interactive mode (when TTY is available) prompts for agent targets, trust policy, and optionally sets up a git `post-merge` hook to auto-run `dotagents install` on pull (defaults to no). Sets up gitignore entries automatically.
+Create `agents.toml` and `.agents/skills/` directory. Automatically includes the `dotagents` skill from `getsentry/dotagents` for CLI guidance. Interactive mode (when TTY is available) prompts for agent targets, trust policy, and optionally sets up a git `post-merge` hook to auto-run `npx @sentry/dotagents install` on pull (defaults to no). Sets up gitignore entries automatically.
 
 | Flag | Description |
 |------|-------------|
@@ -237,7 +237,7 @@ Create `agents.toml` and `.agents/skills/` directory. Automatically includes the
 ### install
 
 ```
-dotagents install [--force]
+npx @sentry/dotagents install [--force]
 ```
 
 Install all dependencies from `agents.toml`. Always fetches latest skills (TTL-based cache refresh). Resolves sources, copies skills, writes lockfile, creates symlinks, generates MCP and hook configs. There is no separate update step.
@@ -249,7 +249,7 @@ Install all dependencies from `agents.toml`. Always fetches latest skills (TTL-b
 ### add
 
 ```
-dotagents add <source> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]
+npx @sentry/dotagents add <source> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]
 ```
 
 Add one or more skill dependencies and install them. Specify skill names as positional arguments or with `--skill` flags.
@@ -268,7 +268,7 @@ When adding multiple skills, any that already exist in `agents.toml` are skipped
 ### remove
 
 ```
-dotagents remove <name>
+npx @sentry/dotagents remove <name>
 ```
 
 Remove a skill from `agents.toml`, delete from disk, and update the lockfile. For skills sourced from a wildcard entry, prompts to add the skill to the `exclude` list instead of removing the entire wildcard.
@@ -276,7 +276,7 @@ Remove a skill from `agents.toml`, delete from disk, and update the lockfile. Fo
 ### sync
 
 ```
-dotagents sync
+npx @sentry/dotagents sync
 ```
 
 Reconcile project state without network access: adopt orphaned skills (installed but not declared), regenerate `.agents/.gitignore`, check for missing skills, repair symlinks, verify/repair MCP and hook configs. Reports issues as warnings or errors.
@@ -284,8 +284,8 @@ Reconcile project state without network access: adopt orphaned skills (installed
 ### mcp add
 
 ```
-dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]
-dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
+npx @sentry/dotagents mcp add <name> --command <cmd> [--args <a>...] [--env <VAR>...]
+npx @sentry/dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
 ```
 
 Add an MCP server declaration to `agents.toml` and run `install` to generate agent configs. Specify exactly one transport: `--command` for stdio or `--url` for HTTP.
@@ -301,7 +301,7 @@ Add an MCP server declaration to `agents.toml` and run `install` to generate age
 ### mcp remove
 
 ```
-dotagents mcp remove <name>
+npx @sentry/dotagents mcp remove <name>
 ```
 
 Remove an MCP server declaration from `agents.toml` and run `install` to regenerate agent configs.
@@ -309,7 +309,7 @@ Remove an MCP server declaration from `agents.toml` and run `install` to regener
 ### mcp list
 
 ```
-dotagents mcp list [--json]
+npx @sentry/dotagents mcp list [--json]
 ```
 
 Show declared MCP servers. Use `--json` for machine-readable output.
@@ -317,7 +317,7 @@ Show declared MCP servers. Use `--json` for machine-readable output.
 ### trust add
 
 ```
-dotagents trust add <source>
+npx @sentry/dotagents trust add <source>
 ```
 
 Add a trusted source to `[trust]` in `agents.toml`. The source type is inferred automatically: contains `/` → `github_repos`, contains `.` → `git_domains`, otherwise → `github_orgs`. Creates the `[trust]` section if absent. Duplicates (case-insensitive) are rejected.
@@ -325,7 +325,7 @@ Add a trusted source to `[trust]` in `agents.toml`. The source type is inferred 
 ### trust remove
 
 ```
-dotagents trust remove <source>
+npx @sentry/dotagents trust remove <source>
 ```
 
 Remove a trusted source from `[trust]` in `agents.toml`. Matching is case-insensitive. Removes the field line if the array becomes empty.
@@ -333,7 +333,7 @@ Remove a trusted source from `[trust]` in `agents.toml`. Matching is case-insens
 ### trust list
 
 ```
-dotagents trust list [--json]
+npx @sentry/dotagents trust list [--json]
 ```
 
 Show trusted sources with their type. Use `--json` for machine-readable output. When `allow_all = true`, reports that all sources are trusted.
@@ -341,7 +341,7 @@ Show trusted sources with their type. Use `--json` for machine-readable output. 
 ### list
 
 ```
-dotagents list [--json]
+npx @sentry/dotagents list [--json]
 ```
 
 Show installed skills and status.
@@ -357,7 +357,7 @@ Skills from wildcard entries are marked with a wildcard indicator.
 ### doctor
 
 ```
-dotagents doctor [--fix]
+npx @sentry/dotagents doctor [--fix]
 ```
 
 Check project health: gitignore setup, installed skills, symlinks, and legacy config fields. Use `--fix` to auto-repair issues.
@@ -430,7 +430,7 @@ Required frontmatter fields: `name` (string), `description` (string).
 
 ## Lockfile (agents.lock)
 
-Auto-generated TOML file. Do not edit manually. Gitignored automatically (`dotagents init` adds it to `.gitignore`).
+Auto-generated TOML file. Do not edit manually. Gitignored automatically (`npx @sentry/dotagents init` adds it to `.gitignore`).
 
 ```toml
 # Auto-generated by dotagents. Do not edit.
@@ -457,7 +457,7 @@ Location: `~/.local/dotagents/` (override: `DOTAGENTS_STATE_DIR`)
 
 - Shallow clone per repo, refreshed after 24-hour TTL
 - All git operations are non-interactive (`GIT_TERMINAL_PROMPT=0`)
-- Use `dotagents install --force` to bypass cache
+- Use `npx @sentry/dotagents install --force` to bypass cache
 
 ## Environment Variables
 
@@ -472,7 +472,7 @@ dotagents always manages gitignore. Two files are gitignored automatically:
 - `agents.lock` -- tracks managed skills
 - `.agents/.gitignore` -- excludes managed skill directories from git
 
-`dotagents init` adds both to the root `.gitignore`. If they're missing, `install` and `sync` warn. Run `dotagents doctor --fix` to add them.
+`npx @sentry/dotagents init` adds both to the root `.gitignore`. If they're missing, `install` and `sync` warn. Run `npx @sentry/dotagents doctor --fix` to add them.
 
 Custom skills created directly in `.agents/skills/` are not gitignored. They're tracked by git normally.
 
@@ -480,7 +480,7 @@ Custom skills created directly in `.agents/skills/` are not gitignored. They're 
 
 ## Update Strategy
 
-`dotagents install` always fetches the latest version of each skill (with a TTL-based cache). There is no separate update command. Collaborators run `dotagents install` after cloning to get the latest skills.
+`npx @sentry/dotagents install` always fetches the latest version of each skill (with a TTL-based cache). There is no separate update command. Collaborators run `npx @sentry/dotagents install` after cloning to get the latest skills.
 
 ## Links
 

--- a/skills/dotagents/SKILL.md
+++ b/skills/dotagents/SKILL.md
@@ -7,7 +7,7 @@ Manage agent skill dependencies declared in `agents.toml`. dotagents resolves, i
 
 ## Running dotagents
 
-If `dotagents` is not available as a direct command, use `npx @sentry/dotagents` instead. For example: `npx @sentry/dotagents sync`. All commands and flags work the same way.
+Always use `npx @sentry/dotagents` to run commands. For example: `npx @sentry/dotagents sync`.
 
 ## References
 
@@ -23,40 +23,40 @@ Read the relevant reference when the task requires deeper detail:
 
 ```bash
 # Initialize a new project (interactive TUI)
-dotagents init
+npx @sentry/dotagents init
 
 # Add a skill from GitHub
-dotagents add getsentry/skills find-bugs
+npx @sentry/dotagents add getsentry/skills find-bugs
 
 # Add multiple skills at once
-dotagents add getsentry/skills find-bugs code-review commit
+npx @sentry/dotagents add getsentry/skills find-bugs code-review commit
 
 # Add all skills from a repo
-dotagents add getsentry/skills --all
+npx @sentry/dotagents add getsentry/skills --all
 
 # Add a pinned skill
-dotagents add getsentry/warden@v1.0.0
+npx @sentry/dotagents add getsentry/warden@v1.0.0
 
 # Install all dependencies from agents.toml
-dotagents install
+npx @sentry/dotagents install
 
 # List installed skills
-dotagents list
+npx @sentry/dotagents list
 ```
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `dotagents init` | Initialize `agents.toml` and `.agents/` directory |
-| `dotagents install` | Install all skills from `agents.toml` |
-| `dotagents add <specifier>` | Add a skill dependency |
-| `dotagents remove <name>` | Remove a skill |
-| `dotagents sync` | Reconcile state (adopt orphans, repair symlinks, fix configs) |
-| `dotagents list` | Show installed skills and their status |
-| `dotagents mcp` | Add, remove, or list MCP server declarations |
-| `dotagents trust` | Add, remove, or list trusted sources |
-| `dotagents doctor` | Check project health and fix issues |
+| `npx @sentry/dotagents init` | Initialize `agents.toml` and `.agents/` directory |
+| `npx @sentry/dotagents install` | Install all skills from `agents.toml` |
+| `npx @sentry/dotagents add <specifier>` | Add a skill dependency |
+| `npx @sentry/dotagents remove <name>` | Remove a skill |
+| `npx @sentry/dotagents sync` | Reconcile state (adopt orphans, repair symlinks, fix configs) |
+| `npx @sentry/dotagents list` | Show installed skills and their status |
+| `npx @sentry/dotagents mcp` | Add, remove, or list MCP server declarations |
+| `npx @sentry/dotagents trust` | Add, remove, or list trusted sources |
+| `npx @sentry/dotagents doctor` | Check project health and fix issues |
 
 All commands accept `--user` to operate on user scope (`~/.agents/`) instead of the current project.
 

--- a/skills/dotagents/references/cli-reference.md
+++ b/skills/dotagents/references/cli-reference.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-dotagents [--user] <command> [options]
+npx @sentry/dotagents [--user] <command> [options]
 ```
 
 ### Global Flags
@@ -21,10 +21,10 @@ dotagents [--user] <command> [options]
 Initialize a new project with `agents.toml` and `.agents/` directory. Automatically includes the `dotagents` skill from `getsentry/dotagents` for CLI guidance, and attempts to install it.
 
 ```bash
-dotagents init
-dotagents init --agents claude,cursor
-dotagents init --force
-dotagents --user init
+npx @sentry/dotagents init
+npx @sentry/dotagents init --agents claude,cursor
+npx @sentry/dotagents init --force
+npx @sentry/dotagents --user init
 ```
 
 | Flag | Description |
@@ -42,8 +42,8 @@ dotagents --user init
 Install all skill dependencies declared in `agents.toml`.
 
 ```bash
-dotagents install
-dotagents install --force
+npx @sentry/dotagents install
+npx @sentry/dotagents install --force
 ```
 
 | Flag | Description |
@@ -66,16 +66,16 @@ dotagents install --force
 Add one or more skill dependencies and install them.
 
 ```bash
-dotagents add getsentry/skills                          # Interactive selection if multiple skills
-dotagents add getsentry/skills find-bugs                # Add by positional name
-dotagents add getsentry/skills find-bugs code-review    # Add multiple skills at once
-dotagents add getsentry/skills --name find-bugs         # Add by --name flag
-dotagents add getsentry/skills --skill find-bugs        # --skill is an alias for --name
-dotagents add getsentry/skills --all                    # Add all as wildcard
-dotagents add getsentry/warden@v1.0.0                   # Pinned ref (inline)
-dotagents add getsentry/skills --ref v2.0.0             # Pinned ref (flag)
-dotagents add git:https://git.corp.dev/team/skills      # Non-GitHub git URL
-dotagents add path:./my-skills/custom                   # Local path
+npx @sentry/dotagents add getsentry/skills                          # Interactive selection if multiple skills
+npx @sentry/dotagents add getsentry/skills find-bugs                # Add by positional name
+npx @sentry/dotagents add getsentry/skills find-bugs code-review    # Add multiple skills at once
+npx @sentry/dotagents add getsentry/skills --name find-bugs         # Add by --name flag
+npx @sentry/dotagents add getsentry/skills --skill find-bugs        # --skill is an alias for --name
+npx @sentry/dotagents add getsentry/skills --all                    # Add all as wildcard
+npx @sentry/dotagents add getsentry/warden@v1.0.0                   # Pinned ref (inline)
+npx @sentry/dotagents add getsentry/skills --ref v2.0.0             # Pinned ref (flag)
+npx @sentry/dotagents add git:https://git.corp.dev/team/skills      # Non-GitHub git URL
+npx @sentry/dotagents add path:./my-skills/custom                   # Local path
 ```
 
 | Flag | Description |
@@ -104,7 +104,7 @@ When adding multiple skills, already-existing entries are skipped with a warning
 Remove a skill dependency.
 
 ```bash
-dotagents remove find-bugs
+npx @sentry/dotagents remove find-bugs
 ```
 
 Removes from `agents.toml`, deletes `.agents/skills/<name>/`, updates lockfile, and regenerates `.gitignore`.
@@ -116,7 +116,7 @@ For skills sourced from a wildcard entry (`name = "*"`), interactively prompts w
 Reconcile project state without network access: adopt orphans, repair symlinks and configs.
 
 ```bash
-dotagents sync
+npx @sentry/dotagents sync
 ```
 
 **Actions performed:**
@@ -134,8 +134,8 @@ Reports issues as warnings (missing MCP/hook configs) or errors (missing skills)
 Check project health and fix issues.
 
 ```bash
-dotagents doctor
-dotagents doctor --fix
+npx @sentry/dotagents doctor
+npx @sentry/dotagents doctor --fix
 ```
 
 | Flag | Description |
@@ -151,8 +151,8 @@ Useful when migrating to a new version of dotagents.
 Show installed skills and their status.
 
 ```bash
-dotagents list
-dotagents list --json
+npx @sentry/dotagents list
+npx @sentry/dotagents list --json
 ```
 
 | Flag | Description |
@@ -175,8 +175,8 @@ Manage MCP (Model Context Protocol) server declarations in `agents.toml`.
 Add an MCP server declaration.
 
 ```bash
-dotagents mcp add github --command npx --args -y --args @modelcontextprotocol/server-github --env GITHUB_TOKEN
-dotagents mcp add remote-api --url https://mcp.example.com/sse --header "Authorization:Bearer token"
+npx @sentry/dotagents mcp add github --command npx --args -y --args @modelcontextprotocol/server-github --env GITHUB_TOKEN
+npx @sentry/dotagents mcp add remote-api --url https://mcp.example.com/sse --header "Authorization:Bearer token"
 ```
 
 | Flag | Description |
@@ -194,7 +194,7 @@ Either `--command` or `--url` is required (mutually exclusive).
 Remove an MCP server declaration.
 
 ```bash
-dotagents mcp remove github
+npx @sentry/dotagents mcp remove github
 ```
 
 #### `mcp list`
@@ -202,8 +202,8 @@ dotagents mcp remove github
 Show declared MCP servers.
 
 ```bash
-dotagents mcp list
-dotagents mcp list --json
+npx @sentry/dotagents mcp list
+npx @sentry/dotagents mcp list --json
 ```
 
 | Flag | Description |

--- a/skills/dotagents/references/configuration.md
+++ b/skills/dotagents/references/configuration.md
@@ -49,7 +49,7 @@ source = "getsentry/skills"
 exclude = ["deprecated-skill"]
 ```
 
-During `install`, dotagents discovers all skills in the source and installs each one (except those in `exclude`). Each skill gets its own lockfile entry. Use `dotagents add <source> --all` to create a wildcard entry from the CLI.
+During `install`, dotagents discovers all skills in the source and installs each one (except those in `exclude`). Each skill gets its own lockfile entry. Use `npx @sentry/dotagents add <source> --all` to create a wildcard entry from the CLI.
 
 ## Trust
 
@@ -152,8 +152,8 @@ Operates on the current project. Requires `agents.toml` at the project root.
 Operates on `~/.agents/` for skills shared across all projects. Override with `DOTAGENTS_HOME`.
 
 ```bash
-dotagents --user init
-dotagents --user add getsentry/skills --all
+npx @sentry/dotagents --user init
+npx @sentry/dotagents --user add getsentry/skills --all
 ```
 
 User-scope symlinks go to `~/.claude/skills/` and `~/.cursor/skills/`.
@@ -168,24 +168,24 @@ Two files are added to the root `.gitignore` during `init`:
 - `agents.lock` — tracks managed skills
 - `.agents/.gitignore` — excludes managed skill directories
 
-If these entries are missing, `install` and `sync` warn. Run `dotagents doctor --fix` to add them.
+If these entries are missing, `install` and `sync` warn. Run `npx @sentry/dotagents doctor --fix` to add them.
 
 ## Caching
 
 - Cache location: `~/.local/dotagents/` (override with `DOTAGENTS_STATE_DIR`)
 - Shallow clone per repo, refreshed after 24-hour TTL
-- Use `dotagents install --force` to bypass cache
+- Use `npx @sentry/dotagents install --force` to bypass cache
 
 ## Troubleshooting
 
 **Skills not installing:**
-- Check `agents.toml` syntax with `dotagents list`
+- Check `agents.toml` syntax with `npx @sentry/dotagents list`
 - Verify source is accessible (`git clone` the URL manually)
 - Check trust config if using restricted mode
-- Run `dotagents doctor` to check project health
+- Run `npx @sentry/dotagents doctor` to check project health
 
 **Symlinks broken:**
-- Run `dotagents sync` to repair
+- Run `npx @sentry/dotagents sync` to repair
 
 **Configuration issues:**
-- Run `dotagents doctor --fix` to auto-repair gitignore and legacy config fields
+- Run `npx @sentry/dotagents doctor --fix` to auto-repair gitignore and legacy config fields

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -147,7 +147,7 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         if (!found) {
           throw new AddError(
             `Skill "${name}" not found in ${sourceForStorage}. ` +
-              `Use 'dotagents add ${sourceForStorage}' without --name to see available skills.`,
+              `Use 'npx @sentry/dotagents add ${sourceForStorage}' without --name to see available skills.`,
           );
         }
       }
@@ -209,7 +209,7 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         if (!found) {
           throw new AddError(
             `Skill "${name}" not found in ${sourceForStorage}. ` +
-              `Use 'dotagents add ${sourceForStorage}' without --name to see available skills.`,
+              `Use 'npx @sentry/dotagents add ${sourceForStorage}' without --name to see available skills.`,
           );
         }
       }
@@ -372,7 +372,7 @@ export default async function add(
   if (!specifier) {
     console.error(
       chalk.red(
-        "Usage: dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]",
+        "Usage: npx @sentry/dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]",
       ),
     );
     process.exitCode = 1;

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -41,7 +41,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
     checks.push({
       name: "agents.toml",
       status: "error",
-      message: "agents.toml not found. Run 'dotagents init' to create one.",
+      message: "agents.toml not found. Run 'npx @sentry/dotagents init' to create one.",
     });
     return { checks, fixed };
   }
@@ -152,7 +152,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
       checks.push({
         name: ".agents/.gitignore",
         status: "warn",
-        message: ".agents/.gitignore is missing. Run 'dotagents install' or 'dotagents sync' to regenerate.",
+        message: ".agents/.gitignore is missing. Run 'npx @sentry/dotagents install' or 'npx @sentry/dotagents sync' to regenerate.",
         fix: async () => {
           await writeAgentsGitignore(scope.agentsDir, managedNames);
         },
@@ -167,7 +167,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
     checks.push({
       name: "skills directory",
       status: "warn",
-      message: ".agents/skills/ directory is missing. Run 'dotagents install' to create it.",
+      message: ".agents/skills/ directory is missing. Run 'npx @sentry/dotagents install' to create it.",
     });
   }
 
@@ -178,7 +178,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
     checks.push({
       name: "installed skills",
       status: "error",
-      message: `${missingSkills.length} skill(s) not installed: ${missingSkills.join(", ")}. Run 'dotagents install'.`,
+      message: `${missingSkills.length} skill(s) not installed: ${missingSkills.join(", ")}. Run 'npx @sentry/dotagents install'.`,
     });
   } else if (declaredNames.length > 0) {
     checks.push({ name: "installed skills", status: "ok", message: `All ${declaredNames.length} declared skill(s) installed.` });
@@ -208,7 +208,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
         checks.push({
           name: "symlinks",
           status: "warn",
-          message: `${issues.length} symlink(s) broken or missing. Run 'dotagents sync' to repair.`,
+          message: `${issues.length} symlink(s) broken or missing. Run 'npx @sentry/dotagents sync' to repair.`,
         });
       } else {
         checks.push({ name: "symlinks", status: "ok", message: "All symlinks intact." });
@@ -317,7 +317,7 @@ export default async function doctor(args: string[], flags?: { user?: boolean })
   } else if (hasIssues && !values["fix"]) {
     const fixable = result.checks.filter((c) => c.status !== "ok" && c.fix).length;
     if (fixable > 0) {
-      console.log(chalk.yellow(`\nRun 'dotagents doctor --fix' to auto-fix ${fixable} issue(s).`));
+      console.log(chalk.yellow(`\nRun 'npx @sentry/dotagents doctor --fix' to auto-fix ${fixable} issue(s).`));
     }
   } else if (!hasIssues) {
     console.log(chalk.green("\nAll checks passed."));

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -109,7 +109,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
     } catch (err) {
       // Re-throw trust errors — these are policy violations, not transient failures
       if (err instanceof TrustError) {throw err;}
-      console.log(chalk.yellow("Could not install skills. Run `dotagents install` to install them later."));
+      console.log(chalk.yellow("Could not install skills. Run `npx @sentry/dotagents install` to install them later."));
     }
   }
 
@@ -142,9 +142,9 @@ function printSummary(
     }
   }
 
-  const cmd = scope.scope === "user" ? "dotagents --user" : "dotagents";
+  const cmd = scope.scope === "user" ? "npx @sentry/dotagents --user" : "npx @sentry/dotagents";
   console.log(
-    `\n${chalk.bold("Next steps:")}\n  1. Add more skills: ${cmd} add @anthropics/pdf-processing\n  2. Install: ${cmd} install`,
+    `\n${chalk.bold("Next steps:")}\n  1. Add skills: ${cmd} add getsentry/skills find-bugs\n  2. Install: ${cmd} install`,
   );
 }
 
@@ -263,7 +263,7 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
     if (gitDir) {
       const setupHook = prompt(
         await clack.confirm({
-          message: "Set up a git hook to auto-run `dotagents install` on pull?",
+          message: "Set up a git hook to auto-run `npx @sentry/dotagents install` on pull?",
           initialValue: false,
         }),
       );
@@ -283,7 +283,7 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
     }
   }
 
-  clack.outro("You're all set! Run `dotagents add` to add more skills.");
+  clack.outro("You're all set! Run `npx @sentry/dotagents add` to add more skills.");
 }
 
 export default async function init(args: string[], flags?: { user?: boolean }): Promise<void> {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -260,7 +260,7 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
     // Health check: warn if agents.lock and .agents/.gitignore are not in root .gitignore
     const missing = await checkRootGitignoreEntries(scope.root);
     if (missing.length > 0) {
-      console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'dotagents doctor --fix' to fix.`));
+      console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'npx @sentry/dotagents doctor --fix' to fix.`));
     }
   }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -240,10 +240,10 @@ async function mcpAdd(args: string[], scope: ScopeRoot): Promise<void> {
   const name = positionals[0];
   if (!name) {
     console.error(
-      chalk.red("Usage: dotagents mcp add <name> --command <cmd> [--env <VAR>...]"),
+      chalk.red("Usage: npx @sentry/dotagents mcp add <name> --command <cmd> [--env <VAR>...]"),
     );
     console.error(
-      chalk.red("       dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"),
+      chalk.red("       npx @sentry/dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"),
     );
     process.exitCode = 1;
     return;
@@ -278,7 +278,7 @@ async function mcpRemove(args: string[], scope: ScopeRoot): Promise<void> {
 
   const name = positionals[0];
   if (!name) {
-    console.error(chalk.red("Usage: dotagents mcp remove <name>"));
+    console.error(chalk.red("Usage: npx @sentry/dotagents mcp remove <name>"));
     process.exitCode = 1;
     return;
   }
@@ -317,7 +317,7 @@ async function mcpList(args: string[], scope: ScopeRoot): Promise<void> {
 }
 
 function printMcpUsage(): void {
-  console.error(`Usage: dotagents mcp <subcommand>
+  console.error(`Usage: npx @sentry/dotagents mcp <subcommand>
 
 Subcommands:
   add      Add an MCP server declaration

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -107,7 +107,7 @@ export default async function remove(args: string[], flags?: { user?: boolean })
 
   const skillName = positionals[0];
   if (!skillName) {
-    console.error(chalk.red("Usage: dotagents remove <name>"));
+    console.error(chalk.red("Usage: npx @sentry/dotagents remove <name>"));
     process.exitCode = 1;
     return;
   }

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -113,7 +113,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
     // Health check: warn if agents.lock and .agents/.gitignore are not in root .gitignore
     const missing = await checkRootGitignoreEntries(scope.root);
     if (missing.length > 0) {
-      console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'dotagents doctor --fix' to fix.`));
+      console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'npx @sentry/dotagents doctor --fix' to fix.`));
     }
   }
 
@@ -123,7 +123,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
       issues.push({
         type: "missing",
         name,
-        message: `"${name}" is in agents.toml but not installed. Run 'dotagents install'.`,
+        message: `"${name}" is in agents.toml but not installed. Run 'npx @sentry/dotagents install'.`,
       });
     }
   }

--- a/src/cli/commands/trust.ts
+++ b/src/cli/commands/trust.ts
@@ -96,7 +96,7 @@ async function trustAdd(args: string[], scope: ScopeRoot): Promise<void> {
 
   const source = positionals[0];
   if (!source) {
-    console.error(chalk.red("Usage: dotagents trust add <source>"));
+    console.error(chalk.red("Usage: npx @sentry/dotagents trust add <source>"));
     console.error(chalk.red("  <source> can be: org, owner/repo, or domain.name"));
     process.exitCode = 1;
     return;
@@ -116,7 +116,7 @@ async function trustRemove(args: string[], scope: ScopeRoot): Promise<void> {
 
   const source = positionals[0];
   if (!source) {
-    console.error(chalk.red("Usage: dotagents trust remove <source>"));
+    console.error(chalk.red("Usage: npx @sentry/dotagents trust remove <source>"));
     process.exitCode = 1;
     return;
   }
@@ -161,7 +161,7 @@ async function trustList(args: string[], scope: ScopeRoot): Promise<void> {
 }
 
 function printTrustUsage(): void {
-  console.error(`Usage: dotagents trust <subcommand>
+  console.error(`Usage: npx @sentry/dotagents trust <subcommand>
 
 Subcommands:
   add      Add a trusted source (org, owner/repo, or domain)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,7 +24,7 @@ function printUsage(): void {
   // eslint-disable-next-line no-console
   console.log(`dotagents - package manager for .agents directories
 
-Usage: dotagents [--user] <command> [options]
+Usage: npx @sentry/dotagents [--user] <command> [options]
 
 Commands:
   init        Initialize agents.toml and .agents/skills/

--- a/src/cli/update-notifier.test.ts
+++ b/src/cli/update-notifier.test.ts
@@ -33,7 +33,7 @@ describe("formatUpdateMessage", () => {
     const msg = formatUpdateMessage("0.7.0", "0.8.0");
     expect(msg).toContain("0.7.0");
     expect(msg).toContain("0.8.0");
-    expect(msg).toContain("npm install -g @sentry/dotagents");
+    expect(msg).toContain("npx @sentry/dotagents@latest");
   });
 
   it("contains the arrow separator", () => {

--- a/src/cli/update-notifier.ts
+++ b/src/cli/update-notifier.ts
@@ -64,7 +64,7 @@ export function formatUpdateMessage(
   currentVersion: string,
   latestVersion: string,
 ): string {
-  return `Update available: ${currentVersion} \u2192 ${latestVersion}\nRun \`npm install -g @sentry/dotagents\` to upgrade`;
+  return `Update available: ${currentVersion} \u2192 ${latestVersion}\nRun \`npx @sentry/dotagents@latest\` to use the latest version`;
 }
 
 /**

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -121,6 +121,6 @@ export function resolveDefaultScope(projectRoot: string): ScopeRoot {
   }
 
   throw new ScopeError(
-    "No agents.toml found. Run 'dotagents init' to set up this project, or use --user for user scope.",
+    "No agents.toml found. Run 'npx @sentry/dotagents init' to set up this project, or use --user for user scope.",
   );
 }

--- a/src/sources/git.ts
+++ b/src/sources/git.ts
@@ -51,7 +51,7 @@ export async function clone(
         throw new GitError(
           `Failed to clone ${url}: authentication required.\n` +
             `Hint: for private repos, use the SSH URL instead:\n` +
-            `  dotagents add ${sshUrl}`,
+            `  npx @sentry/dotagents add ${sshUrl}`,
         );
       }
       throw new GitError(`Failed to clone ${url}: ${stderr}`);

--- a/src/trust/validator.ts
+++ b/src/trust/validator.ts
@@ -81,8 +81,8 @@ export function validateTrustedSource(
     throw new TrustError(
       `Source "${source}" is not trusted. ` +
         `Allowed sources: ${formatAllowed(trust)}.\n` +
-        `Run: dotagents trust add ${parsed.owner!} ` +
-        `(or \`dotagents trust add ${parsed.owner!}/${parsed.repo!}\` for just this repo)`,
+        `Run: npx @sentry/dotagents trust add ${parsed.owner!} ` +
+        `(or \`npx @sentry/dotagents trust add ${parsed.owner!}/${parsed.repo!}\` for just this repo)`,
     );
   }
 
@@ -90,7 +90,7 @@ export function validateTrustedSource(
     const domain = extractDomain(parsed.url!)?.toLowerCase();
     if (domain && trust.git_domains.some((d) => d.toLowerCase() === domain)) {return;}
 
-    const hint = domain ? `\nRun: dotagents trust add ${domain}` : "";
+    const hint = domain ? `\nRun: npx @sentry/dotagents trust add ${domain}` : "";
     throw new TrustError(
       `Source "${source}" is not trusted. Allowed sources: ${formatAllowed(trust)}.${hint}`,
     );


### PR DESCRIPTION
All user-facing error messages, help text, and documentation now
consistently recommend `npx @sentry/dotagents` instead of bare `dotagents`.

Several places in the codebase recommended running `dotagents <command>`
directly, which doesn't work for npx users (the primary install path).
This audits every user-facing string across 18 files and standardizes on
`npx @sentry/dotagents`.

Also fixes:
- Init "Next steps" example used a nonexistent `@anthropics/pdf-processing` — now uses `getsentry/skills find-bugs`
- Update notifier recommended `npm install -g @sentry/dotagents` — now recommends `npx @sentry/dotagents@latest`


Agent transcript: https://claudescope.sentry.dev/share/SBhSrTYMPVs_yKXDI0NQba_NiROdsSjpw1LXeTGvceQ