### PR TITLE
fix(cache): Remove 24h TTL from git source cache

### DIFF
--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -400,10 +400,7 @@ describe("runInstall", () => {
     await exec("git", ["rm", "-rf", "skills/review"], { cwd: repoDir });
     await exec("git", ["commit", "-m", "remove review"], { cwd: repoDir });
 
-    // Clear state dir so the git cache is busted
-    await rm(stateDir, { recursive: true });
-
-    // Re-install
+    // Re-install — should fetch latest without needing --force or cache bust
     const second = await runInstall({ scope });
     expect(second.installed).toContain("pdf");
     expect(second.installed).not.toContain("review");
@@ -445,7 +442,6 @@ describe("runInstall", () => {
     // Also remove "review" from upstream so it gets pruned
     await exec("git", ["rm", "-rf", "skills/review"], { cwd: repoDir });
     await exec("git", ["commit", "-m", "remove review"], { cwd: repoDir });
-    await rm(stateDir, { recursive: true });
 
     await writeFile(
       join(projectRoot, "agents.toml"),
@@ -552,6 +548,39 @@ describe("runInstall", () => {
 
     // Should not auto-create .gitignore (only init does that)
     expect(existsSync(join(projectRoot, ".gitignore"))).toBe(false);
+  });
+
+  it("picks up upstream skill changes without --force", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+
+    const scope = resolveScope("project", projectRoot);
+
+    // First install
+    const first = await runInstall({ scope });
+    expect(first.installed).toContain("pdf");
+
+    const original = await readFile(
+      join(projectRoot, ".agents", "skills", "pdf", "SKILL.md"),
+      "utf-8",
+    );
+
+    // Update the skill upstream
+    await writeFile(join(repoDir, "pdf", "SKILL.md"), `${SKILL_MD("pdf")}\nupdated content`);
+    await exec("git", ["add", "."], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "update pdf skill"], { cwd: repoDir });
+
+    // Re-install — should pick up the change without --force or cache bust
+    await runInstall({ scope });
+
+    const updated = await readFile(
+      join(projectRoot, ".agents", "skills", "pdf", "SKILL.md"),
+      "utf-8",
+    );
+    expect(updated).toContain("updated content");
+    expect(updated).not.toBe(original);
   });
 
   it("minimum_release_age resolves to an older commit when HEAD is too new", async () => {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -72,7 +72,7 @@ async function expandSkills(
     defaultRepositorySource: RepositorySource;
   },
   lockfile: Lockfile | null,
-  opts: { frozen?: boolean; force?: boolean; projectRoot: string; minimumReleaseAge?: number; minimumReleaseAgeExclude?: string[] },
+  opts: { frozen?: boolean; projectRoot: string; minimumReleaseAge?: number; minimumReleaseAgeExclude?: string[] },
 ): Promise<ExpandedSkill[]> {
   const regularDeps = config.skills.filter((d) => !isWildcardDep(d));
   const wildcardDeps = config.skills.filter(isWildcardDep);
@@ -110,7 +110,6 @@ async function expandSkills(
       try {
         named = await resolveWildcardSkills(wDep, {
           projectRoot: opts.projectRoot,
-          ...(opts.force ? { ttlMs: 0 } : {}),
           defaultRepositorySource: config.defaultRepositorySource,
           minimumReleaseAge: opts.minimumReleaseAge,
           minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
@@ -141,7 +140,7 @@ async function expandSkills(
 }
 
 export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
-  const { scope, frozen, force } = opts;
+  const { scope, frozen } = opts;
   const { configPath, lockPath, agentsDir, skillsDir } = scope;
 
   // 1. Read config
@@ -170,7 +169,7 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
         defaultRepositorySource: config.defaultRepositorySource,
       },
       lockfile,
-      { frozen, force, projectRoot: scope.root, minimumReleaseAge, minimumReleaseAgeExclude },
+      { frozen, projectRoot: scope.root, minimumReleaseAge, minimumReleaseAgeExclude },
     );
 
     if (frozen) {
@@ -197,7 +196,6 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
 
       const resolveOpts = {
         projectRoot: scope.root,
-        ...(force ? { ttlMs: 0 } : {}),
         defaultRepositorySource: config.defaultRepositorySource,
         minimumReleaseAge,
         minimumReleaseAgeExclude,

--- a/src/skills/resolver.ts
+++ b/src/skills/resolver.ts
@@ -309,7 +309,6 @@ export async function resolveSkill(
     url: cloneUrl,
     cacheKey,
     ref,
-    ttlMs: opts?.ttlMs,
     minimumReleaseAge: excluded ? undefined : opts?.minimumReleaseAge,
   });
 
@@ -434,7 +433,6 @@ export async function resolveWildcardSkills(
     url: cloneUrl,
     cacheKey,
     ref,
-    ttlMs: opts?.ttlMs,
     minimumReleaseAge: excluded ? undefined : opts?.minimumReleaseAge,
   });
 

--- a/src/sources/cache.test.ts
+++ b/src/sources/cache.test.ts
@@ -30,7 +30,7 @@ describe("ensureCached", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("reuses a fresh unpinned cache when HEAD still matches the recorded default commit", async () => {
+  it("picks up upstream changes on repeated calls", async () => {
     await writeFile(join(repoDir, "README.md"), "first\n");
     await exec("git", ["add", "README.md"], { cwd: repoDir });
     await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
@@ -39,19 +39,26 @@ describe("ensureCached", () => {
     const first = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
     });
+
+    // Push a new commit upstream
+    await writeFile(join(repoDir, "README.md"), "second\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "second"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+    const { stdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const latestCommit = stdout.trim();
 
     const second = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
     });
 
-    expect(second.commit).toBe(first.commit);
+    expect(second.commit).toBe(latestCommit);
+    expect(second.commit).not.toBe(first.commit);
   });
 
-  it("refreshes an unpinned cache after a pinned ref fetch updated FETCH_HEAD", async () => {
+  it("refreshes an unpinned cache after a pinned ref fetch", async () => {
     await writeFile(join(repoDir, "README.md"), "first\n");
     await exec("git", ["add", "README.md"], { cwd: repoDir });
     await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
@@ -63,7 +70,6 @@ describe("ensureCached", () => {
     const first = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
     });
 
     await writeFile(join(repoDir, "README.md"), "second\n");
@@ -77,14 +83,12 @@ describe("ensureCached", () => {
       url: remoteDir,
       cacheKey: "test/repo",
       ref: "stable",
-      ttlMs: 60_000,
     });
     expect(pinned.commit).toBe(initialCommit);
 
     const unpinned = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
     });
 
     expect(first.commit).toBe(initialCommit);
@@ -112,7 +116,6 @@ describe("ensureCached", () => {
     const ageGated = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
       minimumReleaseAge: 1,
     });
     expect(ageGated.commit).toBe(oldCommit);
@@ -120,7 +123,6 @@ describe("ensureCached", () => {
     const unpinned = await ensureCached({
       url: remoteDir,
       cacheKey: "test/repo",
-      ttlMs: 60_000,
     });
     expect(unpinned.commit).toBe(latestCommit);
   });

--- a/src/sources/cache.ts
+++ b/src/sources/cache.ts
@@ -1,11 +1,9 @@
 import { join } from "node:path";
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { clone, fetchAndReset, fetchRef, headCommit, headCommitDate, findCommitOlderThan, checkout, isGitRepo } from "./git.js";
 
 const DEFAULT_STATE_DIR = join(homedir(), ".local", "dotagents");
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const DEFAULT_HEAD_MARKER = join(".git", "dotagents-default-head");
 
 export class CacheError extends Error {
   constructor(message: string) {
@@ -24,43 +22,35 @@ export interface CacheResult {
 /**
  * Get or populate the global cache for a git source.
  *
+ * Always fetches the latest from the remote when a cached clone exists.
+ * A shallow `git fetch --depth=1` is essentially free when already at
+ * the latest commit, so there is no TTL — callers always get fresh state.
+ *
  * Cache layout:
- *   ~/.local/dotagents/<owner>/<repo>/          -- TTL-refreshed shallow clone
+ *   ~/.local/dotagents/<owner>/<repo>/          -- shallow clone
  */
 export async function ensureCached(opts: {
   url: string;
   /** Cache key, e.g. "anthropics/skills" or "git.corp.example.com/team/skills" */
   cacheKey: string;
   ref?: string;
-  ttlMs?: number;
   /** When set, resolve to the newest commit at least this many minutes old. */
   minimumReleaseAge?: number;
 }): Promise<CacheResult> {
   const stateDir = process.env["DOTAGENTS_STATE_DIR"] || DEFAULT_STATE_DIR;
-  const ttl = opts.ttlMs ?? DEFAULT_TTL_MS;
 
   const repoDir = join(stateDir, opts.cacheKey);
 
   if (isGitRepo(repoDir)) {
-    // Always fetch when: a specific ref is requested, age gating is active
-    // (checkout may have left HEAD at an old commit), or cache is stale.
-    const needsRefresh = opts.ref || opts.minimumReleaseAge || await isStale(repoDir, ttl);
-    if (needsRefresh) {
-      if (opts.ref) {
-        await fetchRef(repoDir, opts.ref);
-        await invalidateDefaultHead(repoDir);
-      } else {
-        await fetchAndReset(repoDir);
-        await recordDefaultHead(repoDir);
-      }
+    if (opts.ref) {
+      await fetchRef(repoDir, opts.ref);
+    } else {
+      await fetchAndReset(repoDir);
     }
   } else {
     // Not cached yet — clone
     await mkdir(join(stateDir, opts.cacheKey, ".."), { recursive: true });
     await clone(opts.url, repoDir, opts.ref);
-    if (!opts.ref) {
-      await recordDefaultHead(repoDir);
-    }
   }
 
   // Age gate: reject or resolve to an older commit when HEAD is too new
@@ -80,7 +70,6 @@ export async function ensureCached(opts: {
         );
       }
       await checkout(repoDir, older);
-      await invalidateDefaultHead(repoDir);
     }
   }
 
@@ -90,34 +79,4 @@ export async function ensureCached(opts: {
 
 function minutesOld(date: Date): number {
   return (Date.now() - date.getTime()) / (60 * 1000);
-}
-
-async function isStale(repoDir: string, ttlMs: number): Promise<boolean> {
-  try {
-    const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
-    const [marker, recordedHead, currentHead] = await Promise.all([
-      stat(markerPath),
-      readFile(markerPath, "utf-8"),
-      headCommit(repoDir),
-    ]);
-
-    if (Date.now() - marker.mtimeMs > ttlMs) {
-      return true;
-    }
-
-    return recordedHead.trim() !== currentHead;
-  } catch {
-    // Missing marker or unreadable state — consider stale
-    return true;
-  }
-}
-
-async function recordDefaultHead(repoDir: string): Promise<void> {
-  const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
-  await writeFile(markerPath, await headCommit(repoDir), "utf-8");
-}
-
-async function invalidateDefaultHead(repoDir: string): Promise<void> {
-  const markerPath = join(repoDir, DEFAULT_HEAD_MARKER);
-  await rm(markerPath, { force: true });
 }


### PR DESCRIPTION
Remove the 24h TTL mechanism from the git source cache (`ensureCached`). The cache now always fetches from the remote when a cached clone exists.

A shallow `git fetch --depth=1` is essentially free when already at the latest commit (~200ms), so the TTL was premature optimization that caused stale skills. Users had to manually bust the cache or use `--force` to pick up upstream changes within the 24h window.

This was reported by a user who updated `skill-writer` in `getsentry/skills` and had to delete `~/.local/dotagents/getsentry/skills/` to get the update locally. The issue affects all unpinned git sources (both wildcard and explicit), not just wildcards as the issue title suggests.

The well-known source TTL is preserved since those fetches download all files via HTTP and have meaningfully higher cost.

Fixes #91