### PR TITLE
ref(install): Split install command concerns

### DIFF
--- a/packages/dotagents/src/cli/commands/install-user.test.ts
+++ b/packages/dotagents/src/cli/commands/install-user.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, readFile, readlink, rm, writeFile, lstat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { tmpdir } from "node:os";
+
+const SKILL_MD = `---
+name: pdf
+description: Test skill pdf
+---
+
+# pdf
+`;
+
+describe("runInstall user scope", () => {
+  let tmpDir: string | undefined;
+  const previousHome = process.env["HOME"];
+  const previousDotagentsHome = process.env["DOTAGENTS_HOME"];
+  const previousStateDir = process.env["DOTAGENTS_STATE_DIR"];
+
+  afterEach(async () => {
+    if (previousHome === undefined) {
+      delete process.env["HOME"];
+    } else {
+      process.env["HOME"] = previousHome;
+    }
+    if (previousDotagentsHome === undefined) {
+      delete process.env["DOTAGENTS_HOME"];
+    } else {
+      process.env["DOTAGENTS_HOME"] = previousDotagentsHome;
+    }
+    if (previousStateDir === undefined) {
+      delete process.env["DOTAGENTS_STATE_DIR"];
+    } else {
+      process.env["DOTAGENTS_STATE_DIR"] = previousStateDir;
+    }
+    vi.resetModules();
+
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("installs a user-scope path skill and writes the user agent skill symlink", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dotagents-user-install-"));
+    const homeDir = join(tmpDir, "home");
+    const dotagentsHome = join(tmpDir, "agents");
+    const stateDir = join(tmpDir, "state");
+    const sourceDir = join(dotagentsHome, "skill-source", "pdf");
+
+    process.env["HOME"] = homeDir;
+    process.env["DOTAGENTS_HOME"] = dotagentsHome;
+    process.env["DOTAGENTS_STATE_DIR"] = stateDir;
+    vi.resetModules();
+
+    const [{ runInstall }, { resolveScope }, { loadLockfile }] = await Promise.all([
+      import("./install.js"),
+      import("../../scope.js"),
+      import("../../lockfile/loader.js"),
+    ]);
+
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "SKILL.md"), SKILL_MD);
+    const scope = resolveScope("user");
+    await mkdir(scope.root, { recursive: true });
+    await writeFile(
+      scope.configPath,
+      `version = 1
+agents = ["claude"]
+
+[[skills]]
+name = "pdf"
+source = "path:skill-source/pdf"
+`,
+    );
+
+    const result = await runInstall({ scope });
+
+    expect(result.installed).toEqual(["pdf"]);
+    expect(existsSync(join(scope.skillsDir, "pdf", "SKILL.md"))).toBe(true);
+    expect(await readFile(join(scope.skillsDir, "pdf", "SKILL.md"), "utf-8")).toBe(SKILL_MD);
+
+    const skillsLink = join(homeDir, ".claude", "skills");
+    const stat = await lstat(skillsLink);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(await readlink(skillsLink)).toBe(relative(join(homeDir, ".claude"), scope.skillsDir));
+
+    const lockfile = await loadLockfile(scope.lockPath);
+    expect(lockfile!.skills["pdf"]).toEqual({ source: "path:skill-source/pdf" });
+  });
+});

--- a/packages/dotagents/src/cli/commands/install.ts
+++ b/packages/dotagents/src/cli/commands/install.ts
@@ -1,57 +1,30 @@
-import { join, resolve } from "node:path";
-import { mkdir, rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import chalk from "chalk";
+import { GitError, TrustError } from "@sentry/dotagents-lib";
 import { loadConfig } from "../../config/loader.js";
-import {
-  isWildcardDep,
-  type RepositorySource,
-  type SkillDependency,
-  type SubagentConfig,
-} from "../../config/schema.js";
 import { loadLockfile } from "../../lockfile/loader.js";
 import { writeLockfile } from "../../lockfile/writer.js";
-import { type Lockfile, type LockedSkill } from "../../lockfile/schema.js";
-import {
-  applyDefaultRepositorySource,
-  resolveSkill,
-  resolveWildcardSkills,
-  sourcesMatch,
-  type ResolvedSkill,
-  validateTrustedSource,
-  TrustError,
-  GitError,
-  copyDir,
-} from "@sentry/dotagents-lib";
-import { isInPlaceSkill, managedSkillPath } from "../../utils/fs.js";
-import { getCacheStateDir, HOST_SCAN_DIRS } from "../cache.js";
-import { formatGitError, formatTrustError } from "../errors.js";
-import { writeAgentsGitignore, checkRootGitignoreEntries } from "../../gitignore/writer.js";
-import { ensureSkillsSymlink } from "../../symlinks/manager.js";
-import { getAgent } from "../../agents/registry.js";
-import { writeMcpConfigs, toMcpDeclarations, projectMcpResolver } from "../../agents/mcp-writer.js";
-import { writeHookConfigs, toHookDeclarations, projectHookResolver } from "../../agents/hook-writer.js";
-import { pruneSubagentConfigs, writeSubagentConfigs, projectSubagentResolver, userSubagentResolver } from "../../agents/subagent-writer.js";
-import {
-  InstalledSubagentWriteError,
-  lockEntryForSubagent,
-  loadInstalledSubagents,
-  pruneInstalledSubagents,
-  resolveSubagent,
-  writeInstalledSubagents,
-} from "../../agents/subagent-store.js";
-import { userMcpResolver } from "../../agents/paths.js";
-import type { SubagentDeclaration } from "../../agents/types.js";
+import type { Lockfile } from "../../lockfile/schema.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
 import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
+import { formatGitError, formatTrustError } from "../errors.js";
+import { InstallError } from "./install/errors.js";
+import { installSkills } from "./install/skills.js";
+import { installSubagents, writeCanonicalSubagents } from "./install/subagents.js";
+import { writeInstallGitignore } from "./install/gitignore.js";
+import {
+  writeHookRuntime,
+  writeMcpRuntime,
+  writeSkillSymlinks,
+  writeSubagentRuntime,
+} from "./install/agent-runtime.js";
 
-export class InstallError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "InstallError";
-  }
-}
+export { InstallError };
 
+// Owns install orchestration only: concern modules resolve/copy/prune
+// canonical artifacts, this command assembles the lockfile once canonical
+// writes have succeeded, then writes runtime projections and CLI output.
 export interface InstallOptions {
   scope: ScopeRoot;
   frozen?: boolean;
@@ -65,372 +38,44 @@ export interface InstallResult {
   subagentWarnings: { agent: string; name: string; message: string }[];
 }
 
-/** Expanded skill ready for install — either from an explicit entry or a wildcard */
-interface ExpandedSkill {
-  name: string;
-  dep: SkillDependency;
-  resolved?: ResolvedSkill;
-}
-
-/**
- * Expand config skills into a flat list, resolving wildcards.
- * Explicit entries always win over wildcard-discovered skills.
- */
-async function expandSkills(
-  config: {
-    skills: SkillDependency[];
-    trust?: Parameters<typeof validateTrustedSource>[1];
-    defaultRepositorySource: RepositorySource;
-  },
-  lockfile: Lockfile | null,
-  opts: { frozen?: boolean; projectRoot: string; minimumReleaseAge?: number; minimumReleaseAgeExclude?: string[] },
-): Promise<ExpandedSkill[]> {
-  const regularDeps = config.skills.filter((d) => !isWildcardDep(d));
-  const wildcardDeps = config.skills.filter(isWildcardDep);
-  const explicitNames = new Set(regularDeps.map((d) => d.name));
-
-  const expanded: ExpandedSkill[] = [];
-
-  // Add regular deps
-  for (const dep of regularDeps) {
-    expanded.push({ name: dep.name, dep });
-  }
-
-  // Expand wildcards
-  const wildcardNames = new Map<string, string>(); // name → source (for conflict detection)
-  for (const wDep of wildcardDeps) {
-    const wildcardSourceForTrust = applyDefaultRepositorySource(
-      wDep.source,
-      config.defaultRepositorySource,
-    );
-    validateTrustedSource(wildcardSourceForTrust, config.trust);
-    const excludeSet = new Set(wDep.exclude);
-
-    if (opts.frozen) {
-      // In frozen mode, expand from lockfile — no network needed
-      if (!lockfile) {continue;}
-      for (const [name, locked] of Object.entries(lockfile.skills)) {
-        if (!sourcesMatch(locked.source, wDep.source)) {continue;}
-        if (explicitNames.has(name)) {continue;}
-        if (excludeSet.has(name)) {continue;}
-
-        expanded.push({ name, dep: wDep });
-      }
-    } else {
-      let named;
-      try {
-        named = await resolveWildcardSkills(wDep, {
-          stateDir: getCacheStateDir(),
-          scanDirs: HOST_SCAN_DIRS,
-          projectRoot: opts.projectRoot,
-          defaultRepositorySource: config.defaultRepositorySource,
-          minimumReleaseAge: opts.minimumReleaseAge,
-          minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
-        });
-      } catch (err) {
-        // Let GitError and TrustError bubble — they carry structured details
-        // (auth-required SSH hint, allowed-source list) the outer handler renders.
-        if (err instanceof GitError || err instanceof TrustError) {throw err;}
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new InstallError(`Failed to resolve wildcard source "${wDep.source}": ${msg}`);
-      }
-      for (const { name, resolved } of named) {
-        if (explicitNames.has(name)) {continue;} // explicit wins
-
-        // Check for conflicts between different wildcards
-        const existingSource = wildcardNames.get(name);
-        if (existingSource && !sourcesMatch(existingSource, wDep.source)) {
-          throw new InstallError(
-            `Skill "${name}" found in both wildcard sources: "${existingSource}" and "${wDep.source}". ` +
-              `Use an explicit [[skills]] entry or add it to one source's exclude list.`,
-          );
-        }
-        wildcardNames.set(name, wDep.source);
-
-        expanded.push({ name, dep: wDep, resolved });
-      }
-    }
-  }
-
-  return expanded;
-}
-
-function validateFrozenSubagents(
-  subagents: SubagentConfig[],
-  lockfile: Lockfile | null,
-): void {
-  if (subagents.length === 0) {return;}
-  if (!lockfile) {
-    throw new InstallError("--frozen requires agents.lock to exist.");
-  }
-
-  for (const subagent of subagents) {
-    if (!lockfile.subagents[subagent.name]) {
-      throw new InstallError(
-        `--frozen: subagent "${subagent.name}" is in agents.toml but missing from agents.lock.`,
-      );
-    }
-  }
-}
-
 export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
   const { scope, frozen } = opts;
-  const { configPath, lockPath, agentsDir, skillsDir } = scope;
-  const subagentsDir = join(agentsDir, "agents");
+  const config = await loadConfig(scope.configPath);
+  const lockfile = await loadLockfile(scope.lockPath);
+  const skills = await installSkills(config, lockfile, scope, frozen);
+  const subagents = await installSubagents(config, lockfile, scope, frozen);
+  const newLock: Lockfile = {
+    version: 1,
+    skills: skills.lockEntries,
+    subagents: subagents.lockEntries,
+  };
 
-  // 1. Read config
-  const config = await loadConfig(configPath);
-  const lockfile = await loadLockfile(lockPath);
-  const newLock: Lockfile = { version: 1, skills: {}, subagents: {} };
-  const installed: string[] = [];
-  const skipped: string[] = [];
-  const pruned: string[] = [];
-
-  // Ensure skills/ exists (needed for symlinks even without skills)
-  await mkdir(skillsDir, { recursive: true });
-
-  // 2. Resolve and install skills (if any declared)
-  if (config.skills.length > 0) {
-    if (frozen && !lockfile) {
-      throw new InstallError("--frozen requires agents.lock to exist.");
-    }
-
-    const minimumReleaseAge = config.minimum_release_age;
-    const minimumReleaseAgeExclude = config.minimum_release_age_exclude;
-    const expanded = await expandSkills(
-      {
-        skills: config.skills,
-        trust: config.trust,
-        defaultRepositorySource: config.defaultRepositorySource,
-      },
-      lockfile,
-      { frozen, projectRoot: scope.root, minimumReleaseAge, minimumReleaseAgeExclude },
-    );
-
-    if (frozen) {
-      for (const { name } of expanded) {
-        if (!lockfile!.skills[name]) {
-          throw new InstallError(
-            `--frozen: skill "${name}" is in agents.toml but missing from agents.lock.`,
-          );
-        }
-      }
-    }
-
-    for (const item of expanded) {
-      const { name, dep } = item;
-
-      // Validate trust before any network work
-      const sourceForTrust = applyDefaultRepositorySource(
-        dep.source,
-        config.defaultRepositorySource,
-      );
-      validateTrustedSource(sourceForTrust, config.trust);
-
-      const resolveOpts = {
-        stateDir: getCacheStateDir(),
-        scanDirs: HOST_SCAN_DIRS,
-        projectRoot: scope.root,
-        defaultRepositorySource: config.defaultRepositorySource,
-        minimumReleaseAge,
-        minimumReleaseAgeExclude,
-      };
-
-      let resolved: ResolvedSkill;
-      if (item.resolved) {
-        resolved = item.resolved;
-      } else {
-        try {
-          resolved = await resolveSkill(name, dep, resolveOpts);
-        } catch (err) {
-          if (err instanceof GitError || err instanceof TrustError) {throw err;}
-          const msg = err instanceof Error ? err.message : String(err);
-          throw new InstallError(`Failed to resolve skill "${name}": ${msg}`);
-        }
-      }
-
-      const destDir = join(skillsDir, name);
-
-      // Skip copy when source resolves to the install destination (in-place skills)
-      if (resolve(resolved.skillDir) !== resolve(destDir)) {
-        await copyDir(resolved.skillDir, destDir);
-      }
-
-      let lockEntry: LockedSkill;
-      if (resolved.type === "git") {
-        lockEntry = {
-          source: dep.source,
-          resolved_url: resolved.resolvedUrl,
-          resolved_path: resolved.resolvedPath,
-          ...(resolved.resolvedRef ? { resolved_ref: resolved.resolvedRef } : {}),
-          resolved_commit: resolved.commit,
-        };
-      } else if (resolved.type === "well-known") {
-        lockEntry = {
-          source: dep.source,
-          resolved_url: resolved.resolvedUrl,
-        };
-      } else {
-        lockEntry = { source: dep.source };
-      }
-
-      newLock.skills[name] = lockEntry;
-      installed.push(name);
-    }
-
-    // Prune stale managed skills (skip in frozen mode to avoid disk/lockfile inconsistency)
-    if (!frozen && lockfile) {
-      for (const [name, locked] of Object.entries(lockfile.skills)) {
-        if (newLock.skills[name]) {continue;} // still tracked
-        if (isInPlaceSkill(locked.source)) {continue;}
-        const skillPath = managedSkillPath(skillsDir, name);
-        if (!skillPath) {continue;}
-        await rm(skillPath, { recursive: true, force: true });
-        pruned.push(name);
-      }
-    }
-  } else if (!frozen && lockfile) {
-    for (const [name, locked] of Object.entries(lockfile.skills)) {
-      if (isInPlaceSkill(locked.source)) {continue;}
-      const skillPath = managedSkillPath(skillsDir, name);
-      if (!skillPath) {continue;}
-      await rm(skillPath, { recursive: true, force: true });
-      pruned.push(name);
-    }
-  }
-
-  // 3. Resolve and install subagent markdown files
-  const installedSubagents: SubagentDeclaration[] = [];
-  if (frozen) {
-    validateFrozenSubagents(config.subagents, lockfile);
-    if (config.subagents.length > 0) {
-      const loaded = await loadInstalledSubagents(subagentsDir, config.subagents);
-      if (loaded.issues.length > 0) {
-        throw new InstallError(loaded.issues.map((issue) => issue.issue).join("\n"));
-      }
-      installedSubagents.push(...loaded.subagents);
-    }
-  } else if (config.subagents.length > 0) {
-    for (const subagentConfig of config.subagents) {
-      let resolved: Awaited<ReturnType<typeof resolveSubagent>>;
-      try {
-        resolved = await resolveSubagent(subagentConfig, {
-          stateDir: getCacheStateDir(),
-          projectRoot: scope.root,
-          defaultRepositorySource: config.defaultRepositorySource,
-          minimumReleaseAge: config.minimum_release_age,
-          minimumReleaseAgeExclude: config.minimum_release_age_exclude,
-          trust: config.trust,
-        });
-      } catch (err) {
-        if (err instanceof GitError || err instanceof TrustError) {throw err;}
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new InstallError(`Failed to resolve subagent "${subagentConfig.name}": ${msg}`);
-      }
-      installedSubagents.push(resolved.subagent);
-      newLock.subagents[resolved.subagent.name] = lockEntryForSubagent(resolved);
-    }
-  }
-
-  const shouldWriteLockfile = !frozen && (lockfile || config.skills.length > 0 || config.subagents.length > 0);
-
-  try {
-    if (!frozen) {
-      await writeInstalledSubagents(subagentsDir, installedSubagents);
-      await pruneInstalledSubagents(subagentsDir, config.subagents);
-    }
-  } catch (err) {
-    if (err instanceof InstalledSubagentWriteError) {
-      throw new InstallError(err.message);
-    }
-    throw err;
-  }
-
-  if (shouldWriteLockfile) {
-    await writeLockfile(lockPath, newLock);
-  }
-
-  // 4. Gitignore (skip for user scope — ~/.agents/ is not a git repo)
-  if (scope.scope === "project") {
-    // For wildcard entries all expanded skills are managed (wildcards can't be in-place)
-    const managedNames = installed.filter((name) => {
-      const dep = config.skills.find((s) => s.name === name);
-      // Wildcard-sourced skills are always managed
-      if (!dep || isWildcardDep(dep)) {return true;}
-      return !isInPlaceSkill(dep.source);
-    });
-    const managedSubagentNames = frozen
-      ? Object.keys(lockfile?.subagents ?? {})
-      : installedSubagents.map((subagent) => subagent.name);
-    await writeAgentsGitignore(
-      agentsDir,
-      managedNames,
-      managedSubagentNames,
-    );
-
-    // Health check: warn if agents.lock and .agents/.gitignore are not in root .gitignore
-    const missing = await checkRootGitignoreEntries(scope.root);
-    if (missing.length > 0) {
-      console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'npx @sentry/dotagents doctor --fix' to fix.`));
-    }
-  }
-
-  // 5. Symlinks — create per-agent symlinks so each agent discovers skills
-  if (scope.scope === "user") {
-    const seen = new Set<string>();
-    for (const agentId of config.agents) {
-      const agent = getAgent(agentId);
-      if (!agent?.userSkillsParentDirs) {continue;}
-      for (const dir of agent.userSkillsParentDirs) {
-        if (seen.has(dir)) {continue;}
-        seen.add(dir);
-        await ensureSkillsSymlink(agentsDir, dir);
-      }
-    }
-  } else {
-    const targets = config.symlinks?.targets ?? [];
-    for (const target of targets) {
-      await ensureSkillsSymlink(agentsDir, join(scope.root, target));
-    }
-
-    const seenParentDirs = new Set(targets);
-    for (const agentId of config.agents) {
-      const agent = getAgent(agentId);
-      if (!agent?.skillsParentDir) {continue;}
-      if (seenParentDirs.has(agent.skillsParentDir)) {continue;}
-      seenParentDirs.add(agent.skillsParentDir);
-      await ensureSkillsSymlink(agentsDir, join(scope.root, agent.skillsParentDir));
-    }
-  }
-
-  // 6. Write MCP config files
-  const mcpResolver = scope.scope === "user" ? userMcpResolver() : projectMcpResolver(scope.root);
-  await writeMcpConfigs(config.agents, toMcpDeclarations(config.mcp), mcpResolver);
-
-  // 7. Write hook config files (skip for user scope)
-  let hookWarnings: { agent: string; message: string }[] = [];
-  if (scope.scope === "project") {
-    hookWarnings = await writeHookConfigs(
-      config.agents,
-      toHookDeclarations(config.hooks),
-      projectHookResolver(scope.root),
-    );
-  }
-
-  // 8. Write custom subagent files
-  const subagentResolver = scope.scope === "user"
-    ? userSubagentResolver()
-    : projectSubagentResolver(scope.root);
-  const subagentResult = await writeSubagentConfigs(
-    config.agents,
-    installedSubagents,
-    subagentResolver,
+  await writeCanonicalSubagents(config, scope, subagents.subagents, frozen);
+  const writeLock = !frozen && (
+    !!lockfile ||
+    config.skills.length > 0 ||
+    config.subagents.length > 0
   );
-  if (!frozen) {
-    await pruneSubagentConfigs(config.agents, installedSubagents, subagentResolver);
+  if (writeLock) {
+    await writeLockfile(scope.lockPath, newLock);
   }
 
-  return { installed, skipped, pruned, hookWarnings, subagentWarnings: subagentResult.warnings };
+  await writeInstallGitignore(config, lockfile, scope, {
+    installedSkillNames: skills.installed,
+    subagents: subagents.subagents,
+  }, frozen);
+  await writeSkillSymlinks(config, scope);
+  await writeMcpRuntime(config, scope);
+  const hookWarnings = await writeHookRuntime(config, scope);
+  const subagentWarnings = await writeSubagentRuntime(config, scope, subagents.subagents, frozen);
+
+  return {
+    installed: skills.installed,
+    skipped: [],
+    pruned: skills.pruned,
+    hookWarnings,
+    subagentWarnings,
+  };
 }
 
 export default async function install(args: string[], flags?: { user?: boolean }): Promise<void> {

--- a/packages/dotagents/src/cli/commands/install/agent-runtime.ts
+++ b/packages/dotagents/src/cli/commands/install/agent-runtime.ts
@@ -1,0 +1,90 @@
+import { join } from "node:path";
+import type { AgentsConfig } from "../../../config/schema.js";
+import type { ScopeRoot } from "../../../scope.js";
+import { getAgent } from "../../../agents/registry.js";
+import { ensureSkillsSymlink } from "../../../symlinks/manager.js";
+import { projectMcpResolver, toMcpDeclarations, writeMcpConfigs } from "../../../agents/mcp-writer.js";
+import { projectHookResolver, toHookDeclarations, writeHookConfigs } from "../../../agents/hook-writer.js";
+import { userMcpResolver } from "../../../agents/paths.js";
+import {
+  pruneSubagentConfigs,
+  projectSubagentResolver,
+  userSubagentResolver,
+  writeSubagentConfigs,
+} from "../../../agents/subagent-writer.js";
+import type { SubagentDeclaration } from "../../../agents/types.js";
+
+/** Writes agent skill symlinks after canonical install artifacts are ready. */
+export async function writeSkillSymlinks(
+  config: AgentsConfig,
+  scope: ScopeRoot,
+): Promise<void> {
+  if (scope.scope === "user") {
+    const seen = new Set<string>();
+    for (const agentId of config.agents) {
+      const agent = getAgent(agentId);
+      if (!agent?.userSkillsParentDirs) {continue;}
+      for (const dir of agent.userSkillsParentDirs) {
+        if (seen.has(dir)) {continue;}
+        seen.add(dir);
+        await ensureSkillsSymlink(scope.agentsDir, dir);
+      }
+    }
+    return;
+  }
+
+  const targets = config.symlinks?.targets ?? [];
+  for (const target of targets) {
+    await ensureSkillsSymlink(scope.agentsDir, join(scope.root, target));
+  }
+
+  const seenParentDirs = new Set(targets);
+  for (const agentId of config.agents) {
+    const agent = getAgent(agentId);
+    if (!agent?.skillsParentDir) {continue;}
+    if (seenParentDirs.has(agent.skillsParentDir)) {continue;}
+    seenParentDirs.add(agent.skillsParentDir);
+    await ensureSkillsSymlink(scope.agentsDir, join(scope.root, agent.skillsParentDir));
+  }
+}
+
+/** Writes MCP runtime config for configured agents. */
+export async function writeMcpRuntime(
+  config: AgentsConfig,
+  scope: ScopeRoot,
+): Promise<void> {
+  const resolver = scope.scope === "user"
+    ? userMcpResolver()
+    : projectMcpResolver(scope.root);
+  await writeMcpConfigs(config.agents, toMcpDeclarations(config.mcp), resolver);
+}
+
+/** Writes project-scoped hook runtime config for configured agents. */
+export async function writeHookRuntime(
+  config: AgentsConfig,
+  scope: ScopeRoot,
+): Promise<{ agent: string; message: string }[]> {
+  if (scope.scope !== "project") {return [];}
+  return writeHookConfigs(
+    config.agents,
+    toHookDeclarations(config.hooks),
+    projectHookResolver(scope.root),
+  );
+}
+
+/** Writes agent-specific subagent runtime projections. */
+export async function writeSubagentRuntime(
+  config: AgentsConfig,
+  scope: ScopeRoot,
+  subagents: SubagentDeclaration[],
+  frozen?: boolean,
+): Promise<{ agent: string; name: string; message: string }[]> {
+  const resolver = scope.scope === "user"
+    ? userSubagentResolver()
+    : projectSubagentResolver(scope.root);
+  const result = await writeSubagentConfigs(config.agents, subagents, resolver);
+  if (!frozen) {
+    await pruneSubagentConfigs(config.agents, subagents, resolver);
+  }
+  return result.warnings;
+}

--- a/packages/dotagents/src/cli/commands/install/errors.ts
+++ b/packages/dotagents/src/cli/commands/install/errors.ts
@@ -1,0 +1,6 @@
+export class InstallError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InstallError";
+  }
+}

--- a/packages/dotagents/src/cli/commands/install/gitignore.ts
+++ b/packages/dotagents/src/cli/commands/install/gitignore.ts
@@ -1,0 +1,55 @@
+import chalk from "chalk";
+import { isWildcardDep, type AgentsConfig } from "../../../config/schema.js";
+import type { Lockfile } from "../../../lockfile/schema.js";
+import type { ScopeRoot } from "../../../scope.js";
+import { checkRootGitignoreEntries, writeAgentsGitignore } from "../../../gitignore/writer.js";
+import { isInPlaceSkill } from "../../../utils/fs.js";
+import type { SubagentDeclaration } from "../../../agents/types.js";
+
+export interface InstallGitignoreArtifacts {
+  installedSkillNames: string[];
+  subagents: SubagentDeclaration[];
+}
+
+function managedSkillNames(
+  config: AgentsConfig,
+  installed: string[],
+): string[] {
+  return installed.filter((name) => {
+    const dep = config.skills.find((s) => s.name === name);
+    if (!dep || isWildcardDep(dep)) {return true;}
+    return !isInPlaceSkill(dep.source);
+  });
+}
+
+function managedSubagentNames(
+  lockfile: Lockfile | null,
+  subagents: SubagentDeclaration[],
+  frozen?: boolean,
+): string[] {
+  return frozen
+    ? Object.keys(lockfile?.subagents ?? {})
+    : subagents.map((subagent) => subagent.name);
+}
+
+/** Regenerates project `.agents/.gitignore` from install results and lockfile state. */
+export async function writeInstallGitignore(
+  config: AgentsConfig,
+  lockfile: Lockfile | null,
+  scope: ScopeRoot,
+  artifacts: InstallGitignoreArtifacts,
+  frozen?: boolean,
+): Promise<void> {
+  if (scope.scope !== "project") {return;}
+
+  await writeAgentsGitignore(
+    scope.agentsDir,
+    managedSkillNames(config, artifacts.installedSkillNames),
+    managedSubagentNames(lockfile, artifacts.subagents, frozen),
+  );
+
+  const missing = await checkRootGitignoreEntries(scope.root);
+  if (missing.length > 0) {
+    console.log(chalk.yellow(`Warning: ${missing.join(", ")} should be in .gitignore. Run 'npx @sentry/dotagents doctor --fix' to fix.`));
+  }
+}

--- a/packages/dotagents/src/cli/commands/install/skills.ts
+++ b/packages/dotagents/src/cli/commands/install/skills.ts
@@ -1,0 +1,221 @@
+import { join, resolve } from "node:path";
+import { mkdir, rm } from "node:fs/promises";
+import { isWildcardDep, type AgentsConfig, type RepositorySource, type SkillDependency } from "../../../config/schema.js";
+import type { Lockfile, LockedSkill } from "../../../lockfile/schema.js";
+import type { ScopeRoot } from "../../../scope.js";
+import { isInPlaceSkill, managedSkillPath } from "../../../utils/fs.js";
+import {
+  applyDefaultRepositorySource,
+  copyDir,
+  GitError,
+  resolveSkill,
+  resolveWildcardSkills,
+  sourcesMatch,
+  TrustError,
+  type ResolvedSkill,
+  validateTrustedSource,
+} from "@sentry/dotagents-lib";
+import { getCacheStateDir, HOST_SCAN_DIRS } from "../../cache.js";
+import { InstallError } from "./errors.js";
+
+/** Expanded skill ready for install: either an explicit entry or wildcard result. */
+interface ExpandedSkill {
+  name: string;
+  dep: SkillDependency;
+  resolved?: ResolvedSkill;
+}
+
+export interface InstallSkillsResult {
+  installed: string[];
+  pruned: string[];
+  lockEntries: Lockfile["skills"];
+}
+
+/**
+ * Expand config skills into a flat list, resolving wildcards.
+ * Explicit entries always win over wildcard-discovered skills.
+ */
+async function expandSkills(
+  config: {
+    skills: SkillDependency[];
+    trust?: Parameters<typeof validateTrustedSource>[1];
+    defaultRepositorySource: RepositorySource;
+  },
+  lockfile: Lockfile | null,
+  opts: { frozen?: boolean; projectRoot: string; minimumReleaseAge?: number; minimumReleaseAgeExclude?: string[] },
+): Promise<ExpandedSkill[]> {
+  const regularDeps = config.skills.filter((d) => !isWildcardDep(d));
+  const wildcardDeps = config.skills.filter(isWildcardDep);
+  const explicitNames = new Set(regularDeps.map((d) => d.name));
+
+  const expanded: ExpandedSkill[] = [];
+  for (const dep of regularDeps) {
+    expanded.push({ name: dep.name, dep });
+  }
+
+  const wildcardNames = new Map<string, string>();
+  for (const wDep of wildcardDeps) {
+    const wildcardSourceForTrust = applyDefaultRepositorySource(
+      wDep.source,
+      config.defaultRepositorySource,
+    );
+    validateTrustedSource(wildcardSourceForTrust, config.trust);
+    const excludeSet = new Set(wDep.exclude);
+
+    if (opts.frozen) {
+      if (!lockfile) {continue;}
+      for (const [name, locked] of Object.entries(lockfile.skills)) {
+        if (!sourcesMatch(locked.source, wDep.source)) {continue;}
+        if (explicitNames.has(name)) {continue;}
+        if (excludeSet.has(name)) {continue;}
+        expanded.push({ name, dep: wDep });
+      }
+      continue;
+    }
+
+    let named;
+    try {
+      named = await resolveWildcardSkills(wDep, {
+        stateDir: getCacheStateDir(),
+        scanDirs: HOST_SCAN_DIRS,
+        projectRoot: opts.projectRoot,
+        defaultRepositorySource: config.defaultRepositorySource,
+        minimumReleaseAge: opts.minimumReleaseAge,
+        minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+      });
+    } catch (err) {
+      if (err instanceof GitError || err instanceof TrustError) {throw err;}
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new InstallError(`Failed to resolve wildcard source "${wDep.source}": ${msg}`);
+    }
+
+    for (const { name, resolved } of named) {
+      if (explicitNames.has(name)) {continue;}
+      const existingSource = wildcardNames.get(name);
+      if (existingSource && !sourcesMatch(existingSource, wDep.source)) {
+        throw new InstallError(
+          `Skill "${name}" found in both wildcard sources: "${existingSource}" and "${wDep.source}". ` +
+            "Use an explicit [[skills]] entry or add it to one source's exclude list.",
+        );
+      }
+      wildcardNames.set(name, wDep.source);
+      expanded.push({ name, dep: wDep, resolved });
+    }
+  }
+
+  return expanded;
+}
+
+function lockEntryForSkill(dep: SkillDependency, resolved: ResolvedSkill): LockedSkill {
+  if (resolved.type === "git") {
+    return {
+      source: dep.source,
+      resolved_url: resolved.resolvedUrl,
+      resolved_path: resolved.resolvedPath,
+      ...(resolved.resolvedRef ? { resolved_ref: resolved.resolvedRef } : {}),
+      resolved_commit: resolved.commit,
+    };
+  }
+  if (resolved.type === "well-known") {
+    return {
+      source: dep.source,
+      resolved_url: resolved.resolvedUrl,
+    };
+  }
+  return { source: dep.source };
+}
+
+/** Resolves, copies, and prunes canonical skill directories for install. */
+export async function installSkills(
+  config: AgentsConfig,
+  lockfile: Lockfile | null,
+  scope: ScopeRoot,
+  frozen?: boolean,
+): Promise<InstallSkillsResult> {
+  const lockEntries: Lockfile["skills"] = {};
+  const installed: string[] = [];
+  const pruned: string[] = [];
+
+  await mkdir(scope.skillsDir, { recursive: true });
+
+  if (config.skills.length > 0) {
+    if (frozen && !lockfile) {
+      throw new InstallError("--frozen requires agents.lock to exist.");
+    }
+
+    const expanded = await expandSkills(
+      {
+        skills: config.skills,
+        trust: config.trust,
+        defaultRepositorySource: config.defaultRepositorySource,
+      },
+      lockfile,
+      {
+        frozen,
+        projectRoot: scope.root,
+        minimumReleaseAge: config.minimum_release_age,
+        minimumReleaseAgeExclude: config.minimum_release_age_exclude,
+      },
+    );
+
+    if (frozen) {
+      for (const { name } of expanded) {
+        if (!lockfile!.skills[name]) {
+          throw new InstallError(
+            `--frozen: skill "${name}" is in agents.toml but missing from agents.lock.`,
+          );
+        }
+      }
+    }
+
+    for (const item of expanded) {
+      const { name, dep } = item;
+      const sourceForTrust = applyDefaultRepositorySource(
+        dep.source,
+        config.defaultRepositorySource,
+      );
+      validateTrustedSource(sourceForTrust, config.trust);
+
+      let resolved: ResolvedSkill;
+      if (item.resolved) {
+        resolved = item.resolved;
+      } else {
+        try {
+          resolved = await resolveSkill(name, dep, {
+            stateDir: getCacheStateDir(),
+            scanDirs: HOST_SCAN_DIRS,
+            projectRoot: scope.root,
+            defaultRepositorySource: config.defaultRepositorySource,
+            minimumReleaseAge: config.minimum_release_age,
+            minimumReleaseAgeExclude: config.minimum_release_age_exclude,
+          });
+        } catch (err) {
+          if (err instanceof GitError || err instanceof TrustError) {throw err;}
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new InstallError(`Failed to resolve skill "${name}": ${msg}`);
+        }
+      }
+
+      const destDir = join(scope.skillsDir, name);
+      if (resolve(resolved.skillDir) !== resolve(destDir)) {
+        await copyDir(resolved.skillDir, destDir);
+      }
+
+      lockEntries[name] = lockEntryForSkill(dep, resolved);
+      installed.push(name);
+    }
+  }
+
+  if (!frozen && lockfile) {
+    for (const [name, locked] of Object.entries(lockfile.skills)) {
+      if (lockEntries[name]) {continue;}
+      if (isInPlaceSkill(locked.source)) {continue;}
+      const skillPath = managedSkillPath(scope.skillsDir, name);
+      if (!skillPath) {continue;}
+      await rm(skillPath, { recursive: true, force: true });
+      pruned.push(name);
+    }
+  }
+
+  return { installed, pruned, lockEntries };
+}

--- a/packages/dotagents/src/cli/commands/install/subagents.ts
+++ b/packages/dotagents/src/cli/commands/install/subagents.ts
@@ -1,0 +1,106 @@
+import { join } from "node:path";
+import type { AgentsConfig, SubagentConfig } from "../../../config/schema.js";
+import type { Lockfile } from "../../../lockfile/schema.js";
+import type { ScopeRoot } from "../../../scope.js";
+import type { SubagentDeclaration } from "../../../agents/types.js";
+import {
+  InstalledSubagentWriteError,
+  lockEntryForSubagent,
+  loadInstalledSubagents,
+  pruneInstalledSubagents,
+  resolveSubagent,
+  writeInstalledSubagents,
+} from "../../../agents/subagent-store.js";
+import { GitError, TrustError } from "@sentry/dotagents-lib";
+import { getCacheStateDir } from "../../cache.js";
+import { InstallError } from "./errors.js";
+
+export interface InstallSubagentsResult {
+  subagents: SubagentDeclaration[];
+  lockEntries: Lockfile["subagents"];
+}
+
+function validateFrozenSubagents(
+  subagents: SubagentConfig[],
+  lockfile: Lockfile | null,
+): void {
+  if (subagents.length === 0) {return;}
+  if (!lockfile) {
+    throw new InstallError("--frozen requires agents.lock to exist.");
+  }
+
+  for (const subagent of subagents) {
+    if (!lockfile.subagents[subagent.name]) {
+      throw new InstallError(
+        `--frozen: subagent "${subagent.name}" is in agents.toml but missing from agents.lock.`,
+      );
+    }
+  }
+}
+
+/** Resolves subagent declarations and lock entries without writing runtime files. */
+export async function installSubagents(
+  config: AgentsConfig,
+  lockfile: Lockfile | null,
+  scope: ScopeRoot,
+  frozen?: boolean,
+): Promise<InstallSubagentsResult> {
+  const subagentsDir = join(scope.agentsDir, "agents");
+  const subagents: SubagentDeclaration[] = [];
+  const lockEntries: Lockfile["subagents"] = {};
+
+  if (frozen) {
+    validateFrozenSubagents(config.subagents, lockfile);
+    if (config.subagents.length > 0) {
+      const loaded = await loadInstalledSubagents(subagentsDir, config.subagents);
+      if (loaded.issues.length > 0) {
+        throw new InstallError(loaded.issues.map((issue) => issue.issue).join("\n"));
+      }
+      subagents.push(...loaded.subagents);
+    }
+    return { subagents, lockEntries };
+  }
+
+  for (const subagentConfig of config.subagents) {
+    let resolved: Awaited<ReturnType<typeof resolveSubagent>>;
+    try {
+      resolved = await resolveSubagent(subagentConfig, {
+        stateDir: getCacheStateDir(),
+        projectRoot: scope.root,
+        defaultRepositorySource: config.defaultRepositorySource,
+        minimumReleaseAge: config.minimum_release_age,
+        minimumReleaseAgeExclude: config.minimum_release_age_exclude,
+        trust: config.trust,
+      });
+    } catch (err) {
+      if (err instanceof GitError || err instanceof TrustError) {throw err;}
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new InstallError(`Failed to resolve subagent "${subagentConfig.name}": ${msg}`);
+    }
+
+    subagents.push(resolved.subagent);
+    lockEntries[resolved.subagent.name] = lockEntryForSubagent(resolved);
+  }
+
+  return { subagents, lockEntries };
+}
+
+/** Writes canonical `.agents/agents` markdown files before the lockfile commit. */
+export async function writeCanonicalSubagents(
+  config: AgentsConfig,
+  scope: ScopeRoot,
+  subagents: SubagentDeclaration[],
+  frozen?: boolean,
+): Promise<void> {
+  if (frozen) {return;}
+  const subagentsDir = join(scope.agentsDir, "agents");
+  try {
+    await writeInstalledSubagents(subagentsDir, subagents);
+    await pruneInstalledSubagents(subagentsDir, config.subagents);
+  } catch (err) {
+    if (err instanceof InstalledSubagentWriteError) {
+      throw new InstallError(err.message);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
The install command now stays as the orchestration layer while skill installation, canonical subagent handling, gitignore generation, runtime projection, and install errors live in focused helper modules. The install ordering and lockfile semantics stay unchanged: canonical writes complete before agents.lock is written, and runtime projections happen afterward.

The added user-scope install test covers path skill installation plus agent skill symlink projection across the new helper boundary.