### PR TITLE
fix(agents): Skip unchanged MCP config writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,13 +76,3 @@ pnpm check
 ```
 
 Or individually: `pnpm lint && pnpm typecheck && pnpm test`
-
-## Before Creating a PR
-
-Run warden to check for bugs and code quality issues:
-
-```bash
-warden
-```
-
-The `warden-skill` is available in this project (installed via dotagents) and provides guidance on warden configuration and usage.

--- a/packages/dotagents/src/agents/mcp-writer.test.ts
+++ b/packages/dotagents/src/agents/mcp-writer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { existsSync } from "node:fs";
@@ -235,6 +235,20 @@ describe("writeMcpConfigs", () => {
     expect(content.mcp.github).toBeDefined();
     // User's custom server should NOT be deleted
     expect(content.mcp["my-custom-server"]).toEqual({ type: "local", command: ["my-tool"] });
+  });
+
+  it("does not rewrite unchanged shared config files", async () => {
+    const filePath = join(dir, ".claude.json");
+    const resolver = () => ({ filePath, shared: true });
+
+    await writeMcpConfigs(["claude"], [HTTP_SERVER], resolver);
+    const first = await stat(filePath, { bigint: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await writeMcpConfigs(["claude"], [HTTP_SERVER], resolver);
+    const second = await stat(filePath, { bigint: true });
+
+    expect(second.mtimeNs).toBe(first.mtimeNs);
   });
 
   it("interpolates env refs in claude HTTP headers/URL with ${VAR} syntax", async () => {

--- a/packages/dotagents/src/agents/mcp-writer.ts
+++ b/packages/dotagents/src/agents/mcp-writer.ts
@@ -39,8 +39,9 @@ export function projectMcpResolver(projectRoot: string): McpTargetResolver {
 
 /**
  * Write MCP config files for each agent.
- * - Dedicated files (shared=false): written fresh each time.
- * - Shared files (shared=true): read existing, merge dotagents servers under the root key, write back.
+ * - Dedicated files (shared=false): generated from scratch.
+ * - Shared files (shared=true): read existing and merge dotagents servers under the root key.
+ * - Files are only written when the serialized output changes.
  */
 export async function writeMcpConfigs(
   agentIds: string[],
@@ -131,7 +132,7 @@ async function freshWrite(
   servers: Record<string, unknown>,
 ): Promise<void> {
   const doc = { [spec.rootKey]: servers };
-  await writeFile(filePath, serialize(doc, spec.format), "utf-8");
+  await writeFileIfChanged(filePath, serialize(doc, spec.format));
 }
 
 async function mergeWrite(
@@ -142,7 +143,7 @@ async function mergeWrite(
   const existing = existsSync(filePath) ? await readExisting(filePath, spec) : {};
   const prev = (existing[spec.rootKey] ?? {}) as Record<string, unknown>;
   existing[spec.rootKey] = { ...prev, ...servers };
-  await writeFile(filePath, serialize(existing, spec.format), "utf-8");
+  await writeFileIfChanged(filePath, serialize(existing, spec.format));
 }
 
 async function readExisting(
@@ -161,4 +162,18 @@ function serialize(doc: Record<string, unknown>, format: "json" | "toml"): strin
     return `${tomlStringify(doc)}\n`;
   }
   return `${JSON.stringify(doc, null, 2)}\n`;
+}
+
+async function writeFileIfChanged(filePath: string, content: string): Promise<void> {
+  try {
+    if ((await readFile(filePath, "utf-8")) === content) {return;}
+  } catch (err) {
+    if (!isNotFoundError(err)) {throw err;}
+  }
+
+  await writeFile(filePath, content, "utf-8");
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
 }


### PR DESCRIPTION
Skip rewriting MCP config files when dotagents regenerates the same serialized config.

The user-scope Claude MCP target is a shared file at `~/.claude.json`; before this change, `install` merged the same servers and called `writeFile` anyway, updating the file mtime on no-op installs. The writer now compares serialized output with existing file content and only writes when bytes change. This also applies to dedicated MCP configs.

This adds a regression test that exercises a shared Claude-style target and asserts the mtime is preserved on an unchanged second write.

Also removes outdated extra PR preflight guidance from `AGENTS.md`, leaving `pnpm check` as the local verification path.

Fixes #102