### PR TITLE
docs: Recommend dotagents QA for runtime changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,7 @@ pnpm check
 ```
 
 Or individually: `pnpm lint && pnpm typecheck && pnpm test`
+
+- Changes affecting install, sync, doctor, skill placement, agent symlinks,
+  generated configs, user scope, or package/runtime behavior should use
+  `skills/dotagents-qa/SKILL.md` for proportionate Docker QA.


### PR DESCRIPTION
Point coding agents to the repository's existing Docker QA skill when changes affect dotagents runtime behavior.

The repository instructions currently stop at `pnpm check`, so agents can miss the higher-fidelity install, sync, generated-config, symlink, and user-scope checks already documented in `skills/dotagents-qa/SKILL.md`. This adds soft, proportionate guidance in the shared `AGENTS.md` rather than changing Garfield or requiring the full QA playbook for every change.