### PR TITLE
fix(lib): Serialize git cache updates

### DIFF
--- a/packages/dotagents-lib/src/sources/cache.test.ts
+++ b/packages/dotagents-lib/src/sources/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ensureCached, validateCacheKey, CacheError } from "./cache.js";
@@ -81,6 +81,50 @@ describe("ensureCached", () => {
 
     expect(second.commit).toBe(latestCommit);
     expect(second.commit).not.toBe(first.commit);
+  });
+
+  it("serializes concurrent first-time clones for the same cache key", async () => {
+    await writeFile(join(repoDir, "README.md"), "first\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+    const { stdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const latestCommit = stdout.trim();
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        ensureCached({
+          stateDir,
+          url: remoteDir,
+          cacheKey: "test/repo",
+        }),
+      ),
+    );
+
+    expect(results.map((result) => result.commit)).toEqual(
+      Array.from({ length: 5 }, () => latestCommit),
+    );
+  });
+
+  it("replaces stale non-git cache directories before cloning", async () => {
+    await writeFile(join(repoDir, "README.md"), "first\n");
+    await exec("git", ["add", "README.md"], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "initial"], { cwd: repoDir });
+    await exec("git", ["push", "origin", "main"], { cwd: repoDir });
+    const { stdout } = await exec("git", ["rev-parse", "HEAD"], { cwd: repoDir });
+    const latestCommit = stdout.trim();
+
+    const staleDir = join(stateDir, "test", "repo");
+    await mkdir(staleDir, { recursive: true });
+    await writeFile(join(staleDir, "partial-clone"), "stale\n");
+
+    const result = await ensureCached({
+      stateDir,
+      url: remoteDir,
+      cacheKey: "test/repo",
+    });
+
+    expect(result.commit).toBe(latestCommit);
   });
 
   it("refreshes an unpinned cache after a pinned ref fetch", async () => {

--- a/packages/dotagents-lib/src/sources/cache.ts
+++ b/packages/dotagents-lib/src/sources/cache.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { clone, fetchAndReset, fetchRef, headCommit, headCommitDate, findCommitOlderThan, checkout, isGitRepo } from "./git.js";
 
 export class CacheError extends Error {
@@ -63,6 +63,29 @@ export interface CacheResult {
   commit: string;
 }
 
+const cacheLocks = new Map<string, Promise<void>>();
+
+async function withCacheLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = cacheLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const next = previous.catch(() => {}).then(() => current);
+
+  cacheLocks.set(key, next);
+  await previous.catch(() => {});
+
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (cacheLocks.get(key) === next) {
+      cacheLocks.delete(key);
+    }
+  }
+}
+
 /**
  * Get or populate the global cache for a git source.
  *
@@ -89,40 +112,43 @@ export async function ensureCached(opts: {
   validateCacheKey(opts.cacheKey);
   const repoDir = join(opts.stateDir, opts.cacheKey);
 
-  if (isGitRepo(repoDir)) {
-    if (opts.ref) {
-      await fetchRef(repoDir, opts.ref);
-    } else {
-      await fetchAndReset(repoDir);
-    }
-  } else {
-    // Not cached yet — clone
-    await mkdir(join(opts.stateDir, opts.cacheKey, ".."), { recursive: true });
-    await clone(opts.url, repoDir, opts.ref);
-  }
-
-  // Age gate: reject or resolve to an older commit when HEAD is too new
-  if (opts.minimumReleaseAge) {
-    const age = minutesOld(await headCommitDate(repoDir));
-    if (age < opts.minimumReleaseAge) {
+  return withCacheLock(repoDir, async () => {
+    if (isGitRepo(repoDir)) {
       if (opts.ref) {
-        // Pinned skill — can't resolve to a different commit, just reject
-        throw new CacheError(
-          `ref "${opts.ref}" is ${Math.floor(age)} minutes old, minimum_release_age requires ${opts.minimumReleaseAge}`,
-        );
+        await fetchRef(repoDir, opts.ref);
+      } else {
+        await fetchAndReset(repoDir);
       }
-      const older = await findCommitOlderThan(repoDir, opts.minimumReleaseAge);
-      if (!older) {
-        throw new CacheError(
-          `minimum_release_age is ${opts.minimumReleaseAge} minutes but no commit that old exists in ${opts.cacheKey}`,
-        );
-      }
-      await checkout(repoDir, older);
+    } else {
+      // Remove an interrupted or stale non-git cache dir before cloning.
+      await rm(repoDir, { recursive: true, force: true });
+      await mkdir(join(opts.stateDir, opts.cacheKey, ".."), { recursive: true });
+      await clone(opts.url, repoDir, opts.ref);
     }
-  }
 
-  const commit = await headCommit(repoDir);
-  return { repoDir, commit };
+    // Age gate: reject or resolve to an older commit when HEAD is too new
+    if (opts.minimumReleaseAge) {
+      const age = minutesOld(await headCommitDate(repoDir));
+      if (age < opts.minimumReleaseAge) {
+        if (opts.ref) {
+          // Pinned skill — can't resolve to a different commit, just reject
+          throw new CacheError(
+            `ref "${opts.ref}" is ${Math.floor(age)} minutes old, minimum_release_age requires ${opts.minimumReleaseAge}`,
+          );
+        }
+        const older = await findCommitOlderThan(repoDir, opts.minimumReleaseAge);
+        if (!older) {
+          throw new CacheError(
+            `minimum_release_age is ${opts.minimumReleaseAge} minutes but no commit that old exists in ${opts.cacheKey}`,
+          );
+        }
+        await checkout(repoDir, older);
+      }
+    }
+
+    const commit = await headCommit(repoDir);
+    return { repoDir, commit };
+  });
 }
 
 function minutesOld(date: Date): number {


### PR DESCRIPTION
Serialize dotagents-lib cache updates per repository path so parallel callers cannot clone into the same empty destination at the same time. This fixes the Warden regression where concurrent trigger startup could fail with `fatal: destination path ... already exists and is not an empty directory` after adopting the async dotagents cache path.

**Cache Recovery**

`ensureCached` now removes stale non-git cache directories before cloning, which lets a later call recover from an interrupted or partial clone instead of failing permanently on the leftover directory.

Fixes WARDEN-M