### PR TITLE
fix(install): Write lockfile after canonical install

### DIFF
--- a/packages/dotagents/src/cli/commands/install.test.ts
+++ b/packages/dotagents/src/cli/commands/install.test.ts
@@ -8,6 +8,7 @@ import { runSync } from "./sync.js";
 import { exec } from "@sentry/dotagents-lib";
 import { loadLockfile } from "../../lockfile/loader.js";
 import { writeLockfile } from "../../lockfile/writer.js";
+import type { Lockfile } from "../../lockfile/schema.js";
 import { resolveScope } from "../../scope.js";
 import { DOTAGENTS_SUBAGENT_MARKER } from "../../agents/definitions/helpers.js";
 
@@ -423,7 +424,7 @@ path = "code-reviewer.md"
     expect(syncResult.adopted).toEqual([]);
   });
 
-  it("updates skill lock entries when installed subagent writes fail", async () => {
+  it("does not update the lockfile when installed subagent writes fail", async () => {
     const skillSourceDir = join(projectRoot, "local-skills", "pdf");
     await mkdir(skillSourceDir, { recursive: true });
     await writeFile(join(skillSourceDir, "SKILL.md"), SKILL_MD("pdf"));
@@ -438,7 +439,7 @@ path = "code-reviewer.md"
       "hand-written subagent\n",
       "utf-8",
     );
-    await writeLockfile(join(projectRoot, "agents.lock"), {
+    const originalLockfile: Lockfile = {
       version: 1,
       skills: {},
       subagents: {
@@ -452,7 +453,8 @@ path = "code-reviewer.md"
           source: "path:old-agents",
         },
       },
-    });
+    };
+    await writeLockfile(join(projectRoot, "agents.lock"), originalLockfile);
 
     await writeFile(
       join(projectRoot, "agents.toml"),
@@ -475,58 +477,11 @@ path = "code-reviewer.md"
     );
 
     const lockfile = await loadLockfile(join(projectRoot, "agents.lock"));
-    expect(lockfile!.skills["pdf"]).toBeDefined();
-    expect(lockfile!.subagents["code-reviewer"]).toBeUndefined();
-    expect(lockfile!.subagents["old-reviewer"]).toBeUndefined();
+    expect(lockfile).toEqual(originalLockfile);
     expect(existsSync(join(projectRoot, ".agents", "skills", "pdf", "SKILL.md"))).toBe(true);
   });
 
-  it("preserves the original install error when fallback lockfile write fails", async () => {
-    const skillSourceDir = join(projectRoot, "local-skills", "pdf");
-    await mkdir(skillSourceDir, { recursive: true });
-    await writeFile(join(skillSourceDir, "SKILL.md"), SKILL_MD("pdf"));
-
-    const sourceDir = join(projectRoot, "agents");
-    await mkdir(sourceDir, { recursive: true });
-    await writeFile(join(sourceDir, "code-reviewer.md"), SUBAGENT_MD("code-reviewer"));
-
-    await mkdir(join(projectRoot, ".agents", "agents"), { recursive: true });
-    await writeFile(
-      join(projectRoot, ".agents", "agents", "code-reviewer.md"),
-      "hand-written subagent\n",
-      "utf-8",
-    );
-
-    const lockPath = join(projectRoot, "agents.lock");
-    await writeLockfile(lockPath, { version: 1, skills: {}, subagents: {} });
-    await chmod(lockPath, 0o400);
-
-    await writeFile(
-      join(projectRoot, "agents.toml"),
-      `version = 1
-[[skills]]
-name = "pdf"
-source = "path:local-skills/pdf"
-
-[[subagents]]
-name = "code-reviewer"
-source = "path:agents"
-path = "code-reviewer.md"
-`,
-    );
-
-    const scope = resolveScope("project", projectRoot);
-
-    try {
-      await expect(runInstall({ scope })).rejects.toThrow(
-        /Subagent file exists and is not managed by dotagents/,
-      );
-    } finally {
-      await chmod(lockPath, 0o600).catch(() => {});
-    }
-  });
-
-  it("does not commit subagent lock entries when stale subagent pruning fails", async () => {
+  it("does not write the lockfile when stale subagent pruning fails", async () => {
     const sourceDir = join(projectRoot, "agents");
     await mkdir(sourceDir, { recursive: true });
     await writeFile(join(sourceDir, "code-reviewer.md"), SUBAGENT_MD("code-reviewer"));
@@ -565,12 +520,11 @@ path = "code-reviewer.md"
       await chmod(stalePath, 0o600).catch(() => {});
     }
 
-    const lockfile = await loadLockfile(join(projectRoot, "agents.lock"));
-    expect(lockfile!.subagents["code-reviewer"]).toBeUndefined();
+    expect(await loadLockfile(join(projectRoot, "agents.lock"))).toBeNull();
     expect(existsSync(join(installedDir, "code-reviewer.md"))).toBe(true);
   });
 
-  it("does not commit subagent lock entries when runtime subagent writes fail", async () => {
+  it("keeps lock entries when runtime subagent writes fail", async () => {
     const skillSourceDir = join(projectRoot, "local-skills", "pdf");
     await mkdir(skillSourceDir, { recursive: true });
     await writeFile(join(skillSourceDir, "SKILL.md"), SKILL_MD("pdf"));
@@ -616,7 +570,7 @@ path = "code-reviewer.md"
 
     const lockfile = await loadLockfile(join(projectRoot, "agents.lock"));
     expect(lockfile!.skills["pdf"]).toBeDefined();
-    expect(lockfile!.subagents["code-reviewer"]).toBeUndefined();
+    expect(lockfile!.subagents["code-reviewer"]).toEqual({ source: "path:agents" });
     expect(existsSync(join(projectRoot, ".agents", "agents", "code-reviewer.md"))).toBe(true);
   });
 

--- a/packages/dotagents/src/cli/commands/install.ts
+++ b/packages/dotagents/src/cli/commands/install.ts
@@ -11,7 +11,7 @@ import {
 } from "../../config/schema.js";
 import { loadLockfile } from "../../lockfile/loader.js";
 import { writeLockfile } from "../../lockfile/writer.js";
-import { type Lockfile, type LockedSkill, type LockedSubagent } from "../../lockfile/schema.js";
+import { type Lockfile, type LockedSkill } from "../../lockfile/schema.js";
 import {
   applyDefaultRepositorySource,
   resolveSkill,
@@ -171,46 +171,6 @@ function validateFrozenSubagents(
       );
     }
   }
-}
-
-function optionalSubagentLockValue(
-  entry: LockedSubagent,
-  key: "resolved_url" | "resolved_path" | "resolved_ref" | "resolved_commit",
-): string | undefined {
-  switch (key) {
-    case "resolved_url":
-      return "resolved_url" in entry ? entry.resolved_url : undefined;
-    case "resolved_path":
-      return "resolved_path" in entry ? entry.resolved_path : undefined;
-    case "resolved_ref":
-      return "resolved_ref" in entry ? entry.resolved_ref : undefined;
-    case "resolved_commit":
-      return "resolved_commit" in entry ? entry.resolved_commit : undefined;
-  }
-}
-
-function subagentLockEntriesEqual(a: LockedSubagent, b: LockedSubagent): boolean {
-  return a.source === b.source
-    && optionalSubagentLockValue(a, "resolved_url") === optionalSubagentLockValue(b, "resolved_url")
-    && optionalSubagentLockValue(a, "resolved_path") === optionalSubagentLockValue(b, "resolved_path")
-    && optionalSubagentLockValue(a, "resolved_ref") === optionalSubagentLockValue(b, "resolved_ref")
-    && optionalSubagentLockValue(a, "resolved_commit") === optionalSubagentLockValue(b, "resolved_commit");
-}
-
-function unchangedSubagentLockEntries(
-  current: Lockfile | null,
-  next: Lockfile,
-): Lockfile["subagents"] {
-  if (!current) {return {};}
-
-  const unchanged: Lockfile["subagents"] = {};
-  for (const [name, entry] of Object.entries(current.subagents)) {
-    const nextEntry = next.subagents[name];
-    if (!nextEntry) {continue;}
-    if (!subagentLockEntriesEqual(entry, nextEntry)) {continue;}
-    unchanged[name] = entry;
-  }
-  return unchanged;
 }
 
 export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
@@ -373,27 +333,13 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
   }
 
   const shouldWriteLockfile = !frozen && (lockfile || config.skills.length > 0 || config.subagents.length > 0);
-  let installedSubagentsSynced = false;
 
   try {
     if (!frozen) {
       await writeInstalledSubagents(subagentsDir, installedSubagents);
       await pruneInstalledSubagents(subagentsDir, config.subagents);
-      installedSubagentsSynced = true;
     }
   } catch (err) {
-    if (shouldWriteLockfile) {
-      try {
-        await writeLockfile(lockPath, {
-          ...newLock,
-          subagents: installedSubagentsSynced
-            ? newLock.subagents
-            : unchangedSubagentLockEntries(lockfile, newLock),
-        });
-      } catch {
-        // Preserve the original install failure; this recovery write is best-effort.
-      }
-    }
     if (err instanceof InstalledSubagentWriteError) {
       throw new InstallError(err.message);
     }
@@ -401,10 +347,7 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
   }
 
   if (shouldWriteLockfile) {
-    await writeLockfile(lockPath, {
-      ...newLock,
-      subagents: unchangedSubagentLockEntries(lockfile, newLock),
-    });
+    await writeLockfile(lockPath, newLock);
   }
 
   // 4. Gitignore (skip for user scope — ~/.agents/ is not a git repo)
@@ -478,31 +421,13 @@ export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
   const subagentResolver = scope.scope === "user"
     ? userSubagentResolver()
     : projectSubagentResolver(scope.root);
-  let subagentResult: Awaited<ReturnType<typeof writeSubagentConfigs>>;
-  try {
-    subagentResult = await writeSubagentConfigs(
-      config.agents,
-      installedSubagents,
-      subagentResolver,
-    );
-    if (!frozen) {
-      await pruneSubagentConfigs(config.agents, installedSubagents, subagentResolver);
-    }
-    if (shouldWriteLockfile) {
-      await writeLockfile(lockPath, newLock);
-    }
-  } catch (err) {
-    if (shouldWriteLockfile) {
-      try {
-        await writeLockfile(lockPath, {
-          ...newLock,
-          subagents: unchangedSubagentLockEntries(lockfile, newLock),
-        });
-      } catch {
-        // Preserve the runtime config failure; this recovery write is best-effort.
-      }
-    }
-    throw err;
+  const subagentResult = await writeSubagentConfigs(
+    config.agents,
+    installedSubagents,
+    subagentResolver,
+  );
+  if (!frozen) {
+    await pruneSubagentConfigs(config.agents, installedSubagents, subagentResolver);
   }
 
   return { installed, skipped, pruned, hookWarnings, subagentWarnings: subagentResult.warnings };


### PR DESCRIPTION
Install now writes agents.lock only after canonical skill and subagent install work succeeds. Canonical subagent write/prune failures leave the existing lockfile untouched, while later runtime subagent projection failures keep the canonical install state that already landed on disk.