### PR TITLE
test: Disable signing in temp git repos

### DIFF
--- a/packages/dotagents-lib/src/skills/resolver.integration.test.ts
+++ b/packages/dotagents-lib/src/skills/resolver.integration.test.ts
@@ -5,6 +5,13 @@ import { tmpdir } from "node:os";
 import { resolveSkill, resolveWildcardSkills } from "./resolver.js";
 import { exec } from "../utils/exec.js";
 
+async function initTestGitRepo(repoDir: string): Promise<void> {
+  await exec("git", ["init"], { cwd: repoDir });
+  await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+  await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+  await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
+}
+
 /**
  * Integration tests that use real git operations.
  * These create local git repos to test the full resolve pipeline.
@@ -27,9 +34,7 @@ describe("resolveSkill integration", () => {
     // Point cache to temp dir
     // Create a local git repo that looks like a skill repository
     await mkdir(repoDir, { recursive: true });
-    await exec("git", ["init"], { cwd: repoDir });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await initTestGitRepo(repoDir);
 
     // Create a skill at the root level
     await mkdir(join(repoDir, "pdf"), { recursive: true });
@@ -179,9 +184,7 @@ describe("resolveWildcardSkills integration", () => {
 
     // Create a local git repo with multiple skills
     await mkdir(repoDir, { recursive: true });
-    await exec("git", ["init"], { cwd: repoDir });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await initTestGitRepo(repoDir);
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(

--- a/packages/dotagents-lib/src/sources/cache.test.ts
+++ b/packages/dotagents-lib/src/sources/cache.test.ts
@@ -5,6 +5,12 @@ import { tmpdir } from "node:os";
 import { ensureCached, validateCacheKey, CacheError } from "./cache.js";
 import { exec } from "../utils/exec.js";
 
+async function configureTestGitRepo(repoDir: string): Promise<void> {
+  await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+  await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+  await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
+}
+
 describe("validateCacheKey", () => {
   it.each([
     ["empty string", ""],
@@ -45,8 +51,7 @@ describe("ensureCached", () => {
 
     await exec("git", ["init", "--bare", "--initial-branch=main", remoteDir]);
     await exec("git", ["clone", remoteDir, repoDir]);
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await configureTestGitRepo(repoDir);
   });
 
   afterEach(async () => {

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -39,6 +39,7 @@ describe("runAdd", () => {
       cwd: repoDir,
     });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
@@ -235,6 +236,7 @@ describe("runAdd", () => {
       cwd: singleRepo,
     });
     await exec("git", ["config", "user.name", "Test"], { cwd: singleRepo });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: singleRepo });
     await mkdir(join(singleRepo, "only-skill"), { recursive: true });
     await writeFile(
       join(singleRepo, "only-skill", "SKILL.md"),
@@ -439,6 +441,7 @@ describe("add() CLI parsing", () => {
       cwd: repoDir,
     });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));

--- a/packages/dotagents/src/cli/commands/doctor.test.ts
+++ b/packages/dotagents/src/cli/commands/doctor.test.ts
@@ -108,6 +108,7 @@ describe("runDoctor", () => {
     execSync("git init", { cwd: projectRoot, stdio: "ignore" });
     execSync("git config user.email test@test.com", { cwd: projectRoot, stdio: "ignore" });
     execSync("git config user.name test", { cwd: projectRoot, stdio: "ignore" });
+    execSync("git config commit.gpgsign false", { cwd: projectRoot, stdio: "ignore" });
 
     await writeFile(join(projectRoot, "agents.toml"), "version = 1\n");
     await writeFile(join(projectRoot, "agents.lock"), "version = 1\n");

--- a/packages/dotagents/src/cli/commands/install.test.ts
+++ b/packages/dotagents/src/cli/commands/install.test.ts
@@ -27,6 +27,13 @@ description: Review code for correctness.
 Review the current diff.
 `;
 
+async function initTestGitRepo(repoDir: string): Promise<void> {
+  await exec("git", ["init"], { cwd: repoDir });
+  await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+  await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+  await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
+}
+
 describe("runInstall", () => {
   let tmpDir: string;
   let stateDir: string;
@@ -52,9 +59,7 @@ describe("runInstall", () => {
     if (repoInitialized) {return;}
 
     await mkdir(repoDir, { recursive: true });
-    await exec("git", ["init"], { cwd: repoDir });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await initTestGitRepo(repoDir);
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
@@ -998,9 +1003,7 @@ path = "reviewer.md"
     // Create a second repo that also has a "pdf" skill
     const repoDir2 = join(tmpDir, "repo2");
     await mkdir(repoDir2, { recursive: true });
-    await exec("git", ["init"], { cwd: repoDir2 });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir2 });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir2 });
+    await initTestGitRepo(repoDir2);
     await mkdir(join(repoDir2, "pdf"), { recursive: true });
     await writeFile(join(repoDir2, "pdf", "SKILL.md"), SKILL_MD("pdf"));
     await exec("git", ["add", "."], { cwd: repoDir2 });
@@ -1055,9 +1058,7 @@ path = "reviewer.md"
     // Create a second repo with a "helper" skill
     const repoDir2 = join(tmpDir, "repo2");
     await mkdir(repoDir2, { recursive: true });
-    await exec("git", ["init"], { cwd: repoDir2 });
-    await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir2 });
-    await exec("git", ["config", "user.name", "Test"], { cwd: repoDir2 });
+    await initTestGitRepo(repoDir2);
     await mkdir(join(repoDir2, "helper"), { recursive: true });
     await writeFile(join(repoDir2, "helper", "SKILL.md"), SKILL_MD("helper"));
     await exec("git", ["add", "."], { cwd: repoDir2 });

--- a/packages/dotagents/src/cli/commands/remove.test.ts
+++ b/packages/dotagents/src/cli/commands/remove.test.ts
@@ -38,6 +38,7 @@ describe("runRemove", () => {
     await exec("git", ["init"], { cwd: repoDir });
     await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
@@ -179,6 +180,7 @@ describe("runRemoveSource", () => {
     await exec("git", ["init"], { cwd: repoDir });
     await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
     await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
 
     await mkdir(join(repoDir, "pdf"), { recursive: true });
     await writeFile(join(repoDir, "pdf", "SKILL.md"), SKILL_MD("pdf"));
@@ -194,6 +196,7 @@ describe("runRemoveSource", () => {
     await exec("git", ["init"], { cwd: otherRepoDir });
     await exec("git", ["config", "user.email", "test@test.com"], { cwd: otherRepoDir });
     await exec("git", ["config", "user.name", "Test"], { cwd: otherRepoDir });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: otherRepoDir });
 
     await mkdir(join(otherRepoDir, "deploy"), { recursive: true });
     await writeFile(join(otherRepoDir, "deploy", "SKILL.md"), SKILL_MD("deploy"));

--- a/packages/dotagents/src/cli/commands/sync.test.ts
+++ b/packages/dotagents/src/cli/commands/sync.test.ts
@@ -199,6 +199,7 @@ describe("runSync", () => {
     await exec("git", ["init"], { cwd: skillRepo });
     await exec("git", ["config", "user.email", "test@example.com"], { cwd: skillRepo });
     await exec("git", ["config", "user.name", "Test User"], { cwd: skillRepo });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: skillRepo });
     await mkdir(join(skillRepo, "pdf"), { recursive: true });
     await writeFile(join(skillRepo, "pdf", "SKILL.md"), SKILL_MD("pdf"));
     await exec("git", ["add", "."], { cwd: skillRepo });
@@ -209,6 +210,7 @@ describe("runSync", () => {
     await exec("git", ["init", "-b", "main"], { cwd: projectSeed });
     await exec("git", ["config", "user.email", "test@example.com"], { cwd: projectSeed });
     await exec("git", ["config", "user.name", "Test User"], { cwd: projectSeed });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: projectSeed });
     await writeFile(
       join(projectSeed, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${skillRepo}"\n`,
@@ -224,6 +226,8 @@ describe("runSync", () => {
     await exec("git", ["config", "user.name", "Alice"], { cwd: aliceRepo });
     await exec("git", ["config", "user.email", "bob@example.com"], { cwd: bobRepo });
     await exec("git", ["config", "user.name", "Bob"], { cwd: bobRepo });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: aliceRepo });
+    await exec("git", ["config", "commit.gpgsign", "false"], { cwd: bobRepo });
 
     try {
       process.env["DOTAGENTS_STATE_DIR"] = aliceStateDir;

--- a/packages/dotagents/src/symlinks/manager.test.ts
+++ b/packages/dotagents/src/symlinks/manager.test.ts
@@ -107,6 +107,7 @@ describe("symlinks", () => {
         cwd: dir,
       });
       await exec("git", ["config", "user.name", "Test"], { cwd: dir });
+      await exec("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
 
       // Create a real skills directory with a committed file
       const targetDir = join(dir, ".claude");


### PR DESCRIPTION
Temp git repositories created by the test suite now opt out of commit signing before tests call git commit. This keeps local developer signing settings from leaking into fixtures and causing unrelated failures or hangs when a signing key/helper is not available.