### PR TITLE
fix(cache): Refresh unpinned repos after ref checkouts

### DIFF
--- a/src/sources/cache.test.ts
+++ b/src/sources/cache.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureCached } from "./cache.js";
+import { exec } from "../utils/exec.js";
+
+describe("ensureCached", () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let remoteDir: string;
+  let repoDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dotagents-cache-"));
+    stateDir = join(tmpDir, "state");
+    remoteDir = join(tmpDir, "remote.git");
+    repoDir = join(tmpDir, "repo");
+
+    process.env["DOTAGENTS_STATE_DIR"] = stateDir;
+
+    await exec("git", ["init", "--bare", "--initial-branch=main", remoteDir]);
+    await exec("git", ["clone", remoteDir, repoDir]);
+    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+  });
+
+  afterEach(async () => {
+    delete process.env["DOTAGENTS_STATE_DIR"];
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reuses a fresh unpinned cache when HEAD still matches the recorded default commit", async () => {
+    await writeFile(join(repoDir, "README.md"), "first\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+
+    const first = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+    });
+
+    const second = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+    });
+
+    expect(second.commit).toBe(first.commit);
+  });
+
+  it("refreshes an unpinned cache after a pinned ref fetch updated FETCH_HEAD", async () => {
+    await writeFile(join(repoDir, "README.md"), "first\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
+    const { stdout: initialStdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const initialCommit = initialStdout.trim();
+    await exec("git", ["branch", "stable", initialCommit], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main", "stable"], { cwd: repoDir });
+
+    const first = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+    });
+
+    await writeFile(join(repoDir, "README.md"), "second\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "second"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main", "stable"], { cwd: repoDir });
+    const { stdout: latestStdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const latestCommit = latestStdout.trim();
+
+    const pinned = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ref: "stable",
+      ttlMs: 60_000,
+    });
+    expect(pinned.commit).toBe(initialCommit);
+
+    const unpinned = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+    });
+
+    expect(first.commit).toBe(initialCommit);
+    expect(unpinned.commit).toBe(latestCommit);
+  });
+
+  it("refreshes an unpinned cache after minimum_release_age checked out an older commit", async () => {
+    await writeFile(join(repoDir, "README.md"), "old\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "old commit", "--date", "2020-01-01T00:00:00"], {
+      cwd: repoDir,
+      env: { ...process.env, GIT_COMMITTER_DATE: "2020-01-01T00:00:00" },
+    });
+    const { stdout: oldStdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const oldCommit = oldStdout.trim();
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+
+    await writeFile(join(repoDir, "README.md"), "new\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "new commit"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+    const { stdout: latestStdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const latestCommit = latestStdout.trim();
+
+    const ageGated = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+      minimumReleaseAge: 1,
+    });
+    expect(ageGated.commit).toBe(oldCommit);
+
+    const unpinned = await ensureCached({
+      url: remoteDir,
+      cacheKey: "test/repo",
+      ttlMs: 60_000,
+    });
+    expect(unpinned.commit).toBe(latestCommit);
+  });
+});

--- a/src/sources/cache.ts
+++ b/src/sources/cache.ts
@@ -1,10 +1,11 @@
 import { join } from "node:path";
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { clone, fetchAndReset, fetchRef, headCommit, headCommitDate, findCommitOlderThan, checkout, isGitRepo } from "./git.js";
 
 const DEFAULT_STATE_DIR = join(homedir(), ".local", "dotagents");
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_HEAD_MARKER = join(".git", "dotagents-default-head");
 
 export class CacheError extends Error {
   constructor(message: string) {
@@ -47,14 +48,19 @@ export async function ensureCached(opts: {
     if (needsRefresh) {
       if (opts.ref) {
         await fetchRef(repoDir, opts.ref);
+        await invalidateDefaultHead(repoDir);
       } else {
         await fetchAndReset(repoDir);
+        await recordDefaultHead(repoDir);
       }
     }
   } else {
     // Not cached yet — clone
     await mkdir(join(stateDir, opts.cacheKey, ".."), { recursive: true });
     await clone(opts.url, repoDir, opts.ref);
+    if (!opts.ref) {
+      await recordDefaultHead(repoDir);
+    }
   }
 
   // Age gate: reject or resolve to an older commit when HEAD is too new
@@ -74,6 +80,7 @@ export async function ensureCached(opts: {
         );
       }
       await checkout(repoDir, older);
+      await invalidateDefaultHead(repoDir);
     }
   }
 
@@ -87,11 +94,30 @@ function minutesOld(date: Date): number {
 
 async function isStale(repoDir: string, ttlMs: number): Promise<boolean> {
   try {
-    const gitDir = join(repoDir, ".git", "FETCH_HEAD");
-    const s = await stat(gitDir);
-    return Date.now() - s.mtimeMs > ttlMs;
+    const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
+    const [marker, recordedHead, currentHead] = await Promise.all([
+      stat(markerPath),
+      readFile(markerPath, "utf-8"),
+      headCommit(repoDir),
+    ]);
+
+    if (Date.now() - marker.mtimeMs > ttlMs) {
+      return true;
+    }
+
+    return recordedHead.trim() !== currentHead;
   } catch {
-    // No FETCH_HEAD yet — consider stale
+    // Missing marker or unreadable state — consider stale
     return true;
   }
+}
+
+async function recordDefaultHead(repoDir: string): Promise<void> {
+  const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
+  await writeFile(markerPath, await headCommit(repoDir), "utf-8");
+}
+
+async function invalidateDefaultHead(repoDir: string): Promise<void> {
+  const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
+  await rm(markerPath, { force: true });
 }


### PR DESCRIPTION
Refresh git cache freshness tracking so unpinned installs recover after the cache has been moved off the default branch.

We were using `.git/FETCH_HEAD` mtime as the freshness signal for cached repos. That breaks when a pinned ref fetch or a `minimum_release_age` checkout updates the cache without leaving it at the default branch head. In that state, later unpinned `add` and `install` calls can treat the cache as fresh and miss newer upstream skills.

This switches the cache to record the last known default-branch commit for unpinned refreshes and invalidates that marker whenever the cache is moved to a pinned or age-gated commit. I also added regression coverage for normal unpinned reuse, recovery after pinned ref fetches, and recovery after age-gated checkouts.