### PR TITLE
fix(git): force cached repo fetches

### DIFF
--- a/src/sources/git.test.ts
+++ b/src/sources/git.test.ts
@@ -5,7 +5,7 @@ vi.mock("../utils/exec.js", () => ({
   ExecError: Error,
 }));
 
-import { clone, headCommitDate, findCommitOlderThan } from "./git.js";
+import { clone, fetchAndReset, fetchRef, headCommitDate, findCommitOlderThan } from "./git.js";
 import { exec } from "../utils/exec.js";
 
 const mockExec = vi.mocked(exec);
@@ -59,6 +59,7 @@ describe("clone", () => {
     // Second call: fetch the specific SHA
     expect(mockExec).toHaveBeenNthCalledWith(2, "git", [
       "fetch",
+      "--force",
       "--depth=1",
       "--",
       "origin",
@@ -146,6 +147,44 @@ describe("clone", () => {
   });
 });
 
+describe("fetchAndReset", () => {
+  it("force-fetches origin before resetting to FETCH_HEAD", async () => {
+    await fetchAndReset("/tmp/repo");
+
+    expect(mockExec).toHaveBeenNthCalledWith(1, "git", [
+      "fetch",
+      "--force",
+      "--depth=1",
+      "--",
+      "origin",
+    ], { cwd: "/tmp/repo" });
+    expect(mockExec).toHaveBeenNthCalledWith(2, "git", [
+      "reset",
+      "--hard",
+      "FETCH_HEAD",
+    ], { cwd: "/tmp/repo" });
+  });
+});
+
+describe("fetchRef", () => {
+  it("force-fetches the requested ref before checkout", async () => {
+    await fetchRef("/tmp/repo", "v0");
+
+    expect(mockExec).toHaveBeenNthCalledWith(1, "git", [
+      "fetch",
+      "--force",
+      "--depth=1",
+      "--",
+      "origin",
+      "v0",
+    ], { cwd: "/tmp/repo" });
+    expect(mockExec).toHaveBeenNthCalledWith(2, "git", [
+      "checkout",
+      "FETCH_HEAD",
+    ], { cwd: "/tmp/repo" });
+  });
+});
+
 describe("headCommitDate", () => {
   it("returns the committer date of HEAD", async () => {
     mockExec.mockResolvedValueOnce({ stdout: "2026-03-15T10:30:00+00:00\n", stderr: "" });
@@ -175,7 +214,7 @@ describe("findCommitOlderThan", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "git",
-      ["fetch", "--unshallow", "--", "origin"],
+      ["fetch", "--force", "--unshallow", "--", "origin"],
       { cwd: "/tmp/repo" },
     );
     expect(mockExec).toHaveBeenNthCalledWith(

--- a/src/sources/git.ts
+++ b/src/sources/git.ts
@@ -77,7 +77,7 @@ export async function clone(
  */
 export async function fetchAndReset(repoDir: string): Promise<void> {
   try {
-    await exec("git", ["fetch", "--depth=1", "--", "origin"], { cwd: repoDir });
+    await exec("git", ["fetch", "--force", "--depth=1", "--", "origin"], { cwd: repoDir });
     await exec("git", ["reset", "--hard", "FETCH_HEAD"], { cwd: repoDir });
   } catch (err) {
     if (err instanceof ExecError) {
@@ -92,7 +92,7 @@ export async function fetchAndReset(repoDir: string): Promise<void> {
  */
 export async function fetchRef(repoDir: string, ref: string): Promise<void> {
   try {
-    await exec("git", ["fetch", "--depth=1", "--", "origin", ref], {
+    await exec("git", ["fetch", "--force", "--depth=1", "--", "origin", ref], {
       cwd: repoDir,
     });
     await exec("git", ["checkout", "FETCH_HEAD"], { cwd: repoDir });
@@ -141,7 +141,7 @@ export async function findCommitOlderThan(
   // Unshallow to get full history — needed to find commits older than the cutoff.
   // Only called when HEAD is too new, so the extra fetch is acceptable.
   try {
-    await exec("git", ["fetch", "--unshallow", "--", "origin"], { cwd: repoDir });
+    await exec("git", ["fetch", "--force", "--unshallow", "--", "origin"], { cwd: repoDir });
   } catch (err) {
     if (!(err instanceof ExecError)) {throw err;}
     // --unshallow fails on a complete (non-shallow) repository — that's fine


### PR DESCRIPTION
Force cached git fetches when refreshing skill repositories.

Dotagents reuses cached clones under `~/.local/dotagents`, and a plain `git fetch` can fail when an upstream named ref like `v0` has been retagged since the cache was created. In that case install fails with `would clobber existing tag` even though the cache should just track the current remote state.

This updates the cache refresh paths to use `git fetch --force` for default branch refreshes, ref fetches, and the age-gate unshallow path. That keeps the cache aligned with the remote for mutable refs while leaving SHA-pinned installs unchanged.

The tests now assert the forced fetch arguments so this behavior stays covered.

`pnpm check` passes locally. `warden` could not run in this environment because the configured command points at a missing local build: `/Users/greg/code/warden/dist/cli/index.js`.