### PR TITLE
chore: Use Warden code-review skill

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -6,8 +6,7 @@ reportOn = "medium"
 ignorePaths = ["dist/**"]
 
 [[skills]]
-name = "find-bugs"
-remote = "getsentry/skills"
+name = "code-review"
 paths = ["packages/*/src/**/*.ts"]
 ignorePaths = ["packages/*/src/**/*.test.ts"]
 


### PR DESCRIPTION
Switch Warden pull request analysis from the old find-bugs skill to the built-in code-review skill. The existing package source path filter and test-file ignore remain unchanged, so the trigger scope stays the same while using Warden's upstream review behavior.