### PR TITLE
ref(cli): Simplify add command flow

### DIFF
--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import add, { runAdd, AddError } from "./add.js";
+import * as clack from "@clack/prompts";
+import add, { runAdd, AddCancelledError, AddError } from "./add.js";
+import * as installModule from "./install.js";
 import { TrustError, exec } from "@sentry/dotagents-lib";
 import { resolveScope } from "../../scope.js";
+
+vi.mock("@clack/prompts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clack/prompts")>();
+  return {
+    ...actual,
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    isCancel: vi.fn(actual.isCancel),
+  };
+});
 
 const SKILL_MD = (name: string) => `---
 name: ${name}
@@ -62,6 +74,8 @@ describe("runAdd", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     delete process.env["DOTAGENTS_STATE_DIR"];
     await rm(tmpDir, { recursive: true });
   });
@@ -105,7 +119,7 @@ describe("runAdd", () => {
     ).rejects.toThrow(AddError);
   });
 
-  it("throws when one of multiple skills is not found (fails fast)", async () => {
+  it("validates every requested git skill before writing", async () => {
     const scope = resolveScope("project", projectRoot);
     await expect(
       runAdd({
@@ -120,7 +134,7 @@ describe("runAdd", () => {
     expect(toml).not.toContain('name = "pdf"');
   });
 
-  it("throws when a skill already exists in config", async () => {
+  it("preserves the single-name duplicate error", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
@@ -136,7 +150,7 @@ describe("runAdd", () => {
     ).rejects.toThrow(AddError);
   });
 
-  it("skips existing skills and adds the rest when adding multiple", async () => {
+  it("skips existing skills only for a multi-name request", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
@@ -177,10 +191,10 @@ describe("runAdd", () => {
       runAdd({
         scope,
         specifier: `git:${repoDir}`,
-        names: ["pdf"],
+        names: ["invalid/name"],
         all: true,
       }),
-    ).rejects.toThrow(AddError);
+    ).rejects.toThrow("Cannot use --all with --name. Use one or the other.");
   });
 
   it("treats shorthand and expanded GitLab sources as the same wildcard", async () => {
@@ -227,6 +241,68 @@ describe("runAdd", () => {
     ).rejects.toThrow(TrustError);
   });
 
+  it("stores the original source spelling and installs once", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\ndefaultRepositorySource = "gitlab"\n`,
+    );
+    const installSpy = vi.spyOn(installModule, "runInstall").mockResolvedValue({
+      installed: [],
+      skipped: [],
+      pruned: [],
+      hookWarnings: [],
+      subagentWarnings: [],
+    });
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "getsentry/skills",
+      all: true,
+    });
+
+    expect(result).toBe("*");
+    expect(installSpy).toHaveBeenCalledOnce();
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain('source = "getsentry/skills"');
+    expect(toml).not.toContain('source = "https://gitlab.com/getsentry/skills"');
+  });
+
+  it("selects explicit well-known names like git catalog names", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith("index.json")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              skills: ["pdf", "review"].map((name) => ({
+                name,
+                description: `Test skill ${name}`,
+                files: ["SKILL.md"],
+              })),
+            }),
+          });
+        }
+        const name = url.includes("/pdf/") ? "pdf" : "review";
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(SKILL_MD(name)),
+        });
+      }),
+    );
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "https://skills.example.com",
+      names: ["pdf", "review"],
+    });
+
+    expect(result).toEqual(["pdf", "review"]);
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain('name = "pdf"');
+    expect(toml).toContain('name = "review"');
+  });
+
   it("auto-selects when repo has a single skill", async () => {
     // Create a repo with only one skill
     const singleRepo = join(tmpDir, "single-repo");
@@ -264,6 +340,72 @@ describe("runAdd", () => {
         interactive: false,
       }),
     ).rejects.toThrow(/Multiple skills found/);
+  });
+
+  it("cancels interactive catalog selection before writing", async () => {
+    vi.mocked(clack.select).mockResolvedValue("pick");
+    vi.mocked(clack.isCancel).mockReturnValue(true);
+
+    await expect(
+      runAdd({
+        scope: resolveScope("project", projectRoot),
+        specifier: `git:${repoDir}`,
+        interactive: true,
+      }),
+    ).rejects.toBeInstanceOf(AddCancelledError);
+
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe(
+      "version = 1\n",
+    );
+  });
+
+  it("persists an interactive all selection and installs once", async () => {
+    vi.mocked(clack.select).mockResolvedValue("all");
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    const install = vi.spyOn(installModule, "runInstall").mockResolvedValue({
+      installed: [],
+      skipped: [],
+      pruned: [],
+      hookWarnings: [],
+      subagentWarnings: [],
+    });
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: `git:${repoDir}`,
+      interactive: true,
+    });
+
+    expect(result).toBe("*");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
+      'name = "*"',
+    );
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("persists interactive skill selections and installs once", async () => {
+    vi.mocked(clack.select).mockResolvedValue("pick");
+    vi.mocked(clack.multiselect).mockResolvedValue(["pdf", "review"]);
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    const install = vi.spyOn(installModule, "runInstall").mockResolvedValue({
+      installed: [],
+      skipped: [],
+      pruned: [],
+      hookWarnings: [],
+      subagentWarnings: [],
+    });
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: `git:${repoDir}`,
+      interactive: true,
+    });
+
+    expect(result).toEqual(["pdf", "review"]);
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain('name = "pdf"');
+    expect(toml).toContain('name = "review"');
+    expect(install).toHaveBeenCalledOnce();
   });
 });
 
@@ -363,7 +505,7 @@ describe("runAdd (local sources)", () => {
     ).rejects.toThrow(AddError);
   });
 
-  it("throws when one of multiple local skills is not found (fails fast)", async () => {
+  it("validates every requested local skill before writing", async () => {
     const scope = resolveScope("project", projectRoot);
     await expect(
       runAdd({
@@ -378,7 +520,7 @@ describe("runAdd (local sources)", () => {
     expect(toml).not.toContain('name = "pdf"');
   });
 
-  it("skips existing local skills and adds the rest when adding multiple", async () => {
+  it("skips existing local skills only for a multi-name request", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "path:local-skills"\n`,

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -56,6 +56,171 @@ export interface AddOptions {
   interactive?: boolean;
 }
 
+type AcquiredSkills =
+  | { type: "root-skill"; name: string }
+  | { type: "catalog"; rootDir: string };
+
+type AddSelection =
+  | { type: "wildcard" }
+  | {
+      type: "skills";
+      names: string[];
+      /** Single names reject duplicates; specified names warn; prompted selections skip silently. */
+      duplicatePolicy: "single" | "specified" | "selected";
+    };
+
+async function acquireSkills(
+  parsed: ReturnType<typeof parseSource>,
+  scope: ScopeRoot,
+  effectiveRef: string | undefined,
+  hasExplicitNames: boolean,
+): Promise<AcquiredSkills> {
+  if (parsed.type === "local") {
+    const rootDir = await resolveLocalSource(scope.root, parsed.path!);
+    if (hasExplicitNames) {return { type: "catalog", rootDir };}
+    const meta = await loadSkillMd(join(rootDir, "SKILL.md"));
+    return { type: "root-skill", name: meta.name };
+  }
+
+  if (parsed.type === "well-known") {
+    const baseUrl = parsed.url!;
+    const url = new URL(baseUrl);
+    const pathname = url.pathname.endsWith("/")
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+    const cached = await ensureWellKnownCached({
+      stateDir: getCacheStateDir(),
+      url: baseUrl,
+      cacheKey: `wellknown/${url.host.toLowerCase()}${pathname}`,
+    });
+    if (!cached) {
+      throw new AddError(
+        `No skills found at ${baseUrl}. If this is a git repository, use the git: prefix: git:${baseUrl}`,
+      );
+    }
+    return { type: "catalog", rootDir: cached.cacheDir };
+  }
+
+  const url = parsed.url!;
+  const cached = await ensureCached({
+    stateDir: getCacheStateDir(),
+    url: parsed.cloneUrl ?? url,
+    cacheKey: parsed.type === "github"
+      ? `${parsed.owner}/${parsed.repo}`
+      : sanitizeCacheKey(url),
+    ref: effectiveRef,
+  });
+  return { type: "catalog", rootDir: cached.repoDir };
+}
+
+async function verifyRequestedNames(
+  rootDir: string,
+  names: string[],
+  source: string,
+): Promise<void> {
+  for (const name of names) {
+    const found = await discoverSkill(rootDir, name, {
+      scanDirs: HOST_SCAN_DIRS,
+    });
+    if (!found) {
+      throw new AddError(
+        `Skill "${name}" not found in ${source}. ` +
+          `Use 'npx @sentry/dotagents add ${source}' without --name to see available skills.`,
+      );
+    }
+  }
+}
+
+async function selectSkills(
+  acquired: AcquiredSkills,
+  names: string[] | undefined,
+  source: string,
+  interactive: boolean | undefined,
+): Promise<AddSelection> {
+  if (acquired.type === "root-skill") {
+    return {
+      type: "skills",
+      names: [acquired.name],
+      duplicatePolicy: "single",
+    };
+  }
+
+  if (names?.length) {
+    await verifyRequestedNames(acquired.rootDir, names, source);
+    return {
+      type: "skills",
+      names,
+      duplicatePolicy: names.length === 1 ? "single" : "specified",
+    };
+  }
+
+  const skills = await discoverAllSkills(acquired.rootDir, {
+    scanDirs: HOST_SCAN_DIRS,
+  });
+  if (skills.length === 0) {
+    throw new AddError(`No skills found in ${source}.`);
+  }
+  if (skills.length === 1) {
+    return {
+      type: "skills",
+      names: [skills[0]!.meta.name],
+      duplicatePolicy: "single",
+    };
+  }
+  if (!interactive) {
+    const availableNames = skills.map((skill) => skill.meta.name).toSorted();
+    throw new AddError(
+      `Multiple skills found in ${source}: ${availableNames.join(", ")}. ` +
+        "Specify skill names as arguments, use --skill to specify which ones, or --all for all skills.",
+    );
+  }
+
+  const mode = await clack.select({
+    message: `Multiple skills found in ${source}. How would you like to add them?`,
+    options: [
+      {
+        label: "All",
+        value: "all" as const,
+        hint: "Wildcard entry — automatically includes new skills added upstream",
+      },
+      {
+        label: "Select specific skills",
+        value: "pick" as const,
+        hint: "Choose individual skills to add",
+      },
+    ],
+  });
+  if (clack.isCancel(mode)) {throw new AddCancelledError();}
+  if (mode === "all") {return { type: "wildcard" };}
+
+  const selected = await clack.multiselect({
+    message: "Select which skills to add:",
+    options: skills
+      .toSorted((a, b) => a.meta.name.localeCompare(b.meta.name))
+      .map((skill) => {
+        const lastSlash = skill.path.lastIndexOf("/");
+        const parentPath = lastSlash === -1
+          ? ""
+          : skill.path.slice(0, lastSlash);
+        const pathHint = STANDARD_PARENTS.has(parentPath)
+          ? ""
+          : chalk.dim(`(${skill.path}) `);
+        return {
+          label: skill.meta.name,
+          value: skill.meta.name,
+          hint: pathHint + skill.meta.description,
+        };
+      }),
+    required: true,
+  });
+  if (clack.isCancel(selected)) {throw new AddCancelledError();}
+  return {
+    type: "skills",
+    names: selected,
+    duplicatePolicy: selected.length === 1 ? "single" : "selected",
+  };
+}
+
 export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   const {
     scope,
@@ -65,13 +230,9 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     all,
     interactive,
   } = opts;
-  // Strip npm-style leading @ (e.g. @getsentry/skills → getsentry/skills)
   const specifier = stripLeadingAt(rawSpecifier);
-  // Deduplicate names to prevent writing duplicate config entries
   const namesOverride = rawNames ? [...new Set(rawNames)] : rawNames;
   const { configPath } = scope;
-
-  // Load config early so we can check trust before any network work
   const config = await loadConfig(configPath);
 
   const hintedSpecifier = applyDefaultRepositorySource(
@@ -79,8 +240,6 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     config.defaultRepositorySource,
   );
 
-  // Validate the specifier is a recognized source format (check after expansion
-  // so multi-slash GitLab paths like group/subgroup/repo pass when configured)
   if (!isExplicitSourceSpecifier(hintedSpecifier) && !parseOwnerRepoShorthand(hintedSpecifier)) {
     throw new AddError(
       `Invalid source "${specifier}". ` +
@@ -88,8 +247,6 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     );
   }
 
-  // Reject bare http:// URLs that aren't GitHub/GitLab (those get upgraded to HTTPS).
-  // Well-known sources require HTTPS to prevent MITM attacks.
   if (/^http:\/\//i.test(hintedSpecifier) && !GITHUB_HTTPS_URL.test(hintedSpecifier) && !GITLAB_HTTPS_URL.test(hintedSpecifier)) {
     throw new AddError(
       `Insecure source "${specifier}". Well-known sources require HTTPS. ` +
@@ -99,47 +256,17 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
 
   const parsed = parseSource(hintedSpecifier);
 
-  // Store the original source form (shorthand, SSH, HTTPS) — strip inline @ref (stored separately)
   const sourceForStorage = parsed.ref
     ? specifier.slice(0, -(parsed.ref.length + 1))
     : specifier;
-
-  // Validate trust against the expanded source (not the shorthand) so that
-  // defaultRepositorySource=gitlab doesn't bypass trust checks
   validateTrustedSource(hintedSpecifier, config.trust);
-
-  // Determine ref (flag overrides inline @ref)
   const effectiveRef = ref ?? parsed.ref;
   const refOpts = effectiveRef ? { ref: effectiveRef } : {};
 
-  async function addWildcard(): Promise<"*"> {
-    if (
-      config.skills.some(
-        (s) =>
-          isWildcardDep(s) && sourcesMatch(s.source, sourceForStorage),
-      )
-    ) {
-      throw new AddError(
-        `A wildcard entry for "${sourceForStorage}" already exists in agents.toml.`,
-      );
-    }
-    await addWildcardToConfig(configPath, sourceForStorage, {
-      ...refOpts,
-      exclude: [],
-    });
-    await runInstall({ scope });
-    return "*";
+  if (all && namesOverride?.length) {
+    throw new AddError("Cannot use --all with --name. Use one or the other.");
   }
 
-  // --all: add a wildcard entry
-  if (all) {
-    if (namesOverride?.length) {
-      throw new AddError("Cannot use --all with --name. Use one or the other.");
-    }
-    return addWildcard();
-  }
-
-  // Validate user-provided skill names before any filesystem operations
   if (namesOverride?.length) {
     for (const name of namesOverride) {
       if (!VALID_SKILL_NAME.test(name)) {
@@ -150,368 +277,89 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     }
   }
 
-  let skillName: string;
-
-  if (parsed.type === "local") {
-    // Local source — resolve the path
-    const localDir = await resolveLocalSource(scope.root, parsed.path!);
-
-    if (namesOverride?.length) {
-      // User specified name(s), verify each exists in the local directory
-      for (const name of namesOverride) {
-        const found = await discoverSkill(localDir, name, { scanDirs: HOST_SCAN_DIRS });
-        if (!found) {
-          throw new AddError(
-            `Skill "${name}" not found in ${sourceForStorage}. ` +
-              `Use 'npx @sentry/dotagents add ${sourceForStorage}' without --name to see available skills.`,
-          );
-        }
+  async function persist(selection: AddSelection): Promise<string | string[]> {
+    if (selection.type === "wildcard") {
+      if (
+        config.skills.some(
+          (skill) =>
+            isWildcardDep(skill) &&
+            sourcesMatch(skill.source, sourceForStorage),
+        )
+      ) {
+        throw new AddError(
+          `A wildcard entry for "${sourceForStorage}" already exists in agents.toml.`,
+        );
       }
-
-      if (namesOverride.length === 1) {
-        skillName = namesOverride[0]!;
-      } else {
-        // Multiple names — skip existing, add the rest
-        const toAdd: string[] = [];
-        for (const name of namesOverride) {
-          if (config.skills.some((s) => s.name === name)) {
-            console.warn(
-              chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
-            );
-          } else {
-            toAdd.push(name);
-          }
-        }
-
-        if (toAdd.length === 0) {
-          throw new AddError(
-            "All specified skills already exist in agents.toml.",
-          );
-        }
-
-        for (const name of toAdd) {
-          await addSkillToConfig(configPath, name, {
-            source: sourceForStorage,
-            ...refOpts,
-          });
-        }
-        await runInstall({ scope });
-        return toAdd;
-      }
-    } else {
-      // No names — load SKILL.md from root for the name
-      const meta = await loadSkillMd(join(localDir, "SKILL.md"));
-      skillName = meta.name;
+      await addWildcardToConfig(configPath, sourceForStorage, {
+        ...refOpts,
+        exclude: [],
+      });
+      await runInstall({ scope });
+      return "*";
     }
-  } else if (parsed.type === "well-known") {
-    // Well-known HTTP source — fetch index and download skills
-    const baseUrl = parsed.url!;
-    const u = new URL(baseUrl);
-    const pathname = u.pathname.endsWith("/") ? u.pathname.slice(0, -1) : u.pathname;
-    const cacheKey = `wellknown/${u.host.toLowerCase()}${pathname}`;
 
-    const cached = await ensureWellKnownCached({
-      stateDir: getCacheStateDir(),
-      url: baseUrl,
-      cacheKey,
-    });
+    if (selection.duplicatePolicy === "single") {
+      const name = selection.names[0]!;
+      if (config.skills.some((skill) => skill.name === name)) {
+        throw new AddError(
+          `Skill "${name}" already exists in agents.toml. Remove it first to re-add.`,
+        );
+      }
+      await addSkillToConfig(configPath, name, {
+        source: sourceForStorage,
+        ...refOpts,
+      });
+      await runInstall({ scope });
+      return name;
+    }
 
-    if (!cached) {
+    const toAdd: string[] = [];
+    for (const name of selection.names) {
+      if (config.skills.some((skill) => skill.name === name)) {
+        if (selection.duplicatePolicy === "specified") {
+          console.warn(
+            chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
+          );
+        }
+        continue;
+      }
+      toAdd.push(name);
+    }
+    if (toAdd.length === 0) {
+      const qualifier = selection.duplicatePolicy === "selected"
+        ? "selected"
+        : "specified";
       throw new AddError(
-        `No skills found at ${baseUrl}. If this is a git repository, use the git: prefix: git:${baseUrl}`,
+        `All ${qualifier} skills already exist in agents.toml.`,
       );
     }
-
-    if (namesOverride?.length) {
-      // User specified name(s), verify each exists
-      for (const name of namesOverride) {
-        const found = await discoverSkill(cached.cacheDir, name, { scanDirs: HOST_SCAN_DIRS });
-        if (!found) {
-          throw new AddError(
-            `Skill "${name}" not found in ${sourceForStorage}. ` +
-              `Use 'npx @sentry/dotagents add ${sourceForStorage}' without --name to see available skills.`,
-          );
-        }
-      }
-
-      if (namesOverride.length === 1) {
-        skillName = namesOverride[0]!;
-      } else {
-        // Multiple names — skip existing, add the rest
-        const toAdd: string[] = [];
-        for (const name of namesOverride) {
-          if (config.skills.some((s) => s.name === name)) {
-            console.warn(
-              chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
-            );
-          } else {
-            toAdd.push(name);
-          }
-        }
-
-        if (toAdd.length === 0) {
-          throw new AddError(
-            "All specified skills already exist in agents.toml.",
-          );
-        }
-
-        for (const name of toAdd) {
-          await addSkillToConfig(configPath, name, {
-            source: sourceForStorage,
-            ...refOpts,
-          });
-        }
-        await runInstall({ scope });
-        return toAdd;
-      }
-    } else {
-      // Discover all skills and pick
-      const skills = await discoverAllSkills(cached.cacheDir, { scanDirs: HOST_SCAN_DIRS });
-      if (skills.length === 0) {
-        throw new AddError(`No skills found in ${sourceForStorage}.`);
-      }
-      if (skills.length === 1) {
-        skillName = skills[0]!.meta.name;
-      } else if (interactive) {
-        const mode = await clack.select({
-          message: `Multiple skills found in ${sourceForStorage}. How would you like to add them?`,
-          options: [
-            {
-              label: "All",
-              value: "all" as const,
-              hint: "Wildcard entry — automatically includes new skills added upstream",
-            },
-            {
-              label: "Select specific skills",
-              value: "pick" as const,
-              hint: "Choose individual skills to add",
-            },
-          ],
-        });
-
-        if (clack.isCancel(mode)) {
-          throw new AddCancelledError();
-        }
-
-        if (mode === "all") {
-          return addWildcard();
-        }
-
-        const selected = await clack.multiselect({
-          message: "Select which skills to add:",
-          options: skills
-            .toSorted((a, b) => a.meta.name.localeCompare(b.meta.name))
-            .map((s) => {
-              const lastSlash = s.path.lastIndexOf("/");
-              const parentPath = lastSlash === -1 ? "" : s.path.slice(0, lastSlash);
-              const pathHint = STANDARD_PARENTS.has(parentPath)
-                ? ""
-                : chalk.dim(`(${s.path}) `);
-              return {
-                label: s.meta.name,
-                value: s.meta.name,
-                hint: pathHint + s.meta.description,
-              };
-            }),
-          required: true,
-        });
-
-        if (clack.isCancel(selected)) {
-          throw new AddCancelledError();
-        }
-
-        if (selected.length === 1) {
-          skillName = selected[0]!;
-        } else {
-          const added: string[] = [];
-          for (const name of selected) {
-            if (config.skills.some((s) => s.name === name)) {continue;}
-            await addSkillToConfig(configPath, name, {
-              source: sourceForStorage,
-              ...refOpts,
-            });
-            added.push(name);
-          }
-          if (added.length === 0) {
-            throw new AddError(
-              "All selected skills already exist in agents.toml.",
-            );
-          }
-          await runInstall({ scope });
-          return added;
-        }
-      } else {
-        const names = skills.map((s) => s.meta.name).toSorted();
-        throw new AddError(
-          `Multiple skills found in ${sourceForStorage}: ${names.join(", ")}. ` +
-            `Specify skill names as arguments, use --skill to specify which ones, or --all for all skills.`,
-        );
-      }
+    for (const name of toAdd) {
+      await addSkillToConfig(configPath, name, {
+        source: sourceForStorage,
+        ...refOpts,
+      });
     }
-  } else {
-    // Git source — clone and discover
-    const url = parsed.url!;
-    const cloneUrl = parsed.cloneUrl ?? url;
-    const cacheKey =
-      parsed.type === "github"
-        ? `${parsed.owner}/${parsed.repo}`
-        : sanitizeCacheKey(url);
-
-    const cached = await ensureCached({
-      stateDir: getCacheStateDir(),
-      url: cloneUrl,
-      cacheKey,
-      ref: effectiveRef,
-    });
-
-    if (namesOverride?.length) {
-      // User specified name(s), verify each exists
-      for (const name of namesOverride) {
-        const found = await discoverSkill(cached.repoDir, name, { scanDirs: HOST_SCAN_DIRS });
-        if (!found) {
-          throw new AddError(
-            `Skill "${name}" not found in ${sourceForStorage}. ` +
-              `Use 'npx @sentry/dotagents add ${sourceForStorage}' without --name to see available skills.`,
-          );
-        }
-      }
-
-      if (namesOverride.length === 1) {
-        skillName = namesOverride[0]!;
-      } else {
-        // Multiple names — skip existing, add the rest
-        const toAdd: string[] = [];
-        for (const name of namesOverride) {
-          if (config.skills.some((s) => s.name === name)) {
-            console.warn(
-              chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
-            );
-          } else {
-            toAdd.push(name);
-          }
-        }
-
-        if (toAdd.length === 0) {
-          throw new AddError(
-            "All specified skills already exist in agents.toml.",
-          );
-        }
-
-        for (const name of toAdd) {
-          await addSkillToConfig(configPath, name, {
-            source: sourceForStorage,
-            ...refOpts,
-          });
-        }
-        await runInstall({ scope });
-        return toAdd;
-      }
-    } else {
-      // Discover all skills and pick
-      const skills = await discoverAllSkills(cached.repoDir, { scanDirs: HOST_SCAN_DIRS });
-      if (skills.length === 0) {
-        throw new AddError(`No skills found in ${sourceForStorage}.`);
-      }
-      if (skills.length === 1) {
-        skillName = skills[0]!.meta.name;
-      } else if (interactive) {
-        // Interactive TTY — ask whether to add all or select specific skills
-        const mode = await clack.select({
-          message: `Multiple skills found in ${sourceForStorage}. How would you like to add them?`,
-          options: [
-            {
-              label: "All",
-              value: "all" as const,
-              hint: "Wildcard entry — automatically includes new skills added upstream",
-            },
-            {
-              label: "Select specific skills",
-              value: "pick" as const,
-              hint: "Choose individual skills to add",
-            },
-          ],
-        });
-
-        if (clack.isCancel(mode)) {
-          throw new AddCancelledError();
-        }
-
-        if (mode === "all") {
-          return addWildcard();
-        }
-
-        const selected = await clack.multiselect({
-          message: "Select which skills to add:",
-          options: skills
-            .toSorted((a, b) => a.meta.name.localeCompare(b.meta.name))
-            .map((s) => {
-              const lastSlash = s.path.lastIndexOf("/");
-              const parentPath = lastSlash === -1 ? "" : s.path.slice(0, lastSlash);
-              const pathHint = STANDARD_PARENTS.has(parentPath)
-                ? ""
-                : chalk.dim(`(${s.path}) `);
-              return {
-                label: s.meta.name,
-                value: s.meta.name,
-                hint: pathHint + s.meta.description,
-              };
-            }),
-          required: true,
-        });
-
-        if (clack.isCancel(selected)) {
-          throw new AddCancelledError();
-        }
-
-        if (selected.length === 1) {
-          skillName = selected[0]!;
-        } else {
-          // Multiple selected — add each individually
-          const added: string[] = [];
-          for (const name of selected) {
-            if (config.skills.some((s) => s.name === name)) {continue;}
-            await addSkillToConfig(configPath, name, {
-              source: sourceForStorage,
-              ...refOpts,
-            });
-            added.push(name);
-          }
-          if (added.length === 0) {
-            throw new AddError(
-              "All selected skills already exist in agents.toml.",
-            );
-          }
-          await runInstall({ scope });
-          return added;
-        }
-      } else {
-        // Non-interactive — list them and ask user to re-run with skill names or --all
-        const names = skills.map((s) => s.meta.name).toSorted();
-        throw new AddError(
-          `Multiple skills found in ${sourceForStorage}: ${names.join(", ")}. ` +
-            `Specify skill names as arguments, use --skill to specify which ones, or --all for all skills.`,
-        );
-      }
-    }
+    await runInstall({ scope });
+    return toAdd;
   }
 
-  // Check if skill already exists in config
-  if (config.skills.some((s) => s.name === skillName)) {
-    throw new AddError(
-      `Skill "${skillName}" already exists in agents.toml. Remove it first to re-add.`,
-    );
+  if (all) {
+    return persist({ type: "wildcard" });
   }
 
-  // Add to config
-  await addSkillToConfig(configPath, skillName, {
-    source: sourceForStorage,
-    ...refOpts,
-  });
-
-  // Run install to actually fetch and place the skill
-  await runInstall({ scope });
-
-  return skillName;
+  const acquired = await acquireSkills(
+    parsed,
+    scope,
+    effectiveRef,
+    !!namesOverride?.length,
+  );
+  const selection = await selectSkills(
+    acquired,
+    namesOverride,
+    sourceForStorage,
+    interactive,
+  );
+  return persist(selection);
 }
 
 export default async function add(


### PR DESCRIPTION
Consolidate the add command into source acquisition, skill selection, and persistence phases without changing its supported behavior.

The previous implementation repeated selection, duplicate handling, config writes, and installation across local, git, and well-known sources. Keeping those branches aligned made small changes risky and obscured invariants such as validating all requested skills before writing and installing only once.

This preserves source spelling, trust-before-network ordering, duplicate behavior, local root-skill handling, interactive cancellation, and existing error precedence. The added integration coverage exercises well-known parity and both successful interactive selection paths.

Garfield review and focused Docker QA covered local root, git multi-name, wildcard, and cached well-known add flows.