### PR TITLE
docs: Update dotagents docs for install refresh flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Shared tooling for coding agents. Declare skills, MCP servers, and hooks in `age
 
 **One source of truth.** Skills live in `.agents/skills/` and symlink into `.claude/skills/`, `.cursor/skills/`, or wherever your tools expect them. No copy-pasting between directories.
 
-**One command to install.** `agents.toml` is committed, managed skills are gitignored. Collaborators run `dotagents install` and get the same setup.
+**One command to install.** `agents.toml` is committed, managed skills are gitignored. Collaborators run `dotagents install` to fetch or refresh skills.
 
 **Shareable.** Skills are directories with a `SKILL.md`. Host them in any git repo, discover them automatically, install with one command.
 
-**Multi-agent.** Configure Claude, Cursor, Codex, VS Code, OpenCode, and Pi from a single `agents.toml` -- skills, MCP servers, and hooks.
+**Multi-agent.** Configure Claude, Cursor, Codex, VS Code, and OpenCode from a single `agents.toml` -- skills, MCP servers, and hooks where supported. Pi reads `.agents/skills/` directly.
 
 ## Quick Start
 
@@ -33,7 +33,7 @@ npx @sentry/dotagents add getsentry/skills --all
 
 This creates an `agents.toml` at your project root and an `agents.lock` tracking installed skills.
 
-After cloning a project that already has `agents.toml`, run `install` to fetch everything:
+After cloning a project that already has `agents.toml`, run `install` to fetch skills. Run it again to refresh managed skills:
 
 ```bash
 npx @sentry/dotagents install
@@ -57,7 +57,7 @@ All commands accept `--user` to operate on user scope (`~/.agents/`) instead of 
 
 ## Source Formats
 
-Skills can come from GitHub, GitLab, any git server, or local directories:
+Skills can come from GitHub, GitLab, any git server, well-known HTTPS skill sources, or local directories:
 
 ```toml
 [[skills]]
@@ -75,6 +75,10 @@ source = "https://gitlab.com/group/repo" # GitLab URL
 [[skills]]
 name = "internal"
 source = "git:https://git.corp.dev/repo" # Any git server
+
+[[skills]]
+name = "error-tracking"
+source = "https://cli.sentry.dev"        # Well-known HTTPS source
 
 [[skills]]
 name = "local"

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ npx @sentry/dotagents add getsentry/skills find-bugs code-review commit
 # Add all skills from a repo
 npx @sentry/dotagents add getsentry/skills --all
 
-# Install all declared skills
+# Install or refresh all declared skills
 npx @sentry/dotagents install
 ```
 
@@ -42,7 +42,7 @@ And a lockfile (`agents.lock`) tracking which skills are managed. Both `agents.l
 ## How It Works
 
 1. Declare skill dependencies in `agents.toml` at the project root (or `~/.agents/agents.toml` for user scope)
-2. `install` clones repos (always fetching latest), discovers skills by convention, and copies them into `.agents/skills/`
+2. `install` clones or refreshes sources, discovers skills by convention, and copies them into `.agents/skills/`
 3. `agents.lock` tracks which skills are managed (gitignored automatically)
 4. Managed skills are gitignored. Collaborators run `npx @sentry/dotagents install` after cloning. Custom skills in `.agents/skills/` are tracked by git normally.
 5. Symlinks connect `.agents/skills/` to each agent's expected location (`.claude/skills/`, `.cursor/skills/`, etc.)
@@ -55,6 +55,8 @@ Full example with all sections:
 ```toml
 version = 1
 agents = ["claude", "cursor"]
+minimum_release_age = 60
+minimum_release_age_exclude = ["getsentry/*"]
 
 [project]
 name = "my-project"
@@ -79,6 +81,11 @@ source = "getsentry/skills@v1.0.0"
 [[skills]]
 name = "internal"
 source = "git:https://git.corp.dev/repo"
+
+# Well-known HTTPS source
+[[skills]]
+name = "error-tracking"
+source = "https://cli.sentry.dev"
 
 # Local directory
 [[skills]]
@@ -127,6 +134,8 @@ command = "notify-done"
 | `version` | integer | Yes | -- | Schema version. Always `1`. |
 | `defaultRepositorySource` | string | No | `github` | Host used for shorthand `owner/repo` skill sources. Valid values: `github`, `gitlab`. |
 | `agents` | string[] | No | `[]` | Agent tool IDs: `claude`, `cursor`, `codex`, `vscode`, `opencode`. Creates symlinks and config files for each. |
+| `minimum_release_age` | integer | No | -- | Minimum commit age, in minutes, before a git skill can install. |
+| `minimum_release_age_exclude` | string[] | No | `[]` | Sources that bypass the minimum release age gate. Supports org names, `org/repo`, and `org/*`. |
 
 ### Skills
 
@@ -246,14 +255,10 @@ Create `agents.toml` and `.agents/skills/` directory. Automatically includes the
 ### install
 
 ```
-npx @sentry/dotagents install [--force]
+npx @sentry/dotagents install
 ```
 
-Install all dependencies from `agents.toml`. Always fetches latest skills (TTL-based cache refresh). Resolves sources, copies skills, writes lockfile, creates symlinks, generates MCP and hook configs. There is no separate update step.
-
-| Flag | Description |
-|------|-------------|
-| `--force` | Re-resolve and re-install all skills, ignoring cache |
+Install and refresh dependencies from `agents.toml`. Resolves sources, copies skills, writes the lockfile, creates symlinks, and generates MCP and hook configs. There is no separate update command.
 
 ### add
 
@@ -454,14 +459,16 @@ version = 1
 source = "getsentry/skills"
 resolved_url = "https://github.com/getsentry/skills.git"
 resolved_path = "plugins/sentry-skills/skills/find-bugs"
+resolved_commit = "0123456789abcdef0123456789abcdef01234567"
 ```
 
 | Field | Present For | Description |
 |-------|-------------|-------------|
 | `source` | All | Original source from `agents.toml` |
-| `resolved_url` | Git sources | Resolved git clone URL |
+| `resolved_url` | Git and well-known sources | Resolved git clone URL or HTTP base URL |
 | `resolved_path` | Git sources | Subdirectory within repo where skill was found |
 | `resolved_ref` | Git sources (optional) | Resolved ref name (omitted for default branch) |
+| `resolved_commit` | Git sources (optional) | Full commit SHA that was installed. Informational only; install does not use it for locking. |
 
 Local `path:` skills have `source` only.
 
@@ -469,9 +476,9 @@ Local `path:` skills have `source` only.
 
 Location: `~/.local/dotagents/` (override: `DOTAGENTS_STATE_DIR`)
 
-- Shallow clone per repo, refreshed after 24-hour TTL
+- Git sources use shallow clones and refresh on every install
+- Well-known HTTPS sources refresh after a 24-hour TTL
 - All git operations are non-interactive (`GIT_TERMINAL_PROMPT=0`)
-- Use `npx @sentry/dotagents install --force` to bypass cache
 
 ## Environment Variables
 
@@ -492,9 +499,9 @@ Custom skills created directly in `.agents/skills/` are not gitignored. They're 
 
 `.agents/.gitignore` is regenerated on every `install`, `add`, `remove`, and `sync`.
 
-## Update Strategy
+## Refresh Strategy
 
-`npx @sentry/dotagents install` always fetches the latest skills (with a TTL-based cache), unless a ref is pinned. There is no separate update command. Collaborators run `npx @sentry/dotagents install` after cloning.
+Run `npx @sentry/dotagents install` after cloning or pulling changes. It fetches or refreshes managed skills unless a ref is pinned. There is no separate update command.
 
 ## Links
 

--- a/docs/src/app/cli/page.tsx
+++ b/docs/src/app/cli/page.tsx
@@ -104,24 +104,14 @@ export default function CliPage() {
 
         <CliCommand
           name="install"
-          synopsis="dotagents install [--force]"
-          description="Install all skill dependencies from agents.toml. Resolves sources, copies skills, writes lockfile, creates symlinks, generates MCP and hook configs. Always fetches latest unless a ref is pinned."
-          options={[
-            {
-              flag: "--force",
-              description:
-                "Re-resolve and re-install all skills, ignoring cache",
-            },
-          ]}
-          examples={[
-            "dotagents install",
-            "dotagents install --force    # bypass cache",
-          ]}
+          synopsis="dotagents install"
+          description="Install and refresh skill dependencies from agents.toml. Resolves sources, copies skills, writes the lockfile, creates symlinks, and generates MCP and hook configs. There is no separate update command."
+          examples={["dotagents install"]}
         />
 
         <CliCommand
           name="add"
-          synopsis="dotagents add <source> [--name <name>] [--ref <ref>] [--all]"
+          synopsis="dotagents add <source> [skill...] [--name <name>] [--skill <name>] [--ref <ref>] [--all]"
           description={
             <>
               Add a skill dependency and install it. Auto-discovers skills in
@@ -136,7 +126,11 @@ export default function CliPage() {
           options={[
             {
               flag: "--name <name>",
-              description: "Specify which skill to add (alias: --skill)",
+              description: "Specify which skill to add (repeatable; alias: --skill)",
+            },
+            {
+              flag: "--skill <name>",
+              description: "Alias for --name",
             },
             {
               flag: "--ref <ref>",
@@ -155,7 +149,7 @@ export default function CliPage() {
             "# All skills from a repo",
             "dotagents add getsentry/skills --all",
             "",
-            "# Pinned to a version",
+            "# Pinned to a ref",
             "dotagents add getsentry/warden@v1.0.0",
             "",
             "# Explicit GitLab URL",
@@ -163,6 +157,9 @@ export default function CliPage() {
             "",
             "# Non-GitHub git server",
             "dotagents add git:https://git.corp.dev/team/skills --name review",
+            "",
+            "# Well-known HTTPS source",
+            "dotagents add https://cli.sentry.dev --name error-tracking",
             "",
             "# Local directory",
             "dotagents add path:./my-skills/custom",
@@ -387,6 +384,24 @@ dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"
             </tr>
             <tr>
               <td>
+                <strong>GitLab URL</strong>
+              </td>
+              <td>
+                <code>https://gitlab.com/group/repo</code>
+              </td>
+              <td>Explicit GitLab source</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Well-known HTTPS</strong>
+              </td>
+              <td>
+                <code>https://cli.sentry.dev</code>
+              </td>
+              <td>HTTP source using .well-known skill discovery</td>
+            </tr>
+            <tr>
+              <td>
                 <strong>Local</strong>
               </td>
               <td>
@@ -435,6 +450,26 @@ dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]"
                 <code>codex</code>, <code>vscode</code>,{" "}
                 <code>opencode</code>
               </td>
+            </tr>
+            <tr>
+              <td>
+                <code>minimum_release_age</code>
+              </td>
+              <td>integer</td>
+              <td>--</td>
+              <td>
+                Minimum commit age, in minutes, before a git skill can install.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>minimum_release_age_exclude</code>
+              </td>
+              <td>string[]</td>
+              <td>
+                <code>[]</code>
+              </td>
+              <td>Sources that bypass the minimum release age gate.</td>
             </tr>
             <tr>
               <td>

--- a/docs/src/app/guide/page.tsx
+++ b/docs/src/app/guide/page.tsx
@@ -32,7 +32,8 @@ export default function GuidePage() {
 
         <h3>2. Add Skills</h3>
         <p>
-          Install skills from GitHub repos, git URLs, or local directories.
+          Install skills from GitHub repos, git URLs, well-known HTTPS sources,
+          or local directories.
         </p>
         <pre>
           <code>{`# Add a single skill
@@ -42,7 +43,10 @@ dotagents add getsentry/skills --name find-bugs
 dotagents add getsentry/skills --all
 
 # Pin to a specific ref
-dotagents add getsentry/warden@v1.0.0`}</code>
+dotagents add getsentry/warden@v1.0.0
+
+# Add from a well-known HTTPS source
+dotagents add https://cli.sentry.dev --name error-tracking`}</code>
         </pre>
         <p>
           Each skill is copied into <code>.agents/skills/</code> and symlinked
@@ -54,15 +58,14 @@ dotagents add getsentry/warden@v1.0.0`}</code>
         <h3>3. Install</h3>
         <p>
           After cloning the repo or pulling changes, run <code>install</code>{" "}
-          to fetch skills. Managed skills are gitignored, so every collaborator
-          needs to run this once.
+          to fetch or refresh managed skills. Managed skills are gitignored, so
+          collaborators run this command locally.
         </p>
         <pre>
           <code>dotagents install</code>
         </pre>
         <p>
-          This always fetches the latest skills. There is no separate update
-          step.
+          This is also the update path. There is no separate update command.
         </p>
       </section>
 
@@ -114,7 +117,7 @@ dotagents trust add git.corp.example.com`}</code>
       <section className="section" id="git-hooks">
         <h2>Auto-install with Git Hooks</h2>
         <p>
-          Since managed skills are gitignored, collaborators need to run{" "}
+          Since managed skills are gitignored, run{" "}
           <code>dotagents install</code> after pulling. A{" "}
           <code>post-merge</code> hook automates this:
         </p>
@@ -204,6 +207,8 @@ dotagents --user install`}</code>
         <pre>
           <code>{`version = 1
 agents = ["claude", "cursor"]
+minimum_release_age = 60
+minimum_release_age_exclude = ["getsentry/*"]
 
 [trust]
 github_orgs = ["getsentry"]
@@ -217,6 +222,11 @@ source = "getsentry/skills"
 [[skills]]
 name = "warden-skill"
 source = "getsentry/warden@v1.0.0"
+
+# Well-known HTTPS source
+[[skills]]
+name = "error-tracking"
+source = "https://cli.sentry.dev"
 
 # Wildcard: all skills from a repo
 [[skills]]

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -50,8 +50,8 @@ export default function Home() {
             <h3>One command to install</h3>
             <p>
               <code>agents.toml</code> is committed, managed skills are
-              gitignored. Collaborators run <code>install</code> and get the
-              same setup.
+              gitignored. Collaborators run <code>install</code> to fetch or
+              refresh skills.
             </p>
           </div>
           <div className="feature">
@@ -179,8 +179,8 @@ export default function Home() {
       <section className="section" id="adding-skills">
         <h2>Adding Skills</h2>
         <p>
-          Use <code>dotagents add</code> to install skills from git repos or
-          local directories.
+          Use <code>dotagents add</code> to install skills from git repos,
+          well-known HTTPS sources, or local directories.
         </p>
         <pre>
           <code>{`# Add a single skill from a GitHub repo
@@ -197,6 +197,9 @@ dotagents add https://gitlab.com/group/repo --name find-bugs
 
 # From a non-GitHub git server
 dotagents add git:https://git.corp.dev/team/skills --name review
+
+# From a well-known HTTPS source
+dotagents add https://cli.sentry.dev --name error-tracking
 
 # From a local directory
 dotagents add path:./my-skills/custom`}</code>

--- a/docs/src/app/security/page.tsx
+++ b/docs/src/app/security/page.tsx
@@ -130,7 +130,8 @@ version = 1
 [skills.find-bugs]
 source = "getsentry/skills"
 resolved_url = "https://github.com/getsentry/skills.git"
-resolved_path = "plugins/sentry-skills/skills/find-bugs"`}</code>
+resolved_path = "plugins/sentry-skills/skills/find-bugs"
+resolved_commit = "0123456789abcdef0123456789abcdef01234567"`}</code>
         </pre>
         <table>
           <thead>
@@ -150,7 +151,7 @@ resolved_path = "plugins/sentry-skills/skills/find-bugs"`}</code>
               <td>
                 <code>resolved_url</code>
               </td>
-              <td>Resolved git clone URL</td>
+              <td>Resolved git clone URL or HTTP base URL</td>
             </tr>
             <tr>
               <td>
@@ -163,6 +164,12 @@ resolved_path = "plugins/sentry-skills/skills/find-bugs"`}</code>
                 <code>resolved_ref</code>
               </td>
               <td>Resolved ref name (omitted for default branch)</td>
+            </tr>
+            <tr>
+              <td>
+                <code>resolved_commit</code>
+              </td>
+              <td>Installed commit SHA. Informational only</td>
             </tr>
           </tbody>
         </table>
@@ -179,16 +186,13 @@ resolved_path = "plugins/sentry-skills/skills/find-bugs"`}</code>
           <code>DOTAGENTS_STATE_DIR</code>).
         </p>
         <ul>
-          <li>
-            Shallow clone per repo, refreshed after a 24-hour TTL
-          </li>
+          <li>Shallow clone per git source</li>
           <li>
             All git operations are non-interactive (
             <code>GIT_TERMINAL_PROMPT=0</code>)
           </li>
-          <li>
-            Use <code>dotagents install --force</code> to bypass cache
-          </li>
+          <li>Git sources refresh on every install</li>
+          <li>Well-known HTTPS sources use a 24-hour TTL</li>
         </ul>
       </section>
     </>

--- a/packages/dotagents-lib/README.md
+++ b/packages/dotagents-lib/README.md
@@ -1,10 +1,10 @@
 # @sentry/dotagents-lib
 
-Reusable core for [SKILL.md](https://www.anthropic.com/engineering/skills) loading, source resolution, and trust validation. This is the library powering the [`@sentry/dotagents`](https://www.npmjs.com/package/@sentry/dotagents) CLI; depend on it directly when you want to consume agent skills from your own tooling without buying into `agents.toml`.
+Reusable core for [SKILL.md](https://www.anthropic.com/engineering/skills) loading, source resolution, and trust validation. This library powers the [`@sentry/dotagents`](https://www.npmjs.com/package/@sentry/dotagents) CLI. Depend on it directly when you want to consume agent skills from your own tooling without using `agents.toml`.
 
 ## What's in here
 
-- **Source-string grammar** — `parseSource`, `applyDefaultRepositorySource`, `normalizeSource`, etc. The recognised forms are `owner/repo[@ref]`, GitHub/GitLab URLs (HTTPS and SSH), `git:<url>`, `path:<rel>`, and bare `https://` for well-known endpoints.
+- **Source-string grammar** — `parseSource`, `applyDefaultRepositorySource`, `normalizeSource`, etc. The recognized forms are `owner/repo[@ref]`, GitHub/GitLab URLs (HTTPS and SSH), `git:<url>`, `path:<rel>`, and bare `https://` for well-known endpoints.
 - **Resolution** — `resolveSkill(name, dep, opts?)` and `resolveWildcardSkills(dep, opts?)` clone/cache the source and return the on-disk skill directory plus a commit SHA for git sources. Both accept an optional `trust?: TrustPolicy` opt for opt-in trust enforcement at the resolver layer.
 - **SKILL.md loading and discovery** — `loadSkillMd`, `discoverSkill`, `discoverAllSkills`.
 - **Cache primitives** — `ensureCached`, `ensureWellKnownCached`. The lib has no default cache location; callers pass `stateDir` explicitly so hosts own their own conventions and env-var prefixes.

--- a/skills/dotagents/SKILL.md
+++ b/skills/dotagents/SKILL.md
@@ -37,7 +37,7 @@ npx @sentry/dotagents add getsentry/skills --all
 # Add a pinned skill
 npx @sentry/dotagents add getsentry/warden@v1.0.0
 
-# Install all dependencies from agents.toml
+# Install or refresh all dependencies from agents.toml
 npx @sentry/dotagents install
 
 # List installed skills
@@ -71,6 +71,7 @@ For full options and flags, read [references/cli-reference.md](references/cli-re
 | GitHub SSH | `git@github.com:owner/repo.git` | SSH clone URL |
 | GitHub HTTPS | `https://github.com/owner/repo` | Full HTTPS URL |
 | Git URL | `git:https://git.corp.dev/team/skills` | Any non-GitHub git remote |
+| Well-known HTTPS | `https://cli.sentry.dev` | HTTP source using `.well-known/skills/` |
 | Local path | `path:./my-skills/custom` | Relative to project root |
 
 ## Key Concepts
@@ -83,3 +84,4 @@ For full options and flags, read [references/cli-reference.md](references/cli-re
 - **Hooks**: `[[hooks]]` declarations write tool-event hooks to each agent's config
 - **Gitignore**: Managed skills are always gitignored; custom in-place skills are tracked
 - **User scope**: `--user` flag manages skills in `~/.agents/` shared across all projects
+- **Updates**: Run `npx @sentry/dotagents install` to refresh managed skills; there is no `update` command

--- a/skills/dotagents/references/cli-reference.md
+++ b/skills/dotagents/references/cli-reference.md
@@ -39,22 +39,17 @@ npx @sentry/dotagents --user init
 
 ### `install`
 
-Install all skill dependencies declared in `agents.toml`.
+Install or refresh skill dependencies declared in `agents.toml`. There is no separate `update` command.
 
 ```bash
 npx @sentry/dotagents install
-npx @sentry/dotagents install --force
 ```
-
-| Flag | Description |
-|------|-------------|
-| `--force` | Re-resolve and re-install all skills, ignoring cache |
 
 **Workflow:**
 1. Load config and lockfile
 2. Expand wildcard entries (discover all skills from source)
 3. Validate trust for each skill source
-4. Resolve skills (always fetches latest)
+4. Resolve skills (refreshing sources through the cache)
 5. Copy skills into `.agents/skills/<name>/`
 6. Write/update lockfile
 7. Generate `.agents/.gitignore`
@@ -75,6 +70,7 @@ npx @sentry/dotagents add getsentry/skills --all                    # Add all as
 npx @sentry/dotagents add getsentry/warden@v1.0.0                   # Pinned ref (inline)
 npx @sentry/dotagents add getsentry/skills --ref v2.0.0             # Pinned ref (flag)
 npx @sentry/dotagents add git:https://git.corp.dev/team/skills      # Non-GitHub git URL
+npx @sentry/dotagents add https://cli.sentry.dev --name error-tracking # Well-known HTTPS source
 npx @sentry/dotagents add path:./my-skills/custom                   # Local path
 ```
 
@@ -91,6 +87,7 @@ npx @sentry/dotagents add path:./my-skills/custom                   # Local path
 - `https://github.com/owner/repo` -- GitHub HTTPS URL
 - `git@github.com:owner/repo.git` -- GitHub SSH URL
 - `git:https://...` -- Non-GitHub git URL
+- `https://<domain>` -- Well-known HTTP skill source
 - `path:../relative` -- Local filesystem path
 
 When a repo contains multiple skills, dotagents auto-discovers them. If only one skill is found, it's added automatically. If multiple are found and no names are given, an interactive picker is shown (TTY) or skills are listed (non-TTY).
@@ -107,13 +104,13 @@ Remove a skill dependency.
 npx @sentry/dotagents remove find-bugs
 ```
 
-Removes from `agents.toml`, deletes `.agents/skills/<name>/`, updates lockfile, and regenerates `.gitignore`.
+Removes from `agents.toml`, deletes `.agents/skills/<name>/`, updates the lockfile, and regenerates `.agents/.gitignore`.
 
 For skills sourced from a wildcard entry (`name = "*"`), interactively prompts whether to add the skill to the wildcard's `exclude` list. If declined, the removal is cancelled.
 
 ### `sync`
 
-Reconcile project state without network access: adopt orphans, repair symlinks and configs.
+Reconcile project state without network access: adopt local orphans, prune stale managed skills, and repair symlinks and configs.
 
 ```bash
 npx @sentry/dotagents sync
@@ -122,10 +119,11 @@ npx @sentry/dotagents sync
 **Actions performed:**
 1. Adopt orphaned skills (installed but not declared in config)
 2. Regenerate `.agents/.gitignore`
-3. Check for missing skills
-4. Repair agent symlinks
-5. Verify/repair MCP configs
-6. Verify/repair hook configs
+3. Prune stale managed skills removed from config
+4. Check for missing skills
+5. Repair agent symlinks
+6. Verify/repair MCP configs
+7. Verify/repair hook configs
 
 Reports issues as warnings (missing MCP/hook configs) or errors (missing skills).
 

--- a/skills/dotagents/references/config-schema.md
+++ b/skills/dotagents/references/config-schema.md
@@ -5,6 +5,9 @@
 ```toml
 version = 1                     # Required, must be 1
 agents = ["claude", "cursor"]   # Optional, agent targets
+defaultRepositorySource = "github" # Optional, github or gitlab
+minimum_release_age = 60        # Optional, minutes
+minimum_release_age_exclude = ["getsentry/*"] # Optional
 
 [project]                       # Optional
 [trust]                         # Optional
@@ -18,7 +21,10 @@ agents = ["claude", "cursor"]   # Optional, agent targets
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `version` | integer | Yes | -- | Schema version, must be `1` |
+| `defaultRepositorySource` | string | No | `github` | Host for shorthand `owner/repo` sources. Valid values: `github`, `gitlab` |
 | `agents` | string[] | No | `[]` | Agent targets: `claude`, `cursor`, `codex`, `vscode`, `opencode` |
+| `minimum_release_age` | integer | No | -- | Minimum commit age, in minutes, before a git skill can install |
+| `minimum_release_age_exclude` | string[] | No | `[]` | Sources that bypass `minimum_release_age` |
 
 ## Project Section
 
@@ -51,7 +57,7 @@ path = "tools/my-skill"         # Optional, subdirectory within repo
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Unique identifier. Pattern: `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` |
-| `source` | string | Yes | `owner/repo`, `owner/repo@ref`, `git:url`, or `path:relative` |
+| `source` | string | Yes | `owner/repo`, `owner/repo@ref`, GitHub/GitLab URL, `https://<domain>`, `git:url`, or `path:relative` |
 | `ref` | string | No | Tag, branch, or commit SHA to pin |
 | `path` | string | No | Subdirectory containing the skill within the source repo |
 
@@ -146,18 +152,20 @@ Auto-generated. Do not edit manually. Gitignored automatically.
 version = 1
 
 [skills.find-bugs]
-source = "getsentry/skills"
+source = "getsentry/skills@v1.0.0"
 resolved_url = "https://github.com/getsentry/skills.git"
 resolved_path = "plugins/sentry-skills/skills/find-bugs"
 resolved_ref = "v1.0.0"
+resolved_commit = "0123456789abcdef0123456789abcdef01234567"
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `source` | string | Original source from `agents.toml` |
-| `resolved_url` | string | Resolved git URL |
+| `resolved_url` | string | Resolved git URL or well-known HTTP base URL |
 | `resolved_path` | string | Subdirectory within repo |
 | `resolved_ref` | string | Ref that was resolved (omitted for default branch) |
+| `resolved_commit` | string | Full commit SHA that was installed. Informational only |
 
 Local path skills have `source` only.
 

--- a/skills/dotagents/references/configuration.md
+++ b/skills/dotagents/references/configuration.md
@@ -33,7 +33,9 @@ path = "plugins/sentry-skills/skills/find-bugs"
 | GitHub pinned | `getsentry/skills@v1.0.0` | Same, checked out at `v1.0.0` |
 | GitHub HTTPS | `https://github.com/owner/repo` | URL used directly |
 | GitHub SSH | `git@github.com:owner/repo.git` | SSH clone |
+| GitLab HTTPS | `https://gitlab.com/group/repo` | URL used directly |
 | Git URL | `git:https://git.corp.dev/team/skills` | Any non-GitHub git remote |
+| Well-known HTTPS | `https://cli.sentry.dev` | HTTP source using `.well-known/skills/` |
 | Local | `path:./my-skills/custom` | Relative to project root |
 
 **Skill name rules:** Must start with alphanumeric, contain only `[a-zA-Z0-9._-]`.
@@ -160,6 +162,17 @@ User-scope symlinks go to `~/.claude/skills/` and `~/.cursor/skills/`.
 
 When no `agents.toml` exists and you're not inside a git repo, dotagents falls back to user scope automatically.
 
+## Minimum Release Age
+
+Use `minimum_release_age` to require git commits to age before install. The value is in minutes. Local and well-known HTTPS sources are not affected.
+
+```toml
+minimum_release_age = 60
+minimum_release_age_exclude = ["getsentry/*"]
+```
+
+Use `minimum_release_age_exclude` for trusted sources that can bypass the age gate.
+
 ## Gitignore
 
 dotagents always manages gitignore. It generates `.agents/.gitignore` listing managed (remote) skills. In-place skills (`path:.agents/skills/...`) are never gitignored since they must be tracked in git.
@@ -173,8 +186,8 @@ If these entries are missing, `install` and `sync` warn. Run `npx @sentry/dotage
 ## Caching
 
 - Cache location: `~/.local/dotagents/` (override with `DOTAGENTS_STATE_DIR`)
-- Shallow clone per repo, refreshed after 24-hour TTL
-- Use `npx @sentry/dotagents install --force` to bypass cache
+- Git sources use shallow clones and refresh on every install
+- Well-known HTTPS sources refresh after a 24-hour TTL
 
 ## Troubleshooting
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -147,7 +147,7 @@ Trust is checked before any network work in both `dotagents add` and `dotagents 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Skill name. Must start with alphanumeric and contain only `[a-zA-Z0-9._-]`. |
-| `source` | Yes | Skill source. `owner/repo` (resolved via `defaultRepositorySource`), `owner/repo@ref`, `https://github.com/owner/repo`, `https://gitlab.com/group/repo`, `git:<url>`, or `path:<relative>`. |
+| `source` | Yes | Skill source. `owner/repo` (resolved via `defaultRepositorySource`), `owner/repo@ref`, GitHub/GitLab URLs, well-known `https://<domain>` sources, `git:<url>`, or `path:<relative>`. |
 | `ref` | No | Git ref (tag, branch, or SHA). Can also be specified inline as `owner/repo@ref`. Defaults to repo's default branch. |
 | `path` | No | Explicit subdirectory path to the skill within the repo. Only needed when automatic discovery fails. |
 
@@ -311,11 +311,13 @@ version = 1
 source = "getsentry/skills"
 resolved_url = "https://github.com/getsentry/skills.git"
 resolved_path = "plugins/sentry-skills/skills/find-bugs"
+resolved_commit = "0123456789abcdef0123456789abcdef01234567"
 
 [skills.warden-skill]
 source = "getsentry/warden"
 resolved_url = "https://github.com/getsentry/warden.git"
 resolved_path = ".claude/skills/warden-skill"
+resolved_commit = "89abcdef0123456789abcdef0123456789abcdef"
 
 [skills.error-tracking]
 source = "https://cli.sentry.dev"
@@ -339,7 +341,7 @@ source = "path:../shared-skills/my-custom-skill"
 
 ## CLI Commands
 
-The CLI binary is `dotagents`. Currently runs via `tsx` during development; will be compiled with Bun for standalone distribution.
+The CLI binary is `dotagents`. During development, run it with `pnpm dev -- <command>` or `tsx`. Published packages are built with `tsc` and run on Node.js 20+.
 
 ### `dotagents init`
 
@@ -368,7 +370,7 @@ dotagents init [--force] [--agents claude,cursor]
 Install all dependencies from `agents.toml`.
 
 ```
-dotagents install [--force]
+dotagents install
 ```
 
 **Behavior:**
@@ -383,9 +385,6 @@ dotagents install [--force]
 6. Create/verify symlinks (legacy `[symlinks]` and agent-specific)
 7. Write MCP config files for each declared agent
 8. Print summary
-
-**Flags:**
-- `--force`: Re-resolve everything, ignore cache.
 
 ### `dotagents add <specifier>`
 
@@ -578,7 +577,8 @@ Source string
 Cache location: `~/.local/dotagents/` (overridable via `DOTAGENTS_STATE_DIR`)
 
 Structure:
-- `owner/repo/` — shallow clone, refreshed per TTL (default 24h)
+- `owner/repo/` -- shallow git clone, refreshed on every install
+- `<https-domain>/` -- well-known HTTPS cache, refreshed after a 24-hour TTL
 
 Git operations (all non-interactive: `GIT_TERMINAL_PROMPT=0`, SSH `BatchMode=yes`):
 - Initial: `git clone --depth=1`
@@ -590,7 +590,7 @@ A valid skill directory must contain:
 - `SKILL.md` with YAML frontmatter (delimited by `---`)
 - Frontmatter must include `name` (string) and `description` (string)
 
-The YAML frontmatter is parsed with a minimal key-value parser (no external YAML dependency). Supports simple `key: value` pairs and quoted values.
+The YAML frontmatter is parsed with the `yaml` package. `allowed-tools` can be a space-delimited string or a YAML list.
 
 ---
 
@@ -676,73 +676,54 @@ For each target in the array, dotagents creates `<target>/skills/ -> .agents/ski
 
 ```
 dotagents/
-  AGENTS.md                # Agent instructions
-  CLAUDE.md -> AGENTS.md   # Symlink
-  agents.toml              # Self-dogfooding
-  agents.lock              # Tracks managed skills (gitignored)
-  warden.toml              # Warden config for code analysis
-  package.json
-  tsconfig.json
-  vitest.config.ts
-  .gitignore
+  AGENTS.md                  # Agent instructions
+  CLAUDE.md -> AGENTS.md     # Symlink
+  agents.toml                # Self-dogfooding
+  agents.lock                # Tracks managed skills (gitignored)
+  warden.toml                # Warden config for code analysis
+  package.json               # pnpm workspace root
+  pnpm-workspace.yaml
   specs/
-    SPEC.md                # This file
-  src/
-    index.ts               # Library entry point (re-exports all modules)
-    scope.ts               # Project/user scope resolution
-    cli/
-      index.ts             # CLI entry point, command routing
-      commands/
-        init.ts
-        install.ts
-        add.ts
-        remove.ts
-        sync.ts
-        list.ts
-        mcp.ts
-    agents/
-      types.ts             # McpDeclaration, AgentDefinition interfaces
-      registry.ts          # Agent registry (claude, cursor, codex, vscode, opencode)
-      definitions/         # Per-agent definitions (claude.ts, cursor.ts, etc.)
-      mcp-writer.ts        # MCP config file generation per agent
-      hook-writer.ts       # Hook config file generation per agent
-      paths.ts             # Agent config path resolution
-      errors.ts            # Agent-specific error types
-      index.ts             # Re-exports
-    config/
-      schema.ts            # Zod schemas for agents.toml
-      loader.ts            # TOML parse + validate
-      writer.ts            # TOML modification (add/remove skills, MCP, hooks)
-      index.ts             # Re-exports
-    lockfile/
-      schema.ts            # Zod schemas for agents.lock
-      loader.ts            # Parse + validate lockfile
-      writer.ts            # Serialize lockfile (deterministic sorting)
-      index.ts             # Re-exports
-    skills/
-      loader.ts            # Parse SKILL.md YAML frontmatter
-      discovery.ts         # Scan conventional dirs + marketplace format
-      resolver.ts          # Source specifier -> resolved skill on disk
-      index.ts             # Re-exports
-    sources/
-      git.ts               # Git clone/fetch/checkout (shallow, non-interactive)
-      local.ts             # Local path resolution
-      cache.ts             # Global cache (~/.local/dotagents/) with TTL
-      index.ts             # Re-exports
-    symlinks/
-      manager.ts           # Create/verify/repair symlinks, directory migration
-      index.ts             # Re-exports
-    trust/
-      validator.ts         # Trust policy enforcement
-      index.ts             # Re-exports
-    gitignore/
-      writer.ts            # Generate .agents/.gitignore
-      index.ts             # Re-exports
-    utils/
-      exec.ts              # Child process execution (non-interactive git)
-      hash.ts              # Deterministic SHA-256 directory hashing
-      fs.ts                # copyDir helper
-      index.ts             # Re-exports
+    SPEC.md                  # This file
+  docs/                      # Next.js docs site
+  packages/
+    dotagents/               # @sentry/dotagents CLI and host library
+      src/
+        index.ts             # Host public API re-exports
+        scope.ts             # Project/user scope resolution
+        cli/
+          index.ts           # CLI entry point, command routing
+          update-notifier.ts # npm update check
+          commands/
+            init.ts
+            install.ts
+            add.ts
+            remove.ts
+            sync.ts
+            list.ts
+            mcp.ts
+            trust.ts
+            doctor.ts
+        agents/
+          types.ts           # McpDeclaration, AgentDefinition interfaces
+          registry.ts        # Agent registry (claude, cursor, codex, vscode, opencode)
+          definitions/       # Per-agent definitions
+          mcp-writer.ts      # MCP config file generation per agent
+          hook-writer.ts     # Hook config file generation per agent
+          paths.ts           # Agent config path resolution
+          errors.ts          # Agent-specific error types
+        config/              # agents.toml schema, loader, writer
+        lockfile/            # agents.lock schema, loader, writer
+        symlinks/            # Symlink create/verify/repair
+        gitignore/           # .agents/.gitignore generation
+        utils/               # Host-local helpers
+    dotagents-lib/           # @sentry/dotagents-lib reusable core
+      src/
+        index.ts             # Library public API
+        skills/              # SKILL.md loader, discovery, resolver
+        sources/             # git, cache, local, well-known source handling
+        trust/               # Trust policy validation
+        utils/               # exec and filesystem helpers
 ```
 
 ## Dependencies
@@ -755,6 +736,7 @@ dotagents/
 | `zod` | Runtime schema validation (v4, imported as `zod/v4`) |
 | `chalk` | Terminal colors |
 | `@clack/prompts` | Interactive CLI prompts |
+| `yaml` | SKILL.md frontmatter parsing in `@sentry/dotagents-lib` |
 
 ### Dev
 
@@ -768,38 +750,30 @@ dotagents/
 | `lint-staged` | Run oxlint on staged files |
 | `@types/node` | Node.js type definitions |
 
-No git library -- uses `git` CLI directly with non-interactive mode. No YAML library -- uses minimal key-value parser for SKILL.md frontmatter.
+No git library -- dotagents uses the `git` CLI directly with non-interactive mode. SKILL.md frontmatter is parsed with the `yaml` package.
 
 ## Build and Distribution
 
-### Current (Development)
+### Development
 
 ```bash
 pnpm dev -- init          # Run via tsx
-npx tsx src/cli/index.ts  # Direct execution
+npx tsx packages/dotagents/src/cli/index.ts  # Direct execution
 ```
 
-### Planned (Bun Compile)
-
-Standalone binary with no runtime dependencies:
+### Package Build
 
 ```bash
-bun build src/cli/index.ts --compile --outfile dist/dotagents
+pnpm build
 ```
 
-### Platform Matrix
+Both workspace packages build TypeScript into `dist/`. The CLI package exposes `dist/cli/index.js` as the `dotagents` binary.
 
-Build per-platform binaries via GitHub Actions:
+### Distribution
 
-| Platform | Target |
-|----------|--------|
-| macOS arm64 | `darwin-arm64` |
-| macOS x64 | `darwin-x64` |
-| Linux x64 | `linux-x64` |
-| Linux arm64 | `linux-arm64` |
+npm is the supported distribution channel:
 
-### Distribution Channels
-
-1. **GitHub Releases**: Per-platform binaries attached to releases
-2. **Install script**: `curl -fsSL https://dotagents.dev/install.sh | sh` (detects platform, downloads binary)
-3. **npm** (fallback): `npx dotagents` for users with Node.js
+```bash
+npm install -g @sentry/dotagents
+npx @sentry/dotagents <command>
+```


### PR DESCRIPTION
Update dotagents docs and bundled skill references to match the current CLI behavior: `install` is the refresh path, and there is no `update` command. This also brings source-format, lockfile, caching, and SPEC distribution docs in line with the current code.

**Current CLI Surface**

Document `install` as install/refresh, remove public `install --force` references, and clarify git versus well-known HTTPS cache behavior.

**Schema and Architecture Docs**

Add current references for well-known HTTPS sources, minimum release age, `resolved_commit`, YAML frontmatter parsing, and the workspace package layout.

Refs GH-99