### PR TITLE
feat(skills): Add dotagents QA skill

### DIFF
--- a/.agents/skills/dotagents-qa
+++ b/.agents/skills/dotagents-qa
@@ -1,0 +1,1 @@
+../../skills/dotagents-qa

--- a/skills/dotagents-qa/SKILL.md
+++ b/skills/dotagents-qa/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: dotagents-qa
+description: QA dotagents behavior changes with a local fixture project. Use when changes may affect dotagents install, sync, list, doctor, skill placement, agent symlinks, MCP or hook config generation, user scope, or package/runtime behavior and an agent needs to prove a representative agents.toml setup still installs correctly.
+---
+
+# dotagents QA
+
+Answer the practical question: "With this local dotagents build, does a representative `agents.toml` still install and wire the expected files?"
+
+## Workflow
+
+1. Inspect the changed surface:
+   - `git status --short`
+   - `git diff --stat`
+   - `git diff -- <paths>`
+2. Build the local CLI before smoke testing:
+
+```bash
+pnpm build
+```
+
+3. Create a temp project that exercises the changed behavior. Start here and add only what the change needs.
+
+```bash
+set -euo pipefail
+REPO="$(pwd)"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/local-skills" "$TMP/home" "$TMP/state"
+for skill in review commit; do
+  mkdir -p "$TMP/local-skills/$skill"
+  printf -- "---\nname: %s\ndescription: Fixture %s skill.\n---\n\n%s fixture.\n" \
+    "$skill" "$skill" "$skill" > "$TMP/local-skills/$skill/SKILL.md"
+done
+
+cat > "$TMP/agents.toml" <<'EOF'
+version = 1
+agents = ["claude", "cursor"]
+
+[[skills]]
+name = "review"
+source = "path:./local-skills/review"
+
+[[skills]]
+name = "commit"
+source = "path:./local-skills/commit"
+
+[[mcp]]
+name = "fixture"
+command = "node"
+args = ["-e", "process.exit(0)"]
+
+[[hooks]]
+event = "Stop"
+command = "echo fixture"
+EOF
+```
+
+4. Run the local CLI from inside the temp project, with home/cache isolated:
+
+```bash
+set -euo pipefail
+export HOME="$TMP/home" DOTAGENTS_STATE_DIR="$TMP/state"
+cd "$TMP"
+node "$REPO/packages/dotagents/dist/cli/index.js" install
+node "$REPO/packages/dotagents/dist/cli/index.js" list > "$TMP/list.out"
+node "$REPO/packages/dotagents/dist/cli/index.js" doctor --fix
+node "$REPO/packages/dotagents/dist/cli/index.js" doctor
+```
+
+5. Assert the behavior that matters:
+
+```bash
+set -euo pipefail
+grep -q "review" "$TMP/list.out" && grep -q "commit" "$TMP/list.out"
+test -f .agents/skills/review/SKILL.md && test -f .agents/skills/commit/SKILL.md
+test -L .claude/skills
+test -f .mcp.json
+test -f .cursor/mcp.json
+test -f .claude/settings.json
+test -f .cursor/hooks.json
+```
+
+For `sync` changes, break generated state and assert repair:
+
+```bash
+set -euo pipefail
+rm .mcp.json .claude/skills
+node "$REPO/packages/dotagents/dist/cli/index.js" sync
+test -f .mcp.json
+test -L .claude/skills
+```
+
+## Adjust The Fixture
+
+- Skill resolution changes: use multiple local skills, nested `skills/` directories, or the exact `path:` layout touched by the change.
+- Agent placement changes: edit `agents = [...]` and assert expected symlinks/config files.
+- MCP or hook changes: include representative `[[mcp]]` or `[[hooks]]` entries and inspect generated JSON/TOML.
+- User-scope changes: set `DOTAGENTS_HOME="$TMP/user-home"` and pass `--user`; never write to the real home directory.
+- Package/runtime changes: run the built CLI as above, or pack/install the package only when the packaging path itself changed.
+- Remote source changes: use `getsentry/skills`; avoid remotes for ordinary install-location checks.
+
+## Optional Agent CLI Checks
+
+Use only when discovery/registration changed.
+
+```bash
+set -euo pipefail
+mkdir -p "$TMP/codex-home"
+CODEX_HOME="$TMP/codex-home" codex debug prompt-input "probe skills" > "$TMP/codex-prompt.json"
+grep -q "review" "$TMP/codex-prompt.json"
+```
+
+Claude: no cheap dry-run skill list. If auth/network/model cost is acceptable, run a minimal non-interactive `/skill-name` prompt from `$TMP`; otherwise report skipped.
+
+## Optional Remote Check
+
+Use only when source resolution, trust, git, well-known, or network behavior changed.
+
+```toml
+[[skills]]
+name = "code-review"
+source = "getsentry/skills"
+```
+
+Run `pnpm check` after the smoke test unless there is a concrete reason to run only a targeted package check.
+
+## Report
+
+Include the temp path if it remains for debugging, the exact fixture shape, commands run, assertions made, and any skipped checks.

--- a/skills/dotagents-qa/SOURCES.md
+++ b/skills/dotagents-qa/SOURCES.md
@@ -1,0 +1,30 @@
+# dotagents QA Sources
+
+## Source Inventory
+
+| Source | Contribution |
+|--------|--------------|
+| `AGENTS.md` | pnpm and validation conventions |
+| `package.json` | `pnpm build` and `pnpm check` scripts |
+| `specs/SPEC.md` | canonical `.agents/skills/`, agent symlink, MCP, hook, install, sync, list, and doctor behavior |
+| `packages/dotagents/src/agents/definitions/claude.ts` | Claude project skills and generated config paths |
+| `packages/dotagents/src/agents/definitions/cursor.ts` | Cursor shares `.claude/skills` and writes Cursor-specific MCP/hook config |
+| `packages/dotagents/src/cli/cache.ts` | `DOTAGENTS_STATE_DIR` cache isolation |
+| `packages/dotagents/src/cli/update-notifier.ts` | `HOME` isolation for update-check cache |
+| `skills/dotagents/SKILL.md` | sibling skill layout |
+| local `codex debug prompt-input` probe | verifies Codex can expose `.agents/skills` metadata without a model call |
+
+## Decisions
+
+- Keep the runtime skill as an inline smoke-test guide rather than a broad QA matrix.
+- Use local `path:` skills by default so the fixture tests dotagents wiring without network/trust noise.
+- Build first and run `packages/dotagents/dist/cli/index.js` from inside the temp project.
+- Include representative local skills, agents, MCP, and hooks because those cover the main generated outputs.
+- Expose the skill through `.agents/skills/dotagents-qa` so existing Claude/Cursor symlinks discover it.
+- Keep agent CLI registration and remote-source checks optional because they add auth, network, or tool-version variance.
+
+## Trigger Notes
+
+Should trigger for requests like "QA this dotagents install change", "test dotagents in a temp project", "verify skill placement", and "make sure sync still repairs generated files".
+
+Should not trigger for general dotagents usage help or unrelated project QA.

--- a/skills/dotagents-qa/SPEC.md
+++ b/skills/dotagents-qa/SPEC.md
@@ -1,0 +1,33 @@
+# dotagents QA Specification
+
+## Intent
+
+Provide a concise workflow for proving that local dotagents changes still install a representative `agents.toml` setup into the expected project locations.
+
+## Scope
+
+In scope:
+- building and running the local dotagents CLI
+- creating disposable project fixtures with local skill sources
+- verifying `.agents/skills/`, agent skills symlinks, MCP configs, hook configs, `list`, `doctor`, and `sync`
+- optionally checking agent CLI registration when discovery paths changed
+- optionally using `getsentry/skills` for remote source behavior
+- isolating home and cache state during smoke tests
+
+Out of scope:
+- release publishing
+- network-backed source testing for ordinary install-location changes
+- replacing focused Vitest regression coverage for logic bugs
+
+## Runtime Contract
+
+- Start from the changed dotagents behavior and customize the fixture only as needed.
+- Run the built CLI from inside the temp project so project scope resolves correctly.
+- Isolate `HOME`, `DOTAGENTS_STATE_DIR`, and `DOTAGENTS_HOME` for user-scope checks.
+- Report fixture shape, commands, assertions, skipped checks, and residual risk.
+
+## Maintenance
+
+- Keep `SKILL.md` focused on temp-project smoke testing.
+- Update the fixture when dotagents changes config fields, generated file locations, or supported agents.
+- Add scripts only if the same fixture becomes stable enough to automate.


### PR DESCRIPTION
Adds a `dotagents-qa` project skill focused on the main local QA question for this repo: after changing dotagents behavior, does a representative `agents.toml` fixture still install and wire the expected files?

The skill centers on a disposable local project that installs two local `path:` skills, configures Claude/Cursor, writes representative MCP and hook declarations, runs the built local CLI, checks `list` and `doctor`, and intentionally breaks generated state to verify `sync` repairs it. The fixture keeps `HOME` and `DOTAGENTS_STATE_DIR` inside the temp directory so smoke tests do not touch the real user environment.

It also keeps optional checks concise: use Codex or Claude CLI probes only when discovery/registration paths changed, and use `getsentry/skills` only when remote source, trust, git, well-known, or network behavior is in scope. The skill source lives under `skills/dotagents-qa` and is exposed through `.agents/skills/dotagents-qa`, so Claude and Cursor discover it through the existing skills symlinks.

Validated with the skill structural validator, the documented temp-project smoke flow including the optional Codex probe, and `pnpm check`.
