### PR TITLE
Update post-merge hook installation command

### DIFF
--- a/docs/src/app/guide/page.tsx
+++ b/docs/src/app/guide/page.tsx
@@ -121,7 +121,7 @@ dotagents trust add git.corp.example.com`}</code>
         <pre>
           <code>{`#!/bin/sh
 # .git/hooks/post-merge
-npx @sentry/dotagents install || echo "dotagents install failed"
+npx --yes @sentry/dotagents install || echo "dotagents install failed"
 `}</code>
         </pre>
         <p>


### PR DESCRIPTION
Adds the `--yes` flag to bypass the `Need to install the following packages: @sentry/dotagents. OK to proceed? (y)` prompt which causes the post-merge hook to hang.