### PR TITLE
ref(config): Simplify text mutations

### DIFF
--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -7,6 +7,7 @@ import {
   addWildcardToConfig,
   addExcludeToWildcard,
   removeSkillFromConfig,
+  removeSkillBlocksBySource,
   addMcpToConfig,
   removeMcpFromConfig,
   generateDefaultConfig,
@@ -233,6 +234,40 @@ describe("writer", () => {
       const after = await readFile(configPath, "utf-8");
       expect(after).toBe(before);
     });
+
+    it.each([
+      {
+        operation: "named skill",
+        input: `version = 1\n# keep this comment\n\n  [[skills]]\n  name\t=\t'remove-me' # target\n  source\t=\t'org/remove'\n\n[[skills]]\nname = 'keep-me'\nsource = 'org/keep'\n\n[misc]\nvalue = 'unchanged'\n`,
+        expected: `version = 1\n# keep this comment\n\n[[skills]]\nname = 'keep-me'\nsource = 'org/keep'\n\n[misc]\nvalue = 'unchanged'\n`,
+        expectedNames: ["keep-me"],
+        mutate: () => removeSkillFromConfig(configPath, "remove-me"),
+      },
+      {
+        operation: "matching source",
+        input: `version = 1\n\n[[skills]]\nname = 'remove-a'\nsource = 'org/remove'\n\n[[skills]]\nname = "keep"\nsource = "org/keep"\n\n[[skills]]\nname = 'remove-b'\nsource = 'https://github.com/org/remove.git'\n\n[[mcp]]\nname = 'manual'\ncommand = 'keep-this'\n`,
+        expected: `version = 1\n\n[[skills]]\nname = "keep"\nsource = "org/keep"\n\n[[mcp]]\nname = 'manual'\ncommand = 'keep-this'\n`,
+        expectedNames: ["keep"],
+        mutate: () => removeSkillBlocksBySource(configPath, "org/remove"),
+      },
+    ])("preserves unrelated text when removing a $operation", async ({ input, expected, expectedNames, mutate }) => {
+      await writeFile(configPath, input);
+
+      await mutate();
+
+      expect(await readFile(configPath, "utf-8")).toBe(expected);
+      const config = await loadConfig(configPath);
+      expect(config.skills.map((skill) => skill.name)).toEqual(expectedNames);
+    });
+
+    it("leaves source-based removal text unchanged when no source matches", async () => {
+      const input = `version = 1\n\n[[skills]]\n  name = 'keep'\n  source = 'org/keep' # comment\n`;
+      await writeFile(configPath, input);
+
+      await removeSkillBlocksBySource(configPath, "org/missing");
+
+      expect(await readFile(configPath, "utf-8")).toBe(input);
+    });
   });
 
   describe("addWildcardToConfig", () => {
@@ -317,6 +352,20 @@ describe("writer", () => {
       const anthropics = config.skills.find((s) => s.source === "anthropics/skills");
       expect(isWildcardDep(getsentry!) && getsentry!.exclude).toContain("my-skill");
       expect(isWildcardDep(anthropics!) && anthropics!.exclude).toEqual([]);
+    });
+
+    it("preserves indentation and comments around an existing exclude list", async () => {
+      const input = `version = 1\n\n  [[skills]]\n  name = '*'\n  source = 'getsentry/skills'\n  exclude = ['old'] # keep this\n\n[misc]\nvalue = 'unchanged'\n`;
+      await writeFile(configPath, input);
+
+      await addExcludeToWildcard(configPath, "getsentry/skills", "new");
+
+      expect(await readFile(configPath, "utf-8")).toBe(
+        `version = 1\n\n  [[skills]]\n  name = '*'\n  source = 'getsentry/skills'\n  exclude = ['old', "new"] # keep this\n\n[misc]\nvalue = 'unchanged'\n`,
+      );
+      const config = await loadConfig(configPath);
+      const wildcard = config.skills[0]!;
+      expect(isWildcardDep(wildcard) && wildcard.exclude).toEqual(["old", "new"]);
     });
   });
 
@@ -423,6 +472,19 @@ describe("writer", () => {
       const config = await loadConfig(configPath);
       expect(config.mcp).toHaveLength(0);
       expect(config.skills.find((s) => s.name === "github")).toBeDefined();
+    });
+
+    it("preserves comments, quoting, indentation, and adjacent sections", async () => {
+      const input = `version = 1\n# retained\n\n  [[mcp]]\n  name = 'remove-me'\n  command = 'old-command'\n[[mcp]]\nname = 'keep-me'\ncommand = 'keep-command' # retained inline\n\n[trust]\ngithub_orgs = ['example']\n`;
+      const expected = `version = 1\n# retained\n[[mcp]]\nname = 'keep-me'\ncommand = 'keep-command' # retained inline\n\n[trust]\ngithub_orgs = ['example']\n`;
+      await writeFile(configPath, input);
+
+      await removeMcpFromConfig(configPath, "remove-me");
+
+      expect(await readFile(configPath, "utf-8")).toBe(expected);
+      const config = await loadConfig(configPath);
+      expect(config.mcp.map((server) => server.name)).toEqual(["keep-me"]);
+      expect(config.trust?.github_orgs).toEqual(["example"]);
     });
   });
 });

--- a/packages/dotagents/src/config/writer.ts
+++ b/packages/dotagents/src/config/writer.ts
@@ -58,34 +58,11 @@ export async function removeSkillBlocksBySource(
 ): Promise<void> {
   const content = await readFile(filePath, "utf-8");
   const lines = content.split("\n");
-  const result: string[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    if (lines[i]!.trim() === "[[skills]]") {
-      const headerLine = lines[i]!;
-      i++;
-      const { blockLines, nextIndex } = collectBlockLines(lines, i);
-      i = nextIndex;
-
-      const sourceValue = blockLines.map((l) => extractTomlStringValue(l, "source")).find(Boolean);
-
-      if (sourceValue && sourcesMatch(sourceValue, source)) {
-        while (result.length > 0 && result.at(-1)?.trim() === "") {
-          result.pop();
-        }
-        continue;
-      }
-
-      result.push(headerLine, ...blockLines);
-      continue;
-    }
-
-    result.push(lines[i]!);
-    i++;
-  }
-
-  await writeFile(filePath, result.join("\n"), "utf-8");
+  const result = removeArrayTables(lines, "[[skills]]", (span) => {
+    const value = getStringField(lines, span, "source");
+    return value !== undefined && sourcesMatch(value, source);
+  });
+  await writeFile(filePath, result, "utf-8");
 }
 
 /**
@@ -119,55 +96,27 @@ export async function addExcludeToWildcard(
 ): Promise<void> {
   const content = await readFile(filePath, "utf-8");
   const lines = content.split("\n");
-  const result: string[] = [];
-  let i = 0;
-  let found = false;
+  const span = findArrayTables(lines, "[[skills]]").find((candidate) => {
+    const name = getStringField(lines, candidate, "name");
+    const candidateSource = getStringField(lines, candidate, "source");
+    return name === "*" && candidateSource !== undefined && sourcesMatch(candidateSource, source);
+  });
 
-  while (i < lines.length) {
-    if (lines[i]!.trim() === "[[skills]]") {
-      const headerLine = lines[i]!;
-      i++;
-      const { blockLines, nextIndex } = collectBlockLines(lines, i);
-      i = nextIndex;
-
-      const nameValue = blockLines.map((l) => extractTomlStringValue(l, "name")).find(Boolean);
-      const sourceValue = blockLines.map((l) => extractTomlStringValue(l, "source")).find(Boolean);
-
-      if (
-        nameValue === "*" &&
-        sourceValue &&
-        sourcesMatch(sourceValue, source) &&
-        !found
-      ) {
-        found = true;
-        const excludeIdx = blockLines.findIndex((l) => l.trim().startsWith("exclude"));
-        if (excludeIdx >= 0) {
-          const excludeLine = blockLines[excludeIdx]!;
-          const match = excludeLine.trim().match(/^(exclude\s*=\s*)\[([^\]]*)\]/);
-          if (match) {
-            const existing = match[2]!.trim();
-            const newValue = existing
-              ? `${match[1]}[${existing}, ${stringify({ v: skillName }).replace("v = ", "")}]`
-              : `${match[1]}[${stringify({ v: skillName }).replace("v = ", "")}]`;
-            blockLines[excludeIdx] = newValue;
-          }
-        } else {
-          const excludeValue = stringify({ v: [skillName] }).replace("v = ", "");
-          blockLines.push(`exclude = ${excludeValue}`);
-        }
-        result.push(headerLine, ...blockLines);
-        continue;
+  if (span) {
+    const excludeIdx = findFieldLine(lines, span, "exclude");
+    if (excludeIdx === undefined) {
+      lines.splice(span.end, 0, `exclude = ${tomlValue([skillName])}`);
+    } else {
+      const match = lines[excludeIdx]!.match(/^(\s*exclude\s*=\s*)\[([^\]]*)\](.*)$/);
+      if (match) {
+        const existing = match[2]!.trim();
+        const values = existing ? `${existing}, ${tomlValue(skillName)}` : tomlValue(skillName);
+        lines[excludeIdx] = `${match[1]}[${values}]${match[3]}`;
       }
-
-      result.push(headerLine, ...blockLines);
-      continue;
     }
-
-    result.push(lines[i]!);
-    i++;
   }
 
-  await writeFile(filePath, result.join("\n"), "utf-8");
+  await writeFile(filePath, lines.join("\n"), "utf-8");
 }
 
 /**
@@ -215,62 +164,80 @@ function extractTomlStringValue(line: string, key: string): string | undefined {
   return match?.[1] ?? match?.[2];
 }
 
-/**
- * Collect a TOML array-of-tables block starting after the header.
- * Includes blank lines within the block; stops at the next `[` header or EOF.
- */
-function collectBlockLines(lines: string[], start: number): { blockLines: string[]; nextIndex: number } {
-  const blockLines: string[] = [];
-  let i = start;
-  while (i < lines.length && !lines[i]!.trim().startsWith("[")) {
-    blockLines.push(lines[i]!);
+/** Half-open table range ending before its separator blank lines or the next header. */
+interface ArrayTableSpan {
+  start: number;
+  end: number;
+}
+
+function findArrayTables(lines: string[], header: string): ArrayTableSpan[] {
+  const spans: ArrayTableSpan[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i]!.trim() !== header) {
+      i++;
+      continue;
+    }
+
+    const start = i;
     i++;
+    while (i < lines.length && !lines[i]!.trim().startsWith("[")) {i++;}
+    let end = i;
+    while (end > start + 1 && lines[end - 1]!.trim() === "") {end--;}
+    spans.push({ start, end });
   }
-  // Trim trailing blank lines from the block (they belong between blocks, not inside)
-  while (blockLines.length > 0 && blockLines.at(-1)!.trim() === "") {
-    blockLines.pop();
-    i--;
+  return spans;
+}
+
+function findFieldLine(
+  lines: string[],
+  span: ArrayTableSpan,
+  key: string,
+): number | undefined {
+  const assignment = new RegExp(`^${key}\\s*=`);
+  for (let i = span.start + 1; i < span.end; i++) {
+    const trimmed = lines[i]!.trim();
+    if (assignment.test(trimmed)) {return i;}
   }
-  return { blockLines, nextIndex: i };
+  return undefined;
+}
+
+function getStringField(
+  lines: string[],
+  span: ArrayTableSpan,
+  key: string,
+): string | undefined {
+  const fieldLine = findFieldLine(lines, span, key);
+  return fieldLine === undefined
+    ? undefined
+    : extractTomlStringValue(lines[fieldLine]!, key);
+}
+
+function removeArrayTables(
+  lines: string[],
+  header: string,
+  shouldRemove: (span: ArrayTableSpan) => boolean,
+): string {
+  const spans = findArrayTables(lines, header).filter(shouldRemove);
+  for (const span of spans.toReversed()) {
+    let start = span.start;
+    while (start > 0 && lines[start - 1]!.trim() === "") {start--;}
+    lines.splice(start, span.end - start);
+  }
+  return lines.join("\n");
 }
 
 function removeBlockByHeader(content: string, header: string, name: string): string {
   const lines = content.split("\n");
-  const result: string[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    if (lines[i]!.trim() === header) {
-      const headerLine = lines[i]!;
-      i++;
-      const { blockLines, nextIndex } = collectBlockLines(lines, i);
-      i = nextIndex;
-
-      // Check if this block's name matches
-      const nameValue = blockLines.map((l) => extractTomlStringValue(l, "name")).find(Boolean);
-      if (nameValue === name) {
-        // Remove blank lines before the block
-        while (result.length > 0 && result.at(-1)?.trim() === "") {
-          result.pop();
-        }
-        // Skip this block
-        continue;
-      }
-
-      // Not the target — keep the block
-      result.push(headerLine, ...blockLines);
-      continue;
-    }
-
-    result.push(lines[i]!);
-    i++;
-  }
-
-  return result.join("\n");
+  return removeArrayTables(
+    lines,
+    header,
+    (span) => getStringField(lines, span, "name") === name,
+  );
 }
 
-function tomlArray(values: string[]): string {
-  return stringify({ v: values }).replace("v = ", "");
+function tomlValue(value: unknown): string {
+  return stringify({ v: value }).replace("v = ", "").trimEnd();
 }
 
 /**
@@ -308,7 +275,7 @@ export async function addTrustSource(
     const match = trimmedLine.match(new RegExp(`^(${field}\\s*=\\s*)\\[([^\\]]*)\\]`));
     if (match) {
       const existing = match[2]!.trim();
-      const newVal = stringify({ v: value }).replace("v = ", "");
+      const newVal = tomlValue(value);
       const updated = existing
         ? `${match[1]}[${existing}, ${newVal}]`
         : `${match[1]}[${newVal}]`;
@@ -327,7 +294,7 @@ export async function addTrustSource(
       if (trimmed === "" && insertIdx + 1 < lines.length && lines[insertIdx + 1]!.trim().startsWith("[")) {break;}
       insertIdx++;
     }
-    lines.splice(insertIdx, 0, `${field} = ${tomlArray([value])}`);
+    lines.splice(insertIdx, 0, `${field} = ${tomlValue([value])}`);
     await writeFile(filePath, lines.join("\n"), "utf-8");
     return;
   }
@@ -339,12 +306,12 @@ export async function addTrustSource(
   });
 
   if (arrayTableIdx >= 0) {
-    lines.splice(arrayTableIdx, 0, `[trust]`, `${field} = ${tomlArray([value])}`, "");
+    lines.splice(arrayTableIdx, 0, `[trust]`, `${field} = ${tomlValue([value])}`, "");
     await writeFile(filePath, lines.join("\n"), "utf-8");
     return;
   }
 
-  const newContent = `${content.trimEnd()}\n\n[trust]\n${field} = ${tomlArray([value])}\n`;
+  const newContent = `${content.trimEnd()}\n\n[trust]\n${field} = ${tomlValue([value])}\n`;
   await writeFile(filePath, newContent, "utf-8");
 }
 
@@ -447,7 +414,7 @@ export function generateDefaultConfig(opts?: DefaultConfigOptions | string[]): s
       if (fields.length > 0) {
         config += `\n[trust]\n`;
         for (const key of fields) {
-          config += `${key} = ${tomlArray(t[key])}\n`;
+          config += `${key} = ${tomlValue(t[key])}\n`;
         }
       }
     }


### PR DESCRIPTION
Consolidate repeated agents.toml array-table scanning and value encoding without changing the text-preserving mutation strategy.

The config writer intentionally edits TOML as text so CLI operations retain comments and human formatting. Skill, source, MCP, and wildcard operations had accumulated separate scanners with subtly different whitespace handling. This replaces them with one small half-open span mechanism and a shared TOML value encoder.

Trust-table mutation remains specialized because it has different ownership and section semantics. This does not introduce a general TOML parser or whole-document serialization.

Formatting contracts cover comments, indentation, single quotes, blank lines, adjacent sections, textual no-ops, inline comments, and tabs around assignments. Garfield review caught and fixed compatibility with tab-separated fields; built-CLI Docker QA exercised named skill, source, MCP, and wildcard mutations.