### PR TITLE
feat(lib): Expose discovery, parsing, and tool-name primitives

### DIFF
--- a/packages/dotagents-lib/package.json
+++ b/packages/dotagents-lib/package.json
@@ -26,5 +26,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/dotagents-lib/src/index.ts
+++ b/packages/dotagents-lib/src/index.ts
@@ -1,6 +1,10 @@
 // SKILL.md loading
 export { loadSkillMd, SkillLoadError } from "./skills/loader.js";
-export type { SkillMeta } from "./skills/loader.js";
+export type { SkillMeta, LoadSkillMdOptions } from "./skills/loader.js";
+
+// Tool name vocabulary (allowed-tools frontmatter)
+export { TOOL_NAMES, isToolName } from "./skills/tool-name.js";
+export type { ToolName } from "./skills/tool-name.js";
 
 // Skill discovery
 export { discoverSkill, discoverAllSkills } from "./skills/discovery.js";
@@ -19,8 +23,10 @@ export {
   isSourceExcluded,
   stripLeadingAt,
   ResolveError,
+  ParseSourceError,
   VALID_SKILL_NAME,
 } from "./skills/resolver.js";
+export type { ParseSourceErrorKind } from "./skills/resolver.js";
 export type {
   ResolvedSkill,
   ResolvedGitSkill,
@@ -68,6 +74,16 @@ export {
 } from "./trust/validator.js";
 export type { TrustPolicy } from "./trust/policy.js";
 export type { TrustErrorDetails } from "./trust/validator.js";
+
+// Git name safety
+export {
+  validateGitNameSafety,
+  GitNameSafetyError,
+} from "./sources/name-safety.js";
+export type {
+  GitNameSafetyField,
+  GitNameSafetyReason,
+} from "./sources/name-safety.js";
 
 // General-purpose utilities used by callers
 export { exec, ExecError } from "./utils/exec.js";

--- a/packages/dotagents-lib/src/skills/discovery.test.ts
+++ b/packages/dotagents-lib/src/skills/discovery.test.ts
@@ -410,3 +410,73 @@ describe("discoverAllSkills", () => {
     );
   });
 });
+
+const AGENT_MD = (name: string) => `---
+name: ${name}
+description: Agent ${name}
+---
+# ${name}
+`;
+
+describe("markerFile opt", () => {
+  let repoDir: string;
+
+  beforeEach(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), "dotagents-marker-"));
+  });
+
+  afterEach(async () => {
+    await rm(repoDir, { recursive: true });
+  });
+
+  it("default marker discovers SKILL.md but not AGENT.md", async () => {
+    await mkdir(join(repoDir, "skills", "skill-a"), { recursive: true });
+    await writeFile(join(repoDir, "skills", "skill-a", "SKILL.md"), SKILL_MD("skill-a"));
+    await mkdir(join(repoDir, "skills", "agent-a"), { recursive: true });
+    await writeFile(join(repoDir, "skills", "agent-a", "AGENT.md"), AGENT_MD("agent-a"));
+
+    const results = await discoverAllSkills(repoDir);
+    expect(results.map((r) => r.meta.name)).toEqual(["skill-a"]);
+  });
+
+  it("override marker discovers AGENT.md but not SKILL.md", async () => {
+    await mkdir(join(repoDir, "agents", "skill-a"), { recursive: true });
+    await writeFile(join(repoDir, "agents", "skill-a", "SKILL.md"), SKILL_MD("skill-a"));
+    await mkdir(join(repoDir, "agents", "agent-a"), { recursive: true });
+    await writeFile(join(repoDir, "agents", "agent-a", "AGENT.md"), AGENT_MD("agent-a"));
+
+    const results = await discoverAllSkills(repoDir, {
+      scanDirs: ["agents"],
+      markerFile: "AGENT.md",
+    });
+    expect(results.map((r) => r.meta.name)).toEqual(["agent-a"]);
+  });
+
+  it("discoverSkill respects override marker", async () => {
+    await mkdir(join(repoDir, "agents", "my-agent"), { recursive: true });
+    await writeFile(join(repoDir, "agents", "my-agent", "AGENT.md"), AGENT_MD("my-agent"));
+
+    const result = await discoverSkill(repoDir, "my-agent", {
+      scanDirs: ["agents"],
+      markerFile: "AGENT.md",
+    });
+    expect(result?.meta.name).toBe("my-agent");
+  });
+
+  it("marker opt does not affect marketplace discovery (which is SKILL-specific)", async () => {
+    // Marketplace structure with SKILL.md
+    await mkdir(join(repoDir, ".claude-plugin"), { recursive: true });
+    await writeFile(join(repoDir, ".claude-plugin", "marketplace.json"), "{}");
+    await mkdir(join(repoDir, "plugins", "p", "skills", "marketplace-skill"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(repoDir, "plugins", "p", "skills", "marketplace-skill", "SKILL.md"),
+      SKILL_MD("marketplace-skill"),
+    );
+
+    // Even with markerFile=AGENT.md, marketplace plugin scan still finds SKILL.md skills.
+    const results = await discoverAllSkills(repoDir, { markerFile: "AGENT.md" });
+    expect(results.map((r) => r.meta.name)).toContain("marketplace-skill");
+  });
+});

--- a/packages/dotagents-lib/src/skills/discovery.ts
+++ b/packages/dotagents-lib/src/skills/discovery.ts
@@ -22,23 +22,31 @@ export interface DiscoveredSkill {
 const ROOT_SCAN_DIR = ".";
 const DEFAULT_RECURSIVE_SCAN_DIRS: readonly string[] = ["skills"];
 
+const DEFAULT_MARKER_FILE = "SKILL.md";
+
 export interface DiscoveryOpts {
   /** Recursive scan dirs, in priority order. Defaults to `["skills"]`. */
   scanDirs?: readonly string[];
+  /**
+   * Filename that marks a skill directory. Default `"SKILL.md"`. Hosts that
+   * also discover agents (e.g. warden) pass `"AGENT.md"` here.
+   * Marketplace-format discovery is unaffected; it remains SKILL-specific.
+   */
+  markerFile?: string;
 }
 
 interface SkillDir {
-  /** Absolute path to the directory containing SKILL.md */
+  /** Absolute path to the directory containing the marker file */
   absPath: string;
   /** Relative path from the scan root to this directory */
   relPath: string;
 }
 
 /**
- * Recursively walk a directory tree finding all directories that contain SKILL.md.
- * Stops descending into a directory once SKILL.md is found (skill dirs are leaf nodes).
+ * Recursively walk a directory tree finding all directories that contain the marker file.
+ * Stops descending into a directory once the marker is found (skill dirs are leaf nodes).
  */
-async function walkSkillDirs(baseDir: string, relPrefix = ""): Promise<SkillDir[]> {
+async function walkSkillDirs(baseDir: string, markerFile: string, relPrefix = ""): Promise<SkillDir[]> {
   if (!existsSync(baseDir)) {return [];}
 
   let entries;
@@ -55,12 +63,12 @@ async function walkSkillDirs(baseDir: string, relPrefix = ""): Promise<SkillDir[
     const absPath = join(baseDir, entry.name);
     const relPath = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
 
-    if (existsSync(join(absPath, "SKILL.md"))) {
+    if (existsSync(join(absPath, markerFile))) {
       // This is a skill directory — collect it and don't descend further
       direct.push({ absPath, relPath });
     } else {
       // Not a skill — recurse into it to find nested skills
-      const children = await walkSkillDirs(absPath, relPath);
+      const children = await walkSkillDirs(absPath, markerFile, relPath);
       nested.push(...children);
     }
   }
@@ -85,11 +93,12 @@ async function listSkillDirs(
   repoDir: string,
   scanDir: string,
   recursive: boolean,
+  markerFile: string,
 ): Promise<SkillDir[]> {
   const absDir = join(repoDir, scanDir);
-  if (recursive) {return walkSkillDirs(absDir);}
+  if (recursive) {return walkSkillDirs(absDir, markerFile);}
 
-  // Flat scan: only direct children with SKILL.md
+  // Flat scan: only direct children with the marker file
   if (!existsSync(absDir)) {return [];}
   let entries;
   try {
@@ -101,13 +110,13 @@ async function listSkillDirs(
   for (const entry of entries) {
     if (!entry.isDirectory()) {continue;}
     const absPath = join(absDir, entry.name);
-    if (existsSync(join(absPath, "SKILL.md"))) {
+    if (existsSync(join(absPath, markerFile))) {
       results.push({ absPath, relPath: entry.name });
     }
   }
 
   // Check if the root directory itself is a skill (single-skill repo pattern)
-  if (scanDir === ROOT_SCAN_DIR && existsSync(join(absDir, "SKILL.md"))) {
+  if (scanDir === ROOT_SCAN_DIR && existsSync(join(absDir, markerFile))) {
     results.push({ absPath: absDir, relPath: "." });
   }
 
@@ -117,15 +126,16 @@ async function listSkillDirs(
 /**
  * Discover a specific skill by name within a repo directory.
  * Scans conventional directories in priority order, recursing into
- * subdirectories until SKILL.md is found.
+ * subdirectories until the marker file is found.
  */
 export async function discoverSkill(
   repoDir: string,
   skillName: string,
   opts?: DiscoveryOpts,
 ): Promise<DiscoveredSkill | null> {
+  const markerFile = opts?.markerFile ?? DEFAULT_MARKER_FILE;
   for (const { dir: scanDir, recursive } of buildScanDirs(opts)) {
-    const skillDirs = await listSkillDirs(repoDir, scanDir, recursive);
+    const skillDirs = await listSkillDirs(repoDir, scanDir, recursive, markerFile);
 
     // Within each scan dir: prefer dir-name match, fall back to frontmatter match
     let dirNameMatch: DiscoveredSkill | null = null;
@@ -136,7 +146,7 @@ export async function discoverSkill(
       const fullRelPath = scanDir === ROOT_SCAN_DIR ? relPath : `${scanDir}/${relPath}`;
 
       try {
-        const meta = await loadSkillMd(join(absPath, "SKILL.md"));
+        const meta = await loadSkillMd(join(absPath, markerFile));
         if (!dirNameMatch && dirName === skillName) {
           dirNameMatch = { path: fullRelPath, meta };
         } else if (!frontmatterMatch && meta.name === skillName) {
@@ -152,7 +162,8 @@ export async function discoverSkill(
     if (frontmatterMatch) {return frontmatterMatch;}
   }
 
-  // Marketplace format
+  // Marketplace format hardcodes SKILL.md — it's a SKILL-specific distribution
+  // convention, not a generic catalog.
   const marketplaceSkill = await tryMarketplaceFormat(repoDir, skillName);
   if (marketplaceSkill) {return marketplaceSkill;}
 
@@ -167,14 +178,15 @@ export async function discoverAllSkills(
   repoDir: string,
   opts?: DiscoveryOpts,
 ): Promise<DiscoveredSkill[]> {
+  const markerFile = opts?.markerFile ?? DEFAULT_MARKER_FILE;
   const found = new Map<string, DiscoveredSkill>();
 
   for (const { dir: scanDir, recursive } of buildScanDirs(opts)) {
-    const skillDirs = await listSkillDirs(repoDir, scanDir, recursive);
+    const skillDirs = await listSkillDirs(repoDir, scanDir, recursive, markerFile);
 
     for (const { absPath, relPath } of skillDirs) {
       try {
-        const meta = await loadSkillMd(join(absPath, "SKILL.md"));
+        const meta = await loadSkillMd(join(absPath, markerFile));
         // First match wins (higher priority scan dirs are checked first)
         if (found.has(meta.name)) {continue;}
         const fullRelPath = scanDir === ROOT_SCAN_DIR ? relPath : `${scanDir}/${relPath}`;
@@ -185,7 +197,7 @@ export async function discoverAllSkills(
     }
   }
 
-  // Marketplace format: plugins/*/skills/*/SKILL.md
+  // Marketplace format hardcodes SKILL.md (see discoverSkill).
   const marketplaceSkills = await scanMarketplaceFormat(repoDir);
   for (const skill of marketplaceSkills) {
     if (!found.has(skill.meta.name)) {

--- a/packages/dotagents-lib/src/skills/loader.test.ts
+++ b/packages/dotagents-lib/src/skills/loader.test.ts
@@ -93,4 +93,130 @@ name: my-skill
 
     await expect(loadSkillMd(skillMd)).rejects.toThrow(SkillLoadError);
   });
+
+  it("folds multi-line plain scalars with single spaces", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: composition-patterns
+description:
+  React composition patterns that scale.
+  Use when refactoring components with boolean prop proliferation.
+---
+Content.
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.description).toBe(
+      "React composition patterns that scale. Use when refactoring components with boolean prop proliferation.",
+    );
+  });
+
+  it("parses nested object frontmatter values", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: with-metadata
+description: Has nested metadata
+metadata:
+  author: vercel
+  version: '1.0.0'
+---
+Content.
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta["metadata"]).toEqual({ author: "vercel", version: "1.0.0" });
+  });
+
+  it("parses array frontmatter values", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: with-tags
+description: Has tags
+tags:
+  - frontend
+  - react
+---
+Content.
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta["tags"]).toEqual(["frontend", "react"]);
+  });
+
+  it("parses allowed-tools into ToolName array", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: tool-skill
+description: Uses allowed-tools
+allowed-tools: Read Grep Glob
+---
+Content.
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  });
+
+  it("warns and drops unknown allowed-tools tokens", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: tool-skill
+description: Mixed tools
+allowed-tools: Read Magic Grep
+---
+Content.
+`,
+    );
+
+    const warnings: string[] = [];
+    const meta = await loadSkillMd(skillMd, {
+      onWarning: (msg) => warnings.push(msg),
+    });
+
+    expect(meta.allowedTools).toEqual(["Read", "Grep"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Magic");
+  });
+
+  it("leaves allowedTools undefined when field is absent", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: no-tools
+description: No allowed-tools field
+---
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toBeUndefined();
+  });
+
+  it("throws SkillLoadError when frontmatter is not a YAML object (e.g. plain string)", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+just-a-string
+---
+`,
+    );
+
+    await expect(loadSkillMd(skillMd)).rejects.toThrow(SkillLoadError);
+  });
 });

--- a/packages/dotagents-lib/src/skills/loader.test.ts
+++ b/packages/dotagents-lib/src/skills/loader.test.ts
@@ -207,6 +207,84 @@ description: No allowed-tools field
     expect(meta.allowedTools).toBeUndefined();
   });
 
+  it("returns empty array (not undefined) when every token is unrecognized", async () => {
+    // A skill that DECLARES allowed-tools but uses unknown names is
+    // semantically distinct from a skill that omits the field entirely.
+    // Authorization gates that treat undefined as "unrestricted" must be
+    // able to see the empty-array signal.
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: future-tool-skill
+description: Uses tools we don't know about yet
+allowed-tools: FutureTool AnotherUnknownTool
+---
+`,
+    );
+
+    const warnings: string[] = [];
+    const meta = await loadSkillMd(skillMd, { onWarning: (m) => warnings.push(m) });
+    expect(meta.allowedTools).toEqual([]);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("parses YAML array form of allowed-tools", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: array-tools
+description: Uses YAML list syntax
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+---
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  });
+
+  it("parses YAML flow-array form of allowed-tools", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: flow-array-tools
+description: Uses YAML flow-array syntax
+allowed-tools: [Read, Grep, Glob]
+---
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+  });
+
+  it("warns and skips non-string entries in YAML array", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: bad-array
+description: Has non-string entry
+allowed-tools:
+  - Read
+  - 42
+  - Grep
+---
+`,
+    );
+
+    const warnings: string[] = [];
+    const meta = await loadSkillMd(skillMd, { onWarning: (m) => warnings.push(m) });
+    expect(meta.allowedTools).toEqual(["Read", "Grep"]);
+    expect(warnings.some((w) => w.includes("non-string"))).toBe(true);
+  });
+
   it("throws SkillLoadError when frontmatter is not a YAML object (e.g. plain string)", async () => {
     const skillMd = join(dir, "SKILL.md");
     await writeFile(

--- a/packages/dotagents-lib/src/skills/loader.test.ts
+++ b/packages/dotagents-lib/src/skills/loader.test.ts
@@ -264,6 +264,39 @@ allowed-tools: [Read, Grep, Glob]
     expect(meta.allowedTools).toEqual(["Read", "Grep", "Glob"]);
   });
 
+  it("preserves empty-array signal: allowed-tools: [] returns []", async () => {
+    // Explicit empty YAML array is "deny all" — must NOT collapse to undefined.
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: deny-all
+description: Explicit empty allow-list
+allowed-tools: []
+---
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toEqual([]);
+  });
+
+  it("treats empty/whitespace string allowed-tools as absent (likely a typo)", async () => {
+    const skillMd = join(dir, "SKILL.md");
+    await writeFile(
+      skillMd,
+      `---
+name: empty-string
+description: Field present but empty
+allowed-tools: "   "
+---
+`,
+    );
+
+    const meta = await loadSkillMd(skillMd);
+    expect(meta.allowedTools).toBeUndefined();
+  });
+
   it("warns and skips non-string entries in YAML array", async () => {
     const skillMd = join(dir, "SKILL.md");
     await writeFile(

--- a/packages/dotagents-lib/src/skills/loader.ts
+++ b/packages/dotagents-lib/src/skills/loader.ts
@@ -1,4 +1,6 @@
 import { readFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
+import { isToolName, type ToolName } from "./tool-name.js";
 
 export class SkillLoadError extends Error {
   constructor(message: string) {
@@ -10,7 +12,14 @@ export class SkillLoadError extends Error {
 export interface SkillMeta {
   name: string;
   description: string;
+  /** Parsed `allowed-tools` frontmatter, when present and well-formed. */
+  allowedTools?: ToolName[];
   [key: string]: unknown;
+}
+
+export interface LoadSkillMdOptions {
+  /** Called for parser warnings (unknown allowed-tools tokens, etc.) */
+  onWarning?: (message: string) => void;
 }
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
@@ -19,7 +28,10 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
  * Parse a SKILL.md file and extract YAML frontmatter.
  * Returns the parsed metadata (name, description, plus any extra fields).
  */
-export async function loadSkillMd(filePath: string): Promise<SkillMeta> {
+export async function loadSkillMd(
+  filePath: string,
+  opts?: LoadSkillMdOptions,
+): Promise<SkillMeta> {
   let content: string;
   try {
     content = await readFile(filePath, "utf-8");
@@ -32,7 +44,19 @@ export async function loadSkillMd(filePath: string): Promise<SkillMeta> {
     throw new SkillLoadError(`No YAML frontmatter in ${filePath}`);
   }
 
-  const meta = parseSimpleYaml(match[1]);
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(match[1]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new SkillLoadError(`Invalid YAML frontmatter in ${filePath}: ${message}`);
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new SkillLoadError(`Frontmatter must be a YAML object: ${filePath}`);
+  }
+
+  const meta = parsed as Record<string, unknown>;
 
   if (typeof meta["name"] !== "string" || !meta["name"]) {
     throw new SkillLoadError(`Missing 'name' in SKILL.md frontmatter: ${filePath}`);
@@ -41,27 +65,45 @@ export async function loadSkillMd(filePath: string): Promise<SkillMeta> {
     throw new SkillLoadError(`Missing 'description' in SKILL.md frontmatter: ${filePath}`);
   }
 
+  const allowedTools = parseAllowedTools(meta["allowed-tools"], opts?.onWarning);
+  if (allowedTools !== undefined) {
+    meta["allowedTools"] = allowedTools;
+  }
+
   return meta as SkillMeta;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * Minimal YAML parser for flat key: value frontmatter.
- * We avoid a full YAML dependency — SKILL.md frontmatter is simple key-value pairs.
+ * Parse the `allowed-tools` frontmatter field into `ToolName[]`. The agentskills.io
+ * spec defines this as a space-delimited string. Unknown tokens are reported via
+ * `onWarning` and dropped — graceful degradation matches host behavior and avoids
+ * forcing lib bumps for every new tool name added upstream.
+ *
+ * Returns `undefined` when the field is absent or has an unrecognized shape.
  */
-function parseSimpleYaml(yaml: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const line of yaml.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {continue;}
-    const colonIdx = trimmed.indexOf(":");
-    if (colonIdx === -1) {continue;}
-    const key = trimmed.slice(0, colonIdx).trim();
-    let value = trimmed.slice(colonIdx + 1).trim();
-    // Strip surrounding quotes
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    result[key] = value;
+function parseAllowedTools(
+  raw: unknown,
+  onWarning?: (message: string) => void,
+): ToolName[] | undefined {
+  if (raw === undefined || raw === null) {return undefined;}
+  if (typeof raw !== "string") {
+    onWarning?.(`allowed-tools must be a string, got ${typeof raw}; ignoring`);
+    return undefined;
   }
-  return result;
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {return undefined;}
+
+  const accepted: ToolName[] = [];
+  for (const token of tokens) {
+    if (isToolName(token)) {
+      accepted.push(token);
+    } else {
+      onWarning?.(`allowed-tools: unknown tool '${token}' (ignored)`);
+    }
+  }
+  return accepted.length > 0 ? accepted : undefined;
 }

--- a/packages/dotagents-lib/src/skills/loader.ts
+++ b/packages/dotagents-lib/src/skills/loader.ts
@@ -78,23 +78,45 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Parse the `allowed-tools` frontmatter field into `ToolName[]`. The agentskills.io
- * spec defines this as a space-delimited string. Unknown tokens are reported via
- * `onWarning` and dropped — graceful degradation matches host behavior and avoids
- * forcing lib bumps for every new tool name added upstream.
+ * Parse the `allowed-tools` frontmatter field into `ToolName[]`.
  *
- * Returns `undefined` when the field is absent or has an unrecognized shape.
+ * The agentskills.io spec defines this as a space-delimited string, but with
+ * a real YAML parser, frontmatter authors can also use YAML's native list
+ * syntax (`- Read\n  - Grep` or `[Read, Grep]`) which parses to a JS array.
+ * Both shapes are accepted.
+ *
+ * Unknown tokens are reported via `onWarning` and dropped. When the field is
+ * present but every token is unrecognized, returns an empty array (rather
+ * than `undefined`) so authorization gates can distinguish "field declared
+ * but values not understood" from "no restriction declared at all" — the
+ * latter is treated as unrestricted by most hosts.
+ *
+ * Returns `undefined` only when the field is genuinely absent or shaped in
+ * a way the lib can't interpret (e.g. an object).
  */
 function parseAllowedTools(
   raw: unknown,
   onWarning?: (message: string) => void,
 ): ToolName[] | undefined {
   if (raw === undefined || raw === null) {return undefined;}
-  if (typeof raw !== "string") {
-    onWarning?.(`allowed-tools must be a string, got ${typeof raw}; ignoring`);
+
+  let tokens: string[];
+  if (typeof raw === "string") {
+    tokens = raw.split(/\s+/).filter(Boolean);
+  } else if (Array.isArray(raw)) {
+    tokens = [];
+    for (const entry of raw) {
+      if (typeof entry === "string" && entry.trim().length > 0) {
+        tokens.push(entry.trim());
+      } else {
+        onWarning?.(`allowed-tools: skipping non-string entry ${JSON.stringify(entry)}`);
+      }
+    }
+  } else {
+    onWarning?.(`allowed-tools must be a string or array, got ${typeof raw}; ignoring`);
     return undefined;
   }
-  const tokens = raw.split(/\s+/).filter(Boolean);
+
   if (tokens.length === 0) {return undefined;}
 
   const accepted: ToolName[] = [];
@@ -105,5 +127,7 @@ function parseAllowedTools(
       onWarning?.(`allowed-tools: unknown tool '${token}' (ignored)`);
     }
   }
-  return accepted.length > 0 ? accepted : undefined;
+  // Keep the empty-array signal: declared-but-no-recognized-tokens is
+  // semantically distinct from field-absent (the latter returns undefined).
+  return accepted;
 }

--- a/packages/dotagents-lib/src/skills/loader.ts
+++ b/packages/dotagents-lib/src/skills/loader.ts
@@ -100,10 +100,15 @@ function parseAllowedTools(
 ): ToolName[] | undefined {
   if (raw === undefined || raw === null) {return undefined;}
 
+  // Track whether the field was declared as an array specifically. An empty
+  // array is "deny all" (explicit signal); an empty/whitespace string is more
+  // likely a typo and we treat it as absent.
   let tokens: string[];
+  let isArrayForm = false;
   if (typeof raw === "string") {
     tokens = raw.split(/\s+/).filter(Boolean);
   } else if (Array.isArray(raw)) {
+    isArrayForm = true;
     tokens = [];
     for (const entry of raw) {
       if (typeof entry === "string" && entry.trim().length > 0) {
@@ -117,7 +122,11 @@ function parseAllowedTools(
     return undefined;
   }
 
-  if (tokens.length === 0) {return undefined;}
+  // Empty/whitespace string: treat as absent (likely a typo).
+  // Empty array: deliberate "deny all" — preserve the empty signal.
+  if (tokens.length === 0) {
+    return isArrayForm ? [] : undefined;
+  }
 
   const accepted: ToolName[] = [];
   for (const token of tokens) {
@@ -127,7 +136,6 @@ function parseAllowedTools(
       onWarning?.(`allowed-tools: unknown tool '${token}' (ignored)`);
     }
   }
-  // Keep the empty-array signal: declared-but-no-recognized-tokens is
-  // semantically distinct from field-absent (the latter returns undefined).
+  // Declared-but-no-recognized-tokens stays distinct from field-absent.
   return accepted;
 }

--- a/packages/dotagents-lib/src/skills/resolver.test.ts
+++ b/packages/dotagents-lib/src/skills/resolver.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeSource,
   sourcesMatch,
   isSourceExcluded,
+  ParseSourceError,
 } from "./resolver.js";
 
 describe("parseOwnerRepoShorthand", () => {
@@ -292,9 +293,10 @@ describe("parseSource", () => {
   });
 
   it("does not parse http:// URL as well-known (HTTPS required)", () => {
-    const result = parseSource("http://localhost:3000");
-    // http:// falls through to owner/repo shorthand — not classified as well-known
-    expect(result.type).not.toBe("well-known");
+    // http:// falls through to the shorthand branch, where the URL's path
+    // structure trips the multi-segment-shorthand strictness check. Either
+    // way, http:// is rejected.
+    expect(() => parseSource("http://localhost:3000")).toThrow(ParseSourceError);
   });
 });
 
@@ -464,5 +466,75 @@ describe("isSourceExcluded", () => {
   it("strips git: prefix for matching", () => {
     expect(isSourceExcluded("git:getsentry/skills", ["getsentry"])).toBe(true);
     expect(isSourceExcluded("git:getsentry/skills", ["getsentry/skills"])).toBe(true);
+  });
+});
+
+describe("parseSource strict shorthand", () => {
+  it("throws ParseSourceError on empty SHA after @", () => {
+    expect(() => parseSource("owner/repo@")).toThrow(ParseSourceError);
+    try {
+      parseSource("owner/repo@");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ParseSourceError);
+      expect((err as ParseSourceError).kind).toBe("empty-sha");
+    }
+  });
+
+  it("throws ParseSourceError on empty SHA in scoped shorthand", () => {
+    try {
+      parseSource("@owner/repo@");
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ParseSourceError);
+      expect((err as ParseSourceError).kind).toBe("empty-sha");
+    }
+  });
+
+  it("throws ParseSourceError on multi-segment shorthand", () => {
+    try {
+      parseSource("owner/repo/nested");
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ParseSourceError);
+      expect((err as ParseSourceError).kind).toBe("multi-segment-shorthand");
+    }
+  });
+
+  it("still parses valid github shorthand without throwing", () => {
+    expect(() => parseSource("owner/repo")).not.toThrow();
+    expect(() => parseSource("owner/repo@abc123")).not.toThrow();
+    expect(() => parseSource("@owner/repo")).not.toThrow();
+  });
+
+  it("still parses GitHub URLs without throwing (URL form unaffected)", () => {
+    expect(() => parseSource("https://github.com/owner/repo@abc")).not.toThrow();
+    expect(() => parseSource("git@github.com:owner/repo.git@abc")).not.toThrow();
+  });
+
+  it("GitLab nested groups via applyDefaultRepositorySource go through URL form, not shorthand", () => {
+    const expanded = applyDefaultRepositorySource("group/sub/repo", "gitlab");
+    expect(() => parseSource(expanded)).not.toThrow();
+    const parsed = parseSource(expanded);
+    expect(parsed.type).toBe("git");
+    expect(parsed.owner).toBe("group/sub");
+    expect(parsed.repo).toBe("repo");
+  });
+});
+
+describe("parseOwnerRepoShorthand strict (mirrors parseSource)", () => {
+  it("returns undefined for empty SHA after @", () => {
+    expect(parseOwnerRepoShorthand("owner/repo@")).toBeUndefined();
+  });
+
+  it("returns undefined for multi-segment shorthand", () => {
+    expect(parseOwnerRepoShorthand("owner/repo/nested")).toBeUndefined();
+  });
+
+  it("still parses valid shorthand", () => {
+    expect(parseOwnerRepoShorthand("owner/repo@abc")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      ref: "abc",
+    });
   });
 });

--- a/packages/dotagents-lib/src/skills/resolver.test.ts
+++ b/packages/dotagents-lib/src/skills/resolver.test.ts
@@ -521,6 +521,33 @@ describe("parseSource strict shorthand", () => {
   });
 });
 
+describe("normalizeSource gracefully handles malformed inputs", () => {
+  // normalizeSource is called from dedup / comparison paths that should not
+  // crash on stale or hand-edited config. parseSource throwing on malformed
+  // shorthand must not propagate up to those callers.
+  it("returns input as-is when parseSource throws empty-sha", () => {
+    expect(normalizeSource("owner/repo@")).toBe("owner/repo@");
+  });
+
+  it("returns input as-is when parseSource throws multi-segment-shorthand", () => {
+    expect(normalizeSource("owner/repo/nested")).toBe("owner/repo/nested");
+  });
+
+  it("still normalizes valid inputs", () => {
+    expect(normalizeSource("https://github.com/owner/repo")).toBe("owner/repo");
+  });
+});
+
+describe("sourcesMatch gracefully handles malformed inputs", () => {
+  it("returns false (not throws) when one side is malformed", () => {
+    expect(sourcesMatch("owner/repo", "owner/repo@")).toBe(false);
+  });
+
+  it("matches two equally-malformed inputs as opaque strings", () => {
+    expect(sourcesMatch("owner/repo@", "owner/repo@")).toBe(true);
+  });
+});
+
 describe("parseOwnerRepoShorthand strict (mirrors parseSource)", () => {
   it("returns undefined for empty SHA after @", () => {
     expect(parseOwnerRepoShorthand("owner/repo@")).toBeUndefined();

--- a/packages/dotagents-lib/src/skills/resolver.ts
+++ b/packages/dotagents-lib/src/skills/resolver.ts
@@ -29,6 +29,27 @@ export class ResolveError extends Error {
   }
 }
 
+/**
+ * Thrown when `parseSource` is asked to parse a malformed shorthand specifier
+ * that previously produced a silent partial parse.
+ *
+ *  - `empty-sha`: input ends with `@` and nothing after (`owner/repo@`).
+ *  - `multi-segment-shorthand`: shorthand has more than two slash-separated
+ *    segments (`owner/repo/nested`). GitLab nested groups are unaffected
+ *    because they go through `applyDefaultRepositorySource` first.
+ */
+export type ParseSourceErrorKind = "empty-sha" | "multi-segment-shorthand";
+
+export class ParseSourceError extends Error {
+  readonly kind: ParseSourceErrorKind;
+
+  constructor(message: string, kind: ParseSourceErrorKind) {
+    super(message);
+    this.name = "ParseSourceError";
+    this.kind = kind;
+  }
+}
+
 export interface ResolvedGitSkill {
   type: "git";
   /** Original source string */
@@ -88,6 +109,10 @@ export function parseOwnerRepoShorthand(
   const atIdx = stripped.indexOf("@");
   const base = atIdx >= 0 ? stripped.slice(0, atIdx) : stripped;
   const ref = atIdx >= 0 ? stripped.slice(atIdx + 1) : undefined;
+
+  // Empty SHA after `@` is malformed shorthand, not a valid no-pin parse.
+  if (atIdx >= 0 && ref === "") {return undefined;}
+
   const parts = base.split("/");
   if (parts.length !== 2) {return undefined;}
 
@@ -204,7 +229,30 @@ export function parseSource(source: string): {
   const atIdx = stripped.indexOf("@");
   const base = atIdx === -1 ? stripped : stripped.slice(0, atIdx);
   const ref = atIdx === -1 ? undefined : stripped.slice(atIdx + 1);
-  const [owner, repo] = base.split("/");
+
+  // Empty SHA after `@` was previously returning `ref: ''` which downstream
+  // code treats as no-pin. Throw instead so a typo doesn't silently fall back
+  // to the tip of the default branch.
+  if (atIdx >= 0 && ref === "") {
+    throw new ParseSourceError(
+      `Invalid source: ${source} (empty SHA after @)`,
+      "empty-sha",
+    );
+  }
+
+  const parts = base.split("/");
+  // Multi-segment shorthand silently dropped trailing segments. Throw so
+  // `owner/repo/nested` doesn't resolve as `owner/repo` against the user's
+  // intent. (GitLab nested groups go through applyDefaultRepositorySource
+  // first and arrive here as URL form, not shorthand.)
+  if (parts.length > 2) {
+    throw new ParseSourceError(
+      `Invalid source: ${source} (multi-segment shorthand; use a full URL for nested groups)`,
+      "multi-segment-shorthand",
+    );
+  }
+
+  const [owner, repo] = parts;
 
   return {
     type: "github",

--- a/packages/dotagents-lib/src/skills/resolver.ts
+++ b/packages/dotagents-lib/src/skills/resolver.ts
@@ -263,9 +263,22 @@ export function parseSource(source: string): {
   };
 }
 
-/** Normalize hosted sources to canonical owner/repo form for comparison/dedup. */
+/**
+ * Normalize hosted sources to canonical owner/repo form for comparison/dedup.
+ *
+ * Best-effort: malformed inputs that `parseSource` rejects are returned as-is
+ * so dedup and comparison paths don't crash on stale or hand-edited config.
+ * Real install/add paths still call `parseSource` directly and surface the
+ * error to the user.
+ */
 export function normalizeSource(source: string): string {
-  const parsed = parseSource(source);
+  let parsed;
+  try {
+    parsed = parseSource(source);
+  } catch (err) {
+    if (err instanceof ParseSourceError) {return source;}
+    throw err;
+  }
   if (parsed.type === "well-known" && parsed.url) {
     // Normalize: strip trailing slash, lowercase hostname
     try {

--- a/packages/dotagents-lib/src/skills/tool-name.test.ts
+++ b/packages/dotagents-lib/src/skills/tool-name.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { TOOL_NAMES, isToolName, type ToolName } from "./tool-name.js";
+
+describe("isToolName", () => {
+  it("accepts every name in TOOL_NAMES", () => {
+    for (const name of TOOL_NAMES) {
+      expect(isToolName(name)).toBe(true);
+    }
+  });
+
+  it("rejects unknown names", () => {
+    expect(isToolName("Magic")).toBe(false);
+    expect(isToolName("read")).toBe(false); // case-sensitive
+    expect(isToolName("")).toBe(false);
+  });
+
+  it("rejects non-string values", () => {
+    expect(isToolName(null)).toBe(false);
+    expect(isToolName(42)).toBe(false);
+    expect(isToolName(["Read"])).toBe(false);
+    expect(isToolName(void 0)).toBe(false);
+  });
+
+  it("narrows the type to ToolName when true", () => {
+    const candidate: unknown = "Read";
+    if (isToolName(candidate)) {
+      // Compile-time check — `candidate` should be ToolName here.
+      const narrowed: ToolName = candidate;
+      expect(narrowed).toBe("Read");
+    }
+  });
+});

--- a/packages/dotagents-lib/src/skills/tool-name.ts
+++ b/packages/dotagents-lib/src/skills/tool-name.ts
@@ -1,0 +1,26 @@
+/**
+ * Closed set of well-known agent tool names. The list tracks Claude Code's
+ * tool inventory, which is the de-facto agentskills.io standard.
+ *
+ * Hosts that want a stricter set layer their own validation on top
+ * (e.g. `z.enum(TOOL_NAMES).refine(...)` to disallow `Bash`).
+ * Hosts that need an open set use `string[]` directly and do their own typing.
+ */
+export const TOOL_NAMES = [
+  "Read",
+  "Write",
+  "Edit",
+  "Bash",
+  "Glob",
+  "Grep",
+  "WebFetch",
+  "WebSearch",
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
+const TOOL_NAME_SET: ReadonlySet<string> = new Set(TOOL_NAMES);
+
+export function isToolName(value: unknown): value is ToolName {
+  return typeof value === "string" && TOOL_NAME_SET.has(value);
+}

--- a/packages/dotagents-lib/src/sources/name-safety.test.ts
+++ b/packages/dotagents-lib/src/sources/name-safety.test.ts
@@ -78,6 +78,24 @@ describe("validateGitNameSafety", () => {
     }
   });
 
+  it("rejects embedded '..' in a segment", () => {
+    try {
+      validateGitNameSafety({ repo: "foo..bar" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).reason).toBe("traversal");
+    }
+  });
+
+  it("rejects embedded '..' in owner segment", () => {
+    try {
+      validateGitNameSafety({ owner: "..foo" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).reason).toBe("traversal");
+    }
+  });
+
   it("rejects invalid characters", () => {
     try {
       validateGitNameSafety({ owner: "weird name" });

--- a/packages/dotagents-lib/src/sources/name-safety.test.ts
+++ b/packages/dotagents-lib/src/sources/name-safety.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { validateGitNameSafety, GitNameSafetyError } from "./name-safety.js";
+
+describe("validateGitNameSafety", () => {
+  it("accepts safe owner/repo/ref", () => {
+    expect(() =>
+      validateGitNameSafety({ owner: "getsentry", repo: "warden", ref: "abc123" }),
+    ).not.toThrow();
+  });
+
+  it("accepts owner with dots, hyphens, underscores", () => {
+    expect(() =>
+      validateGitNameSafety({ owner: "my.org_x-y", repo: "repo" }),
+    ).not.toThrow();
+  });
+
+  it("accepts a refs/heads/branch ref via dots and slashes are not allowed — only flat refs", () => {
+    // refs containing slashes are rejected because we validate as a single segment.
+    // Callers that pass branch refs should pass the leaf only.
+    expect(() => validateGitNameSafety({ ref: "main" })).not.toThrow();
+    expect(() => validateGitNameSafety({ ref: "v1.2.3" })).not.toThrow();
+  });
+
+  it("accepts no fields (all optional)", () => {
+    expect(() => validateGitNameSafety({})).not.toThrow();
+  });
+
+  it("rejects leading-dash owner", () => {
+    expect(() => validateGitNameSafety({ owner: "-malicious" })).toThrow(
+      GitNameSafetyError,
+    );
+    try {
+      validateGitNameSafety({ owner: "-malicious" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitNameSafetyError);
+      expect((err as GitNameSafetyError).field).toBe("owner");
+      expect((err as GitNameSafetyError).reason).toBe("leading-dash");
+    }
+  });
+
+  it("rejects leading-dash repo", () => {
+    try {
+      validateGitNameSafety({ repo: "-evil" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitNameSafetyError);
+      expect((err as GitNameSafetyError).field).toBe("repo");
+      expect((err as GitNameSafetyError).reason).toBe("leading-dash");
+    }
+  });
+
+  it("rejects leading-dash ref", () => {
+    try {
+      validateGitNameSafety({ ref: "--upload-pack=evil" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitNameSafetyError);
+      expect((err as GitNameSafetyError).field).toBe("ref");
+      expect((err as GitNameSafetyError).reason).toBe("leading-dash");
+    }
+  });
+
+  it("rejects '..' as repo", () => {
+    try {
+      validateGitNameSafety({ owner: "safe", repo: ".." });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).reason).toBe("traversal");
+    }
+  });
+
+  it("rejects '.' as repo", () => {
+    try {
+      validateGitNameSafety({ repo: "." });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).reason).toBe("traversal");
+    }
+  });
+
+  it("rejects invalid characters", () => {
+    try {
+      validateGitNameSafety({ owner: "weird name" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).reason).toBe("invalid-characters");
+    }
+  });
+
+  it("accepts GitLab nested group with safe segments", () => {
+    expect(() =>
+      validateGitNameSafety({ owner: "group/subgroup", repo: "repo" }),
+    ).not.toThrow();
+  });
+
+  it("rejects GitLab nested group when one segment is unsafe", () => {
+    try {
+      validateGitNameSafety({ owner: "group/-evil", repo: "repo" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).field).toBe("owner");
+      expect((err as GitNameSafetyError).reason).toBe("leading-dash");
+    }
+  });
+
+  it("rejects GitLab nested group with traversal segment", () => {
+    try {
+      validateGitNameSafety({ owner: "group/../escape", repo: "repo" });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as GitNameSafetyError).field).toBe("owner");
+      expect((err as GitNameSafetyError).reason).toBe("traversal");
+    }
+  });
+});

--- a/packages/dotagents-lib/src/sources/name-safety.ts
+++ b/packages/dotagents-lib/src/sources/name-safety.ts
@@ -68,11 +68,14 @@ function validateSegment(field: GitNameSafetyField, value: string): void {
       `${field} cannot start with '-' (would inject a git flag): ${JSON.stringify(value)}`,
     );
   }
-  if (value === "." || value === "..") {
+  // Reject any consecutive-dot pattern. The exact `.` and `..` cases are the
+  // common ones, but `foo..bar`, `..foo`, etc. would also bypass directory
+  // boundaries when joined into a filesystem path.
+  if (value === "." || value.includes("..")) {
     throw new GitNameSafetyError(
       field,
       "traversal",
-      `${field} cannot be a path-traversal segment: ${JSON.stringify(value)}`,
+      `${field} contains a path-traversal pattern: ${JSON.stringify(value)}`,
     );
   }
   if (!SAFE_NAME_PATTERN.test(value)) {

--- a/packages/dotagents-lib/src/sources/name-safety.ts
+++ b/packages/dotagents-lib/src/sources/name-safety.ts
@@ -1,0 +1,85 @@
+/**
+ * Reasons a git name field can fail safety validation.
+ *
+ *  - `leading-dash`: starts with `-` (would be parsed as a git flag).
+ *  - `traversal`: equals `..`, `.`, or contains a `..` segment.
+ *  - `invalid-characters`: outside the allow-list `[a-zA-Z0-9][a-zA-Z0-9._-]*`.
+ */
+export type GitNameSafetyReason =
+  | "leading-dash"
+  | "traversal"
+  | "invalid-characters";
+
+export type GitNameSafetyField = "owner" | "repo" | "ref";
+
+export class GitNameSafetyError extends Error {
+  readonly field: GitNameSafetyField;
+  readonly reason: GitNameSafetyReason;
+
+  constructor(field: GitNameSafetyField, reason: GitNameSafetyReason, message: string) {
+    super(message);
+    this.name = "GitNameSafetyError";
+    this.field = field;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Owner / repo / ref segments must start with an alphanumeric and contain
+ * only alphanumerics, dots, hyphens, and underscores. Matches GitHub's
+ * username/repo character rules.
+ */
+const SAFE_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+/**
+ * Validate that owner/repo/ref values are safe to splice into a git command
+ * and into filesystem paths. Throws `GitNameSafetyError` on the first violation.
+ *
+ * `parseSource` does not call this automatically — parse and validate stay
+ * separable so callers that need the looser parse (e.g. `normalizeSource`
+ * for dedup comparisons) aren't forced through the strict gate.
+ *
+ * `owner` is validated segment-by-segment so GitLab nested groups
+ * (`group/subgroup`) pass when each segment is independently safe.
+ */
+export function validateGitNameSafety(input: {
+  owner?: string;
+  repo?: string;
+  ref?: string;
+}): void {
+  if (input.owner !== undefined) {
+    for (const segment of input.owner.split("/")) {
+      validateSegment("owner", segment);
+    }
+  }
+  if (input.repo !== undefined) {
+    validateSegment("repo", input.repo);
+  }
+  if (input.ref !== undefined) {
+    validateSegment("ref", input.ref);
+  }
+}
+
+function validateSegment(field: GitNameSafetyField, value: string): void {
+  if (value.startsWith("-")) {
+    throw new GitNameSafetyError(
+      field,
+      "leading-dash",
+      `${field} cannot start with '-' (would inject a git flag): ${JSON.stringify(value)}`,
+    );
+  }
+  if (value === "." || value === "..") {
+    throw new GitNameSafetyError(
+      field,
+      "traversal",
+      `${field} cannot be a path-traversal segment: ${JSON.stringify(value)}`,
+    );
+  }
+  if (!SAFE_NAME_PATTERN.test(value)) {
+    throw new GitNameSafetyError(
+      field,
+      "invalid-characters",
+      `${field} contains invalid characters: ${JSON.stringify(value)}`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,11 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
-  packages/dotagents-lib: {}
+  packages/dotagents-lib:
+    dependencies:
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
 packages:
 


### PR DESCRIPTION
Bundle four additive surface improvements plus two correctness fixes that warden — the lib's first external consumer — would otherwise have to keep reimplementing locally. All changes are confined to `@sentry/dotagents-lib`; the host package builds and tests clean unchanged.

**`ToolName` vocabulary**

Closed set of well-known agent tool names exposed as `TOOL_NAMES` (readonly tuple), `ToolName` (union type), and `isToolName` (type guard). Hosts that need a stricter set layer their own validation; hosts that need open-ended typing use `string[]` directly.

**`allowed-tools` parsed eagerly**

`SkillMeta.allowedTools: ToolName[]` is populated from space-delimited frontmatter (`allowed-tools: Read Grep Glob`). Unknown tokens are reported via an optional `onWarning` callback and dropped — graceful degradation matches what every host already does and avoids forcing lib bumps for every new tool name.

**`markerFile` opt on discovery**

`discoverSkill` and `discoverAllSkills` accept `markerFile?: string` (default `"SKILL.md"`). Hosts that also walk `AGENT.md` (e.g. warden) pass the opt instead of cloning the walker. Marketplace-format discovery stays SKILL-specific because marketplace.json is a SKILL distribution convention.

**`validateGitNameSafety` helper**

Standalone function with typed `GitNameSafetyError` carrying `field` and `reason`. Rejects:
- `leading-dash` (would inject a git flag)
- `traversal` (`..` or `.` segments)
- `invalid-characters` (outside `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)

Owner is validated segment-by-segment so GitLab nested groups (`group/subgroup`) pass when each segment is independently safe. `parseSource` does **not** call this automatically — parse and validate stay separable.

**YAML parser swap**

The 17-line in-house flat-key parser is replaced with the `yaml` package (lib's first runtime dep, ~140KB). SKILL.md frontmatter now correctly handles:

Before, multi-line plain scalars were silently mis-parsed:

```yaml
description:
  React composition patterns that scale.
  Use when refactoring components.
```

→ old parser captured `description` with empty value, then `loadSkillMd` threw \"Missing 'description'\".

After, the same input parses to a single space-folded string. Nested object values (`metadata:` blocks) and arrays (`tags:` lists) work too. `SkillMeta`'s extra-field index signature widens from `string` to `unknown`; consumers narrow with type guards or zod parses.

**Strict shorthand parsing**

`parseSource` now throws `ParseSourceError` (with `kind: 'empty-sha' | 'multi-segment-shorthand'`) on the two malformed shorthand inputs that previously returned silent partial parses:

- `owner/repo@` (empty SHA after `@`) — used to return `ref: ''` which downstream code treated as no-pin.
- `owner/repo/nested` (multi-segment shorthand under default `github`) — used to silently drop `nested`.

`parseOwnerRepoShorthand` mirrors via `undefined` return. URL-form inputs and GitLab nested groups (which arrive via `applyDefaultRepositorySource` as URL form) are unaffected.

**Test coverage**

| Suite | Before | After |
|---|---|---|
| `loader.test.ts` | 6 | 13 |
| `discovery.test.ts` | 27 | 31 |
| `resolver.test.ts` | 67 | 76 |
| `tool-name.test.ts` | — | 4 |
| `name-safety.test.ts` | — | 13 |

Net: 257 lib tests passing (was ~195), 424 host tests passing unchanged.

**Host adoption**

No host code changes in this PR. The host's parser- and discovery-level inputs were already well-formed (its `parseSource` callers come from `agents.toml` config with separate validation upstream), so it picks up the bug fix and the new exports for free.

Refs warden's adoption PR: https://github.com/getsentry/warden/pull/285