### PR TITLE
ref(hooks): Reconcile hook configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ agents = ["claude", "cursor", "codex", "opencode"]
 
 Install and sync repair currently declared MCP entries while preserving undeclared servers and unrelated content in every existing target file. When no servers are declared, existing MCP files remain unchanged because dotagents has no durable evidence that it owns them. Unreadable or structurally incompatible files are reported and left unchanged.
 
+Install and sync also repair the complete generated hook root. Unrelated settings in shared files are preserved; removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+
 Custom subagents are declared with `[[subagents]]` entries. dotagents writes generated runtime-specific files during `install` and repairs them during `sync`:
 
 ```toml

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -223,6 +223,8 @@ Cursor event mapping:
 - `UserPromptSubmit` -> `beforeSubmitPrompt`
 - `Stop` -> `stop`
 
+Install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. The hook root is dotagents-owned: unrelated top-level settings in shared files are preserved, while removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+
 ### Subagents
 
 Each `[[subagents]]` entry requires `name` and `source`. Optional: `ref`, `path`, and `targets`. When `targets` is absent or empty, dotagents attempts every agent listed in `agents` and warns for agents that do not support custom subagents.

--- a/packages/dotagents/src/cli/commands/install.test.ts
+++ b/packages/dotagents/src/cli/commands/install.test.ts
@@ -255,6 +255,44 @@ describe("runInstall", () => {
     ]);
   });
 
+  it("reconciles hook drift and removes owned hook state when declarations are removed", async () => {
+    const configPath = join(projectRoot, "agents.toml");
+    const claudePath = join(projectRoot, ".claude", "settings.json");
+    const cursorPath = join(projectRoot, ".cursor", "hooks.json");
+    await mkdir(join(projectRoot, ".claude"), { recursive: true });
+    await mkdir(join(projectRoot, ".cursor"), { recursive: true });
+    await writeFile(
+      configPath,
+      `version = 1\nagents = ["claude", "cursor"]\n\n[[hooks]]\nevent = "Stop"\ncommand = "check.sh"\n`,
+    );
+    await writeFile(claudePath, JSON.stringify({
+      permissions: { allow: ["Read"] },
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "old.sh" }] }] },
+    }));
+    await writeFile(cursorPath, JSON.stringify({
+      version: 2,
+      hooks: { stop: [{ command: "old.sh" }] },
+    }));
+
+    const scope = resolveScope("project", projectRoot);
+    await runInstall({ scope });
+    expect(JSON.parse(await readFile(claudePath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "check.sh" }] }] },
+    });
+    expect(JSON.parse(await readFile(cursorPath, "utf-8"))).toEqual({
+      version: 1,
+      hooks: { stop: [{ command: "check.sh" }] },
+    });
+
+    await writeFile(configPath, `version = 1\nagents = ["claude", "cursor"]\n`);
+    await runInstall({ scope });
+    expect(JSON.parse(await readFile(claudePath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+    });
+    expect(existsSync(cursorPath)).toBe(false);
+  });
+
   it("returns hook warnings for unsupported agents", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),

--- a/packages/dotagents/src/cli/commands/install/agent-runtime.ts
+++ b/packages/dotagents/src/cli/commands/install/agent-runtime.ts
@@ -3,7 +3,7 @@ import type { ScopeRoot } from "../../../scope.js";
 import { ensureSkillsSymlink } from "../../../symlinks/manager.js";
 import { skillSymlinkTargets } from "../../../targets/skill-symlinks.js";
 import { projectMcpResolver, reconcileMcpConfigs, toMcpDeclarations } from "../../../targets/mcp-writer.js";
-import { projectHookResolver, toHookDeclarations, writeHookConfigs } from "../../../targets/hook-writer.js";
+import { projectHookResolver, reconcileHookConfigs, toHookDeclarations } from "../../../targets/hook-writer.js";
 import { userMcpResolver } from "../../../targets/paths.js";
 import {
   pruneSubagentConfigs,
@@ -51,11 +51,13 @@ export async function writeHookRuntime(
   scope: ScopeRoot,
 ): Promise<{ agent: string; message: string }[]> {
   if (scope.scope !== "project") {return [];}
-  return writeHookConfigs(
+  const result = await reconcileHookConfigs(
     config.agents,
     toHookDeclarations(config.hooks),
     projectHookResolver(scope.root),
+    "apply",
   );
+  return result.warnings;
 }
 
 /** Writes agent-specific subagent runtime projections. */

--- a/packages/dotagents/src/cli/commands/sync.test.ts
+++ b/packages/dotagents/src/cli/commands/sync.test.ts
@@ -459,35 +459,43 @@ headers = { Authorization = "Bearer tok" }
     expect((await lstat(join(projectRoot, ".claude", "skills"))).isSymbolicLink()).toBe(true);
   });
 
-  it("repairs missing hook configs", async () => {
+  it("reconciles missing, drifted, and removed hook configs", async () => {
+    const configPath = join(projectRoot, "agents.toml");
+    const settingsPath = join(projectRoot, ".claude", "settings.json");
     await writeFile(
-      join(projectRoot, "agents.toml"),
+      configPath,
       `version = 1\nagents = ["claude"]\n\n[[hooks]]\nevent = "PreToolUse"\nmatcher = "Bash"\ncommand = ".agents/hooks/block-rm.sh"\n`,
     );
 
-    const result = await runSync({ scope: resolveScope("project", projectRoot) });
-    expect(result.hooksRepaired).toBeGreaterThan(0);
-
-    // Verify config was created
-    expect(existsSync(join(projectRoot, ".claude", "settings.json"))).toBe(true);
-
-    const settings = JSON.parse(await readFile(join(projectRoot, ".claude", "settings.json"), "utf-8"));
+    const scope = resolveScope("project", projectRoot);
+    const missing = await runSync({ scope });
+    expect(missing.hooksRepaired).toBe(1);
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
     expect(settings.hooks.PreToolUse).toBeDefined();
-  });
 
-  it("reports no hook issues when configs are present", async () => {
-    await writeFile(
-      join(projectRoot, "agents.toml"),
-      `version = 1\nagents = ["claude"]\n\n[[hooks]]\nevent = "Stop"\ncommand = "check.sh"\n`,
-    );
+    await writeFile(settingsPath, JSON.stringify({
+      permissions: { allow: ["Read"] },
+      hooks: { PreToolUse: [{ matcher: "Write", hooks: [{ type: "command", command: "old.sh" }] }] },
+    }));
+    const drifted = await runSync({ scope });
+    expect(drifted.hooksRepaired).toBe(1);
+    expect(drifted.issues.filter((issue) => issue.type === "hooks")).toEqual([]);
+    expect(JSON.parse(await readFile(settingsPath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+      hooks: {
+        PreToolUse: [{
+          matcher: "Bash",
+          hooks: [{ type: "command", command: ".agents/hooks/block-rm.sh" }],
+        }],
+      },
+    });
 
-    // First sync to create the config
-    await runSync({ scope: resolveScope("project", projectRoot) });
-
-    // Second sync should find everything in order
-    const result = await runSync({ scope: resolveScope("project", projectRoot) });
-    expect(result.hooksRepaired).toBe(0);
-    expect(result.issues.filter((i) => i.type === "hooks")).toHaveLength(0);
+    await writeFile(configPath, `version = 1\nagents = ["claude"]\n`);
+    const removed = await runSync({ scope });
+    expect(removed.hooksRepaired).toBe(1);
+    expect(JSON.parse(await readFile(settingsPath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+    });
   });
 
   it("repairs missing subagent configs", async () => {

--- a/packages/dotagents/src/cli/commands/sync.ts
+++ b/packages/dotagents/src/cli/commands/sync.ts
@@ -12,7 +12,7 @@ import { writeAgentsGitignore, checkRootGitignoreEntries } from "../../gitignore
 import { ensureSkillsSymlink, verifySymlinks } from "../../symlinks/manager.js";
 import { skillSymlinkTargets } from "../../targets/skill-symlinks.js";
 import { reconcileMcpConfigs, toMcpDeclarations, projectMcpResolver } from "../../targets/mcp-writer.js";
-import { verifyHookConfigs, writeHookConfigs, toHookDeclarations, projectHookResolver } from "../../targets/hook-writer.js";
+import { reconcileHookConfigs, toHookDeclarations, projectHookResolver } from "../../targets/hook-writer.js";
 import { pruneSubagentConfigs, verifySubagentConfigs, writeSubagentConfigs, projectSubagentResolver, userSubagentResolver } from "../../subagents/writer.js";
 import { loadInstalledSubagents, pruneInstalledSubagents } from "../../subagents/store.js";
 import { userMcpResolver } from "../../targets/paths.js";
@@ -198,18 +198,13 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
     const hookDecls = toHookDeclarations(config.hooks);
     const hookResolver = projectHookResolver(scope.root);
 
-    const hookIssues = await verifyHookConfigs(config.agents, hookDecls, hookResolver);
-    if (hookIssues.length > 0) {
-      await writeHookConfigs(config.agents, hookDecls, hookResolver);
-      hooksRepaired = hookIssues.length;
-      for (const issue of hookIssues) {
-        issues.push({
-          type: "hooks",
-          name: issue.agent,
-          message: issue.issue,
-        });
-      }
-    }
+    const hookResult = await reconcileHookConfigs(
+      config.agents,
+      hookDecls,
+      hookResolver,
+      "apply",
+    );
+    hooksRepaired = hookResult.written.length + hookResult.removed.length;
   }
 
   // 7. Verify and repair custom subagent files

--- a/packages/dotagents/src/targets/hook-writer.test.ts
+++ b/packages/dotagents/src/targets/hook-writer.test.ts
@@ -3,7 +3,13 @@ import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { existsSync } from "node:fs";
-import { writeHookConfigs, verifyHookConfigs, toHookDeclarations, projectHookResolver } from "./hook-writer.js";
+import {
+  projectHookResolver,
+  reconcileHookConfigs,
+  toHookDeclarations,
+  verifyHookConfigs,
+  writeHookConfigs,
+} from "./hook-writer.js";
 import type { HookDeclaration } from "./types.js";
 import type { HookConfig } from "../config/schema.js";
 
@@ -41,10 +47,15 @@ describe("writeHookConfigs", () => {
     await rm(dir, { recursive: true });
   });
 
-  it("skips when no hooks declared", async () => {
-    const warnings = await writeHookConfigs(["claude"], [], projectHookResolver(dir));
+  it("preserves the legacy empty-input no-op", async () => {
+    const filePath = join(dir, ".cursor", "hooks.json");
+    const content = '{"version":1,"hooks":{"stop":[]}}';
+    await mkdir(join(dir, ".cursor"), { recursive: true });
+    await writeFile(filePath, content);
+
+    const warnings = await writeHookConfigs(["cursor"], [], projectHookResolver(dir));
     expect(warnings).toEqual([]);
-    expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(false);
+    expect(await readFile(filePath, "utf-8")).toBe(content);
   });
 
   it("writes claude .claude/settings.json", async () => {
@@ -179,9 +190,15 @@ describe("verifyHookConfigs", () => {
     expect(issues).toEqual([]);
   });
 
-  it("returns empty when no hooks declared", async () => {
+  it("preserves the legacy empty-input no-op", async () => {
+    const filePath = join(dir, ".cursor", "hooks.json");
+    const content = '{"version":1,"hooks":{"stop":[]}}';
+    await mkdir(join(dir, ".cursor"), { recursive: true });
+    await writeFile(filePath, content);
+
     const issues = await verifyHookConfigs(["claude"], [], projectHookResolver(dir));
     expect(issues).toEqual([]);
+    expect(await readFile(filePath, "utf-8")).toBe(content);
   });
 
   it("reports missing hooks key", async () => {
@@ -195,6 +212,152 @@ describe("verifyHookConfigs", () => {
 
     const issues = await verifyHookConfigs(["claude"], HOOKS, projectHookResolver(dir));
     expect(issues).toHaveLength(1);
-    expect(issues[0]!.issue).toContain("hooks");
+    expect(issues[0]!.issue).toContain("drifted");
+  });
+
+  it("reports a non-object document instead of throwing", async () => {
+    const claudeDir = join(dir, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(join(claudeDir, "settings.json"), "null\n");
+
+    const issues = await verifyHookConfigs(["claude"], HOOKS, projectHookResolver(dir));
+    expect(issues).toEqual([{
+      agent: "claude",
+      issue: `Failed to read hook config: ${join(claudeDir, "settings.json")}`,
+    }]);
+  });
+});
+
+describe("reconcileHookConfigs", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dotagents-hooks-reconcile-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true });
+  });
+
+  it("repairs shared hook drift while preserving unrelated settings", async () => {
+    const filePath = join(dir, ".claude", "settings.json");
+    await mkdir(join(dir, ".claude"), { recursive: true });
+    await writeFile(filePath, JSON.stringify({
+      permissions: { allow: ["Read"] },
+      hooks: {
+        PreToolUse: [{ matcher: "Write", hooks: [{ type: "command", command: "old.sh" }] }],
+      },
+    }));
+
+    const inspected = await reconcileHookConfigs(
+      ["claude"],
+      HOOKS,
+      projectHookResolver(dir),
+      "inspect",
+    );
+    expect(inspected.issues).toEqual([{
+      agent: "claude",
+      issue: `Hook config drifted: ${filePath}`,
+    }]);
+    expect(inspected.written).toEqual([]);
+
+    const applied = await reconcileHookConfigs(
+      ["claude"],
+      HOOKS,
+      projectHookResolver(dir),
+      "apply",
+    );
+    expect(applied.written).toEqual([filePath]);
+    expect(JSON.parse(await readFile(filePath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+      hooks: {
+        PreToolUse: [{
+          matcher: "Bash",
+          hooks: [{ type: "command", command: ".agents/hooks/block-rm.sh" }],
+        }],
+        Stop: [{ hooks: [{ type: "command", command: ".agents/hooks/check-tests.sh" }] }],
+      },
+    });
+  });
+
+  it("repairs Cursor event mapping and dedicated document fields", async () => {
+    const filePath = join(dir, ".cursor", "hooks.json");
+    await mkdir(join(dir, ".cursor"), { recursive: true });
+    await writeFile(filePath, JSON.stringify({
+      version: 2,
+      hooks: { beforeShellExecution: [{ command: "old.sh" }] },
+    }));
+
+    const result = await reconcileHookConfigs(
+      ["cursor"],
+      HOOKS,
+      projectHookResolver(dir),
+      "apply",
+    );
+
+    expect(result.written).toEqual([filePath]);
+    expect(JSON.parse(await readFile(filePath, "utf-8"))).toEqual({
+      version: 1,
+      hooks: {
+        beforeShellExecution: [{ command: ".agents/hooks/block-rm.sh" }],
+        beforeMCPExecution: [{ command: ".agents/hooks/block-rm.sh" }],
+        stop: [{ command: ".agents/hooks/check-tests.sh" }],
+      },
+    });
+  });
+
+  it("removes an empty shared hook root once for Claude and VS Code", async () => {
+    const filePath = join(dir, ".claude", "settings.json");
+    await mkdir(join(dir, ".claude"), { recursive: true });
+    await writeFile(filePath, JSON.stringify({
+      permissions: { allow: ["Read"] },
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "stale.sh" }] }] },
+    }));
+
+    const result = await reconcileHookConfigs(
+      ["claude", "vscode"],
+      [],
+      projectHookResolver(dir),
+      "apply",
+    );
+
+    expect(result.written).toEqual([filePath]);
+    expect(JSON.parse(await readFile(filePath, "utf-8"))).toEqual({
+      permissions: { allow: ["Read"] },
+    });
+  });
+
+  it("removes a dedicated Cursor hook file when no hooks remain", async () => {
+    const filePath = join(dir, ".cursor", "hooks.json");
+    await mkdir(join(dir, ".cursor"), { recursive: true });
+    await writeFile(filePath, JSON.stringify({ version: 1, hooks: { stop: [] } }));
+
+    const result = await reconcileHookConfigs(
+      ["cursor"],
+      [],
+      projectHookResolver(dir),
+      "apply",
+    );
+
+    expect(result.removed).toEqual([filePath]);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it("returns unsupported-agent warnings separately from drift", async () => {
+    const result = await reconcileHookConfigs(
+      ["claude", "codex"],
+      HOOKS,
+      projectHookResolver(dir),
+      "inspect",
+    );
+
+    expect(result.issues).toEqual([{
+      agent: "claude",
+      issue: `Hook config missing: ${join(dir, ".claude", "settings.json")}`,
+    }]);
+    expect(result.warnings).toEqual([{
+      agent: "codex",
+      message: 'Agent "Codex" does not support hooks',
+    }]);
   });
 });

--- a/packages/dotagents/src/targets/hook-writer.ts
+++ b/packages/dotagents/src/targets/hook-writer.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { existsSync } from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 import { getAgent } from "./registry.js";
 import type { HookDeclaration, HookConfigSpec } from "./types.js";
 import type { HookConfig } from "../config/schema.js";
@@ -12,9 +13,24 @@ export interface HookResolvedTarget {
 
 export type HookTargetResolver = (agentId: string, spec: HookConfigSpec) => HookResolvedTarget;
 
-/**
- * Convert HookConfig entries (from agents.toml) to universal HookDeclarations.
- */
+export interface HookReconcileIssue {
+  agent: string;
+  issue: string;
+}
+
+export interface HookWriteWarning {
+  agent: string;
+  message: string;
+}
+
+export interface HookReconcileResult {
+  issues: HookReconcileIssue[];
+  warnings: HookWriteWarning[];
+  written: string[];
+  removed: string[];
+}
+
+/** Convert HookConfig entries from agents.toml to universal declarations. */
 export function toHookDeclarations(configs: HookConfig[]): HookDeclaration[] {
   return configs.map((h) => ({
     event: h.event,
@@ -23,9 +39,7 @@ export function toHookDeclarations(configs: HookConfig[]): HookDeclaration[] {
   }));
 }
 
-/**
- * Convenience resolver for project-scope hooks: joins spec.filePath with projectRoot.
- */
+/** Resolve project hook config paths relative to the project root. */
 export function projectHookResolver(projectRoot: string): HookTargetResolver {
   return (_id: string, spec: HookConfigSpec) => ({
     filePath: join(projectRoot, spec.filePath),
@@ -33,25 +47,37 @@ export function projectHookResolver(projectRoot: string): HookTargetResolver {
   });
 }
 
-export interface HookWriteWarning {
-  agent: string;
-  message: string;
-}
-
-/**
- * Write hook config files for each agent.
- * - Dedicated files (shared=false): written fresh each time.
- * - Shared files (shared=true): read existing, merge hooks under the root key, write back.
- * - Agents that don't support hooks: collected as warnings.
- */
+/** Write hook configs while retaining the v1 warning-only result shape. */
 export async function writeHookConfigs(
   agentIds: string[],
   hooks: HookDeclaration[],
   resolveTarget: HookTargetResolver,
 ): Promise<HookWriteWarning[]> {
-  const warnings: HookWriteWarning[] = [];
-  if (hooks.length === 0) {return warnings;}
+  if (hooks.length === 0) {return [];}
+  return (await reconcileHookConfigs(agentIds, hooks, resolveTarget, "apply")).warnings;
+}
 
+/** Inspect hook configs while retaining the v1 issue-only result shape. */
+export async function verifyHookConfigs(
+  agentIds: string[],
+  hooks: HookDeclaration[],
+  resolveTarget: HookTargetResolver,
+): Promise<HookReconcileIssue[]> {
+  if (hooks.length === 0) {return [];}
+  return (await reconcileHookConfigs(agentIds, hooks, resolveTarget, "inspect")).issues;
+}
+
+/** Inspect or apply the target-specific hook root owned by dotagents. */
+export async function reconcileHookConfigs(
+  agentIds: string[],
+  hooks: HookDeclaration[],
+  resolveTarget: HookTargetResolver,
+  mode: "inspect" | "apply",
+): Promise<HookReconcileResult> {
+  const issues: HookReconcileIssue[] = [];
+  const warnings: HookWriteWarning[] = [];
+  const written: string[] = [];
+  const removed: string[] = [];
   const seen = new Set<string>();
 
   for (const id of agentIds) {
@@ -59,98 +85,113 @@ export async function writeHookConfigs(
     if (!agent) {continue;}
 
     if (!agent.hooks) {
-      warnings.push({ agent: id, message: `Agent "${agent.displayName}" does not support hooks` });
+      if (hooks.length > 0) {
+        warnings.push({
+          agent: id,
+          message: `Agent "${agent.displayName}" does not support hooks`,
+        });
+      }
       continue;
     }
 
-    const serialized = agent.serializeHooks(hooks);
     const spec = agent.hooks;
     const { filePath, shared } = resolveTarget(id, spec);
     if (seen.has(filePath)) {continue;}
     seen.add(filePath);
 
-    await mkdir(dirname(filePath), { recursive: true });
+    if (hooks.length === 0) {
+      if (!existsSync(filePath)) {continue;}
+      if (!shared) {
+        issues.push({ agent: id, issue: `Stale hook config: ${filePath}` });
+        if (mode === "apply") {
+          await rm(filePath);
+          removed.push(filePath);
+        }
+        continue;
+      }
 
-    if (shared) {
-      await mergeWrite(filePath, spec, serialized);
-    } else {
-      await freshWrite(filePath, spec, serialized);
-    }
-  }
-
-  return warnings;
-}
-
-/**
- * Verify hook configs exist and contain expected hook data.
- * Returns a list of issues found.
- */
-export async function verifyHookConfigs(
-  agentIds: string[],
-  hooks: HookDeclaration[],
-  resolveTarget: HookTargetResolver,
-): Promise<{ agent: string; issue: string }[]> {
-  if (hooks.length === 0) {return [];}
-
-  const issues: { agent: string; issue: string }[] = [];
-  const seen = new Set<string>();
-
-  for (const id of agentIds) {
-    const agent = getAgent(id);
-    if (!agent) {continue;}
-
-    // Skip agents that don't support hooks
-    if (!agent.hooks) {continue;}
-
-    const spec = agent.hooks;
-    const { filePath } = resolveTarget(id, spec);
-    if (seen.has(filePath)) {continue;}
-    seen.add(filePath);
-
-    if (!existsSync(filePath)) {
-      issues.push({ agent: id, issue: `Hook config missing: ${filePath}` });
+      const existing = await readForCleanup(filePath, issues, id);
+      if (!existing || !(spec.rootKey in existing)) {continue;}
+      issues.push({ agent: id, issue: `Stale hook root "${spec.rootKey}" in ${filePath}` });
+      if (mode === "apply") {
+        delete existing[spec.rootKey];
+        await writeDocument(filePath, existing);
+        written.push(filePath);
+      }
       continue;
     }
 
-    try {
-      const existing = await readExisting(filePath);
-      const hooksSection = existing[spec.rootKey];
-      if (!hooksSection || typeof hooksSection !== "object") {
-        issues.push({ agent: id, issue: `Hook config missing "${spec.rootKey}" key in ${filePath}` });
+    const serialized = agent.serializeHooks(hooks);
+    const expected = { ...spec.extraFields, [spec.rootKey]: serialized };
+    if (!existsSync(filePath)) {
+      issues.push({ agent: id, issue: `Hook config missing: ${filePath}` });
+      if (mode === "apply") {
+        await writeDocument(filePath, expected);
+        written.push(filePath);
       }
-    } catch {
+      continue;
+    }
+
+    let existing: Record<string, unknown> | undefined;
+    try {
+      existing = await readExisting(filePath);
+    } catch (error) {
       issues.push({ agent: id, issue: `Failed to read hook config: ${filePath}` });
+      if (mode === "apply" && !shared) {
+        await writeDocument(filePath, expected);
+        written.push(filePath);
+        continue;
+      }
+      if (mode === "apply") {throw error;}
+      continue;
+    }
+
+    const matches = shared
+      ? isDeepStrictEqual(existing[spec.rootKey], serialized)
+      : isDeepStrictEqual(existing, expected);
+    if (matches) {continue;}
+
+    issues.push({ agent: id, issue: `Hook config drifted: ${filePath}` });
+    if (mode === "apply") {
+      const next = shared ? { ...existing, [spec.rootKey]: serialized } : expected;
+      await writeDocument(filePath, next);
+      written.push(filePath);
     }
   }
 
-  return issues;
+  return { issues, warnings, written, removed };
 }
 
-// --- Internal helpers ---
-
-async function freshWrite(
+async function readForCleanup(
   filePath: string,
-  spec: HookConfigSpec,
-  serialized: unknown,
-): Promise<void> {
-  const doc: Record<string, unknown> = {
-    ...spec.extraFields,
-    [spec.rootKey]: serialized,
-  };
-  await writeFile(filePath, `${JSON.stringify(doc, null, 2)}\n`, "utf-8");
+  issues: HookReconcileIssue[],
+  agent: string,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    return await readExisting(filePath);
+  } catch {
+    issues.push({ agent, issue: `Failed to read hook config: ${filePath}` });
+    return undefined;
+  }
 }
 
-async function mergeWrite(
+async function writeDocument(
   filePath: string,
-  spec: HookConfigSpec,
-  serialized: unknown,
+  document: Record<string, unknown>,
 ): Promise<void> {
-  const existing = existsSync(filePath) ? await readExisting(filePath) : {};
-  existing[spec.rootKey] = serialized;
-  await writeFile(filePath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(document, null, 2)}\n`, "utf-8");
 }
 
 async function readExisting(filePath: string): Promise<Record<string, unknown>> {
   const raw = await readFile(filePath, "utf-8");
-  return JSON.parse(raw) as Record<string, unknown>;
+  const document: unknown = JSON.parse(raw);
+  if (!isRecord(document)) {
+    throw new TypeError(`Hook config must contain an object: ${filePath}`);
+  }
+  return document;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -193,6 +193,8 @@ Hook declarations. Each entry defines a hook that dotagents will configure for a
 | `matcher` | No | Tool name to match (e.g. `Bash`). Only for `PreToolUse` and `PostToolUse`. |
 | `command` | Yes | Shell command to execute when the hook fires. |
 
+Install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. The hook root is dotagents-owned: unrelated top-level settings in shared files are preserved, while removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+
 #### `[[subagents]]`
 
 Custom subagent dependencies. Each entry selects one subagent artifact from a source. dotagents imports the artifact into a portable subagent declaration, installs canonical managed Markdown into `.agents/agents/`, and writes generated runtime files for agents listed in `agents` that support custom subagents: Claude, Cursor, Codex, and OpenCode.


### PR DESCRIPTION
Reconcile generated hook state through one lifecycle shared by install and
sync.

Hook verification previously accepted any object at the expected root, so
stale commands, matchers, and Cursor event mappings could survive sync.
Reconciliation now compares the complete serialized hook root and repairs
each affected target once.

The hook root remains dotagents-owned under the existing write contract.
Unrelated top-level settings in shared files are preserved, while removing
all hook declarations removes the shared hook root or dedicated Cursor hook
file. The older write and verify wrappers retain their historical empty-input
no-op behavior.

Garfield review found and fixed compatibility issues around legacy empty
input and non-object JSON inspection. `pnpm check` passed all 804 tests, and
Docker QA covered the full example plus hook drift, shared-setting
preservation, empty-state cleanup, and unsupported-agent warnings.
