### PR TITLE
feat(docs): Add content negotiation for llms.txt

### DIFF
--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const config = {
+  matcher: "/",
+};
+
+export function middleware(request: NextRequest) {
+  if (request.method !== "GET") {
+    return NextResponse.next();
+  }
+
+  const accept = request.headers.get("accept") || "";
+  const types = accept.split(",").map((t) => t.trim().split(";")[0].trim());
+  const mdIndex = types.findIndex(
+    (t) => t === "text/markdown" || t === "text/x-markdown",
+  );
+  const htmlIndex = types.findIndex((t) => t === "text/html");
+
+  // Prefer markdown if it appears before text/html (or html is absent)
+  if (mdIndex !== -1 && (htmlIndex === -1 || mdIndex < htmlIndex)) {
+    return NextResponse.rewrite(new URL("/llms.txt", request.url));
+  }
+
+  return NextResponse.next();
+}

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,12 @@
 {
   "buildCommand": "pnpm build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "headers": [
+    {
+      "source": "/llms.txt",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Add Next.js middleware to the docs site that enables content negotiation
on the root URL. When a client requests `/` with `Accept: text/markdown`
(ranked higher than `text/html`), the middleware rewrites the request to
serve `/llms.txt` instead. This lets AI agents and LLM-powered tools
discover the machine-readable docs automatically via the site root.

Also adds a `Content-Type: text/markdown; charset=utf-8` response header
for `/llms.txt` in `vercel.json` so it's served with the correct MIME type.


Agent transcript: https://claudescope.sentry.dev/share/-am4h51jlB4kFux9p_-TuMwhPSvNxV7xPiMBnBoWI6U