### PR TITLE
ref(subagents): Reconcile runtime configs

### DIFF
--- a/packages/dotagents/src/agents/index.ts
+++ b/packages/dotagents/src/agents/index.ts
@@ -9,6 +9,7 @@ export {
   writeSubagentConfigs,
   pruneSubagentConfigs,
   verifySubagentConfigs,
+  reconcileSubagentConfigs,
   projectSubagentResolver,
   userSubagentResolver,
 } from "../subagents/writer.js";
@@ -25,6 +26,8 @@ export type {
   SubagentWriteWarning,
   SubagentWriteResult,
   SubagentVerifyIssue,
+  SubagentReconcileOptions,
+  SubagentReconcileResult,
 } from "../subagents/writer.js";
 export type {
   SubagentResolveOptions,

--- a/packages/dotagents/src/agents/index.ts
+++ b/packages/dotagents/src/agents/index.ts
@@ -9,7 +9,6 @@ export {
   writeSubagentConfigs,
   pruneSubagentConfigs,
   verifySubagentConfigs,
-  reconcileSubagentConfigs,
   projectSubagentResolver,
   userSubagentResolver,
 } from "../subagents/writer.js";
@@ -26,8 +25,6 @@ export type {
   SubagentWriteWarning,
   SubagentWriteResult,
   SubagentVerifyIssue,
-  SubagentReconcileOptions,
-  SubagentReconcileResult,
 } from "../subagents/writer.js";
 export type {
   SubagentResolveOptions,

--- a/packages/dotagents/src/cli/commands/install/agent-runtime.ts
+++ b/packages/dotagents/src/cli/commands/install/agent-runtime.ts
@@ -6,10 +6,9 @@ import { projectMcpResolver, reconcileMcpConfigs, toMcpDeclarations } from "../.
 import { projectHookResolver, reconcileHookConfigs, toHookDeclarations } from "../../../targets/hook-writer.js";
 import { userMcpResolver } from "../../../targets/paths.js";
 import {
-  pruneSubagentConfigs,
   projectSubagentResolver,
+  reconcileSubagentConfigs,
   userSubagentResolver,
-  writeSubagentConfigs,
 } from "../../../subagents/writer.js";
 import type { SubagentDeclaration } from "../../../subagents/types.js";
 
@@ -70,9 +69,9 @@ export async function writeSubagentRuntime(
   const resolver = scope.scope === "user"
     ? userSubagentResolver()
     : projectSubagentResolver(scope.root);
-  const result = await writeSubagentConfigs(config.agents, subagents, resolver);
-  if (!frozen) {
-    await pruneSubagentConfigs(config.agents, subagents, resolver);
-  }
+  const result = await reconcileSubagentConfigs(config.agents, subagents, resolver, {
+    mode: "apply",
+    prune: !frozen,
+  });
   return result.warnings;
 }

--- a/packages/dotagents/src/cli/commands/sync.ts
+++ b/packages/dotagents/src/cli/commands/sync.ts
@@ -13,7 +13,7 @@ import { ensureSkillsSymlink, verifySymlinks } from "../../symlinks/manager.js";
 import { skillSymlinkTargets } from "../../targets/skill-symlinks.js";
 import { reconcileMcpConfigs, toMcpDeclarations, projectMcpResolver } from "../../targets/mcp-writer.js";
 import { reconcileHookConfigs, toHookDeclarations, projectHookResolver } from "../../targets/hook-writer.js";
-import { pruneSubagentConfigs, verifySubagentConfigs, writeSubagentConfigs, projectSubagentResolver, userSubagentResolver } from "../../subagents/writer.js";
+import { projectSubagentResolver, reconcileSubagentConfigs, userSubagentResolver } from "../../subagents/writer.js";
 import { loadInstalledSubagents, pruneInstalledSubagents } from "../../subagents/store.js";
 import { userMcpResolver } from "../../targets/paths.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
@@ -215,23 +215,16 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
   const subagentResolver = scope.scope === "user"
     ? userSubagentResolver()
     : projectSubagentResolver(scope.root);
-  const subagentIssues = await verifySubagentConfigs(
+  const subagentResult = await reconcileSubagentConfigs(
     config.agents,
     subagentDecls,
     subagentResolver,
+    {
+      mode: "apply",
+      desiredSubagents: config.subagents,
+    },
   );
-
-  const subagentResult = await writeSubagentConfigs(
-    config.agents,
-    subagentDecls,
-    subagentResolver,
-  );
-  const prunedSubagentConfigs = await pruneSubagentConfigs(
-    config.agents,
-    config.subagents,
-    subagentResolver,
-  );
-  subagentsRepaired = subagentResult.written + prunedSubagentConfigs.length + prunedInstalledSubagents.length;
+  subagentsRepaired = subagentResult.written + subagentResult.pruned.length + prunedInstalledSubagents.length;
 
   for (const issue of installedSubagentResult.issues) {
     issues.push({
@@ -240,7 +233,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
       message: issue.issue,
     });
   }
-  for (const issue of subagentIssues) {
+  for (const issue of subagentResult.issues) {
     issues.push({
       type: "subagents",
       name: issue.name,

--- a/packages/dotagents/src/cli/commands/sync.ts
+++ b/packages/dotagents/src/cli/commands/sync.ts
@@ -221,7 +221,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
     subagentResolver,
     {
       mode: "apply",
-      desiredSubagents: config.subagents,
+      retainedSubagents: config.subagents,
     },
   );
   subagentsRepaired = subagentResult.written + subagentResult.pruned.length + prunedInstalledSubagents.length;
@@ -240,19 +240,6 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
       message: issue.issue,
     });
   }
-  for (const warning of subagentResult.warnings) {
-    const alreadyReported = issues.some(
-      (issue) => issue.type === "subagents" && issue.message === warning.message,
-    );
-    if (!alreadyReported) {
-      issues.push({
-        type: "subagents",
-        name: warning.name,
-        message: warning.message,
-      });
-    }
-  }
-
   return {
     issues,
     adopted,

--- a/packages/dotagents/src/subagents/writer.test.ts
+++ b/packages/dotagents/src/subagents/writer.test.ts
@@ -622,7 +622,7 @@ describe("reconcileSubagentConfigs", () => {
       projectSubagentResolver(dir),
       {
         mode: "apply",
-        desiredSubagents: [SUBAGENT, { name: "failed-reviewer" }],
+        retainedSubagents: [SUBAGENT, { name: "failed-reviewer" }],
       },
     );
 
@@ -647,6 +647,22 @@ describe("reconcileSubagentConfigs", () => {
     expect(result.written).toBe(0);
     expect(result.pruned).toEqual([]);
     expect(existsSync(join(dir, ".vscode"))).toBe(false);
+  });
+
+  it("finishes inspection before writing any runtime files", async () => {
+    const resolver = (agentId: string, spec: { projectDir: string }) => {
+      if (agentId === "codex") {throw new Error("failed to resolve codex target");}
+      return { dirPath: join(dir, spec.projectDir) };
+    };
+
+    await expect(reconcileSubagentConfigs(
+      ["claude", "codex"],
+      [{ ...SUBAGENT, targets: ["claude", "codex"] }],
+      resolver,
+      { mode: "apply" },
+    )).rejects.toThrow("failed to resolve codex target");
+
+    expect(existsSync(join(dir, ".claude", "agents", "code-reviewer.md"))).toBe(false);
   });
 
   it("reports unreadable configs during inspection and fails during apply", async () => {

--- a/packages/dotagents/src/subagents/writer.test.ts
+++ b/packages/dotagents/src/subagents/writer.test.ts
@@ -7,6 +7,7 @@ import { parse as parseTOML } from "smol-toml";
 import {
   projectSubagentResolver,
   pruneSubagentConfigs,
+  reconcileSubagentConfigs,
   verifySubagentConfigs,
   writeSubagentConfigs,
 } from "./writer.js";
@@ -17,6 +18,12 @@ const SUBAGENT: SubagentDeclaration = {
   name: "code-reviewer",
   description: "Review code for correctness and missing tests.",
   instructions: "Review the current diff and return findings.",
+};
+
+const OTHER_SUBAGENT: SubagentDeclaration = {
+  name: "test-writer",
+  description: "Write focused tests.",
+  instructions: "Add regression coverage for the current change.",
 };
 
 describe("writeSubagentConfigs", () => {
@@ -557,5 +564,114 @@ Hand-written instructions.
 
     expect(issues).toHaveLength(1);
     expect(issues[0]!.issue).toContain("identity conflicts with unmanaged file");
+  });
+});
+
+describe("reconcileSubagentConfigs", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dotagents-subagents-reconcile-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true });
+  });
+
+  it("inspects missing and conflicting configs without mutation", async () => {
+    const targetDir = join(dir, ".claude", "agents");
+    await mkdir(targetDir, { recursive: true });
+    const unmanagedPath = join(targetDir, "reviewer.md");
+    await writeFile(
+      unmanagedPath,
+      `---\nname: code-reviewer\ndescription: Hand-written reviewer.\n---\n`,
+      "utf-8",
+    );
+
+    const result = await reconcileSubagentConfigs(
+      ["claude"],
+      [SUBAGENT, OTHER_SUBAGENT],
+      projectSubagentResolver(dir),
+      { mode: "inspect" },
+    );
+
+    expect(result.issues.map(({ issue }) => issue)).toEqual([
+      `Subagent config identity conflicts with unmanaged file: ${unmanagedPath}`,
+      `Subagent config missing: ${join(targetDir, "test-writer.md")}`,
+    ]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.written).toBe(0);
+    expect(result.pruned).toEqual([]);
+    expect(existsSync(join(targetDir, "test-writer.md"))).toBe(false);
+    expect(await readFile(unmanagedPath, "utf-8")).toContain("Hand-written reviewer");
+  });
+
+  it("applies desired writes and prunes while protecting declared unloaded files", async () => {
+    const targetDir = join(dir, ".claude", "agents");
+    await mkdir(targetDir, { recursive: true });
+    const declaredPath = join(targetDir, "failed-reviewer.md");
+    const stalePath = join(targetDir, "old-reviewer.md");
+    const managed = (name: string) =>
+      `---\n# ${DOTAGENTS_SUBAGENT_MARKER}\nname: "${name}"\n---\n`;
+    await writeFile(declaredPath, managed("failed-reviewer"), "utf-8");
+    await writeFile(stalePath, managed("old-reviewer"), "utf-8");
+
+    const result = await reconcileSubagentConfigs(
+      ["claude"],
+      [SUBAGENT],
+      projectSubagentResolver(dir),
+      {
+        mode: "apply",
+        desiredSubagents: [SUBAGENT, { name: "failed-reviewer" }],
+      },
+    );
+
+    expect(result.written).toBe(1);
+    expect(result.pruned).toEqual([stalePath]);
+    expect(existsSync(join(targetDir, "code-reviewer.md"))).toBe(true);
+    expect(existsSync(declaredPath)).toBe(true);
+    expect(existsSync(stalePath)).toBe(false);
+  });
+
+  it("reports unsupported targets without creating runtime state", async () => {
+    const result = await reconcileSubagentConfigs(
+      ["vscode"],
+      [SUBAGENT],
+      projectSubagentResolver(dir),
+      { mode: "apply" },
+    );
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.message).toContain("does not support custom subagents");
+    expect(result.written).toBe(0);
+    expect(result.pruned).toEqual([]);
+    expect(existsSync(join(dir, ".vscode"))).toBe(false);
+  });
+
+  it("reports unreadable configs during inspection and fails during apply", async () => {
+    const filePath = join(dir, ".claude", "agents", "code-reviewer.md");
+    await mkdir(join(dir, ".claude", "agents"), { recursive: true });
+    await writeFile(filePath, `# ${DOTAGENTS_SUBAGENT_MARKER}\n`, "utf-8");
+    await chmod(filePath, 0o000);
+
+    try {
+      const inspected = await reconcileSubagentConfigs(
+        ["claude"],
+        [SUBAGENT],
+        projectSubagentResolver(dir),
+        { mode: "inspect" },
+      );
+      expect(inspected.issues[0]!.issue).toContain("Failed to read");
+
+      await expect(reconcileSubagentConfigs(
+        ["claude"],
+        [SUBAGENT],
+        projectSubagentResolver(dir),
+        { mode: "apply" },
+      )).rejects.toThrow();
+    } finally {
+      await chmod(filePath, 0o600);
+    }
   });
 });

--- a/packages/dotagents/src/subagents/writer.ts
+++ b/packages/dotagents/src/subagents/writer.ts
@@ -32,6 +32,19 @@ export interface SubagentVerifyIssue {
   issue: string;
 }
 
+export interface SubagentReconcileOptions {
+  mode: "inspect" | "apply";
+  desiredSubagents?: Pick<SubagentDeclaration, "name" | "targets">[];
+  prune?: boolean;
+}
+
+export interface SubagentReconcileResult {
+  issues: SubagentVerifyIssue[];
+  warnings: SubagentWriteWarning[];
+  written: number;
+  pruned: string[];
+}
+
 interface DesiredDir {
   extension: string;
   spec: SubagentConfigSpec;
@@ -55,71 +68,11 @@ export async function writeSubagentConfigs(
   subagents: SubagentDeclaration[],
   resolveTarget: SubagentTargetResolver,
 ): Promise<SubagentWriteResult> {
-  const warnings: SubagentWriteWarning[] = [];
-  let written = 0;
-  const configuredAgents = new Set(agentIds);
-
-  for (const subagent of subagents) {
-    for (const agentId of selectedAgentIds(agentIds, subagent)) {
-      if (!configuredAgents.has(agentId)) {
-        warnings.push({
-          agent: agentId,
-          name: subagent.name,
-          message: `Subagent "${subagent.name}" targets agent "${agentId}", but "${agentId}" is not listed in agents`,
-        });
-        continue;
-      }
-
-      const agent = getAgent(agentId);
-      if (!agent) {continue;}
-      if (!agent.subagents) {
-        warnings.push({
-          agent: agentId,
-          name: subagent.name,
-          message: `Agent "${agent.displayName}" does not support custom subagents`,
-        });
-        continue;
-      }
-
-      const { dirPath } = resolveTarget(agentId, agent.subagents);
-      const generated = agent.subagents.serialize(subagent);
-      const content = normalizeContent(generated.content);
-      if (!hasDotagentsSubagentMarker(agent.subagents, content)) {
-        throw new Error(`Internal error: generated subagent "${subagent.name}" is missing the dotagents marker`);
-      }
-      const generatedIdentity = generatedSubagentIdentity(
-        agent.subagents,
-        generated.fileName,
-        content,
-        subagent.name,
-      );
-
-      await mkdir(dirPath, { recursive: true });
-      const identityConflict = await findUnmanagedIdentityConflict(
-        dirPath,
-        generated.fileName,
-        agent.subagents,
-        generatedIdentity,
-      );
-      if (identityConflict) {
-        warnings.push({
-          agent: agentId,
-          name: subagent.name,
-          message: `Subagent config identity conflicts with unmanaged file: ${identityConflict}`,
-        });
-        continue;
-      }
-      const didWrite = await writeManagedFile(join(dirPath, generated.fileName), content, {
-        agent: agentId,
-        name: subagent.name,
-        spec: agent.subagents,
-        warnings,
-      });
-      if (didWrite) {written++;}
-    }
-  }
-
-  return { warnings, written };
+  const result = await reconcileSubagentConfigs(agentIds, subagents, resolveTarget, {
+    mode: "apply",
+    prune: false,
+  });
+  return { warnings: result.warnings, written: result.written };
 }
 
 export async function pruneSubagentConfigs(
@@ -136,30 +89,42 @@ export async function verifySubagentConfigs(
   resolveTarget: SubagentTargetResolver,
 ): Promise<SubagentVerifyIssue[]> {
   if (subagents.length === 0) {return [];}
+  const result = await reconcileSubagentConfigs(agentIds, subagents, resolveTarget, {
+    mode: "inspect",
+    prune: false,
+  });
+  return result.issues;
+}
 
+/** Inspect or apply agent-specific runtime projections for declared subagents. */
+export async function reconcileSubagentConfigs(
+  agentIds: string[],
+  subagents: SubagentDeclaration[],
+  resolveTarget: SubagentTargetResolver,
+  options: SubagentReconcileOptions,
+): Promise<SubagentReconcileResult> {
   const issues: SubagentVerifyIssue[] = [];
+  const warnings: SubagentWriteWarning[] = [];
+  let written = 0;
   const configuredAgents = new Set(agentIds);
   const seen = new Set<string>();
 
   for (const subagent of subagents) {
     for (const agentId of selectedAgentIds(agentIds, subagent)) {
       const issueBase = { agent: agentId, name: subagent.name };
-
       if (!configuredAgents.has(agentId)) {
-        issues.push({
-          ...issueBase,
-          issue: `Subagent "${subagent.name}" targets agent "${agentId}", but "${agentId}" is not listed in agents`,
-        });
+        const message = `Subagent "${subagent.name}" targets agent "${agentId}", but "${agentId}" is not listed in agents`;
+        issues.push({ ...issueBase, issue: message });
+        warnings.push({ ...issueBase, message });
         continue;
       }
 
       const agent = getAgent(agentId);
       if (!agent) {continue;}
       if (!agent.subagents) {
-        issues.push({
-          ...issueBase,
-          issue: `Agent "${agent.displayName}" does not support custom subagents`,
-        });
+        const message = `Agent "${agent.displayName}" does not support custom subagents`;
+        issues.push({ ...issueBase, issue: message });
+        warnings.push({ ...issueBase, message });
         continue;
       }
 
@@ -169,55 +134,77 @@ export async function verifySubagentConfigs(
       if (seen.has(filePath)) {continue;}
       seen.add(filePath);
       const content = normalizeContent(generated.content);
+      if (!hasDotagentsSubagentMarker(agent.subagents, content)) {
+        throw new Error(`Internal error: generated subagent "${subagent.name}" is missing the dotagents marker`);
+      }
+      const generatedIdentity = generatedSubagentIdentity(
+        agent.subagents,
+        generated.fileName,
+        content,
+        subagent.name,
+      );
 
       const identityConflict = await findUnmanagedIdentityConflict(
         dirPath,
         generated.fileName,
         agent.subagents,
-        generatedSubagentIdentity(agent.subagents, generated.fileName, content, subagent.name),
+        generatedIdentity,
       );
       if (identityConflict) {
-        issues.push({
-          ...issueBase,
-          issue: `Subagent config identity conflicts with unmanaged file: ${identityConflict}`,
-        });
+        const message = `Subagent config identity conflicts with unmanaged file: ${identityConflict}`;
+        issues.push({ ...issueBase, issue: message });
+        warnings.push({ ...issueBase, message });
         continue;
       }
 
       if (!existsSync(filePath)) {
-        issues.push({
-          ...issueBase,
-          issue: `Subagent config missing: ${filePath}`,
-        });
+        issues.push({ ...issueBase, issue: `Subagent config missing: ${filePath}` });
+        if (options.mode === "apply") {
+          await mkdir(dirPath, { recursive: true });
+          await writeFile(filePath, content, "utf-8");
+          written++;
+        }
         continue;
       }
 
+      let existing: string;
       try {
-        const existing = await readFile(filePath, "utf-8");
-        if (!hasDotagentsSubagentMarker(agent.subagents, existing)) {
-          issues.push({
-            ...issueBase,
-            issue: `Subagent config exists and is not managed by dotagents: ${filePath}`,
-          });
-          continue;
-        }
-
-        if (existing !== normalizeContent(generated.content)) {
-          issues.push({
-            ...issueBase,
-            issue: `Subagent config out of date: ${filePath}`,
-          });
-        }
-      } catch {
+        existing = await readFile(filePath, "utf-8");
+      } catch (error) {
         issues.push({
           ...issueBase,
           issue: `Failed to read subagent config: ${filePath}`,
         });
+        if (options.mode === "apply") {throw error;}
+        continue;
+      }
+
+      if (!hasDotagentsSubagentMarker(agent.subagents, existing)) {
+        const message = `Subagent config exists and is not managed by dotagents: ${filePath}`;
+        issues.push({ ...issueBase, issue: message });
+        warnings.push({ ...issueBase, message });
+        continue;
+      }
+
+      if (existing !== content) {
+        issues.push({ ...issueBase, issue: `Subagent config out of date: ${filePath}` });
+        if (options.mode === "apply") {
+          await writeFile(filePath, content, "utf-8");
+          written++;
+        }
       }
     }
   }
 
-  return issues;
+  const pruned = options.mode === "apply" && options.prune !== false
+    ? await pruneManagedFiles(initDesiredDirs(
+      agentIds,
+      options.desiredSubagents ?? subagents,
+      resolveTarget,
+    ))
+    : [];
+
+  return { issues, warnings, written, pruned };
 }
 
 function initDesiredDirs(
@@ -279,30 +266,6 @@ function markDesired(
     desired.files.add(fileName);
   }
   desiredByDir.set(dirPath, desired);
-}
-
-async function writeManagedFile(
-  filePath: string,
-  content: string,
-  context: { agent: string; name: string; spec: SubagentConfigSpec; warnings: SubagentWriteWarning[] },
-): Promise<boolean> {
-  try {
-    const existing = await readFile(filePath, "utf-8");
-    if (existing === content) {return false;}
-    if (!hasDotagentsSubagentMarker(context.spec, existing)) {
-      context.warnings.push({
-        agent: context.agent,
-        name: context.name,
-        message: `Subagent config exists and is not managed by dotagents: ${filePath}`,
-      });
-      return false;
-    }
-  } catch (err) {
-    if (!isNotFoundError(err)) {throw err;}
-  }
-
-  await writeFile(filePath, content, "utf-8");
-  return true;
 }
 
 async function pruneManagedFiles(
@@ -367,8 +330,4 @@ function hasDotagentsSubagentMarker(spec: SubagentConfigSpec, content: string): 
 
 function normalizeContent(content: string): string {
   return content.endsWith("\n") ? content : `${content}\n`;
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
 }

--- a/packages/dotagents/src/subagents/writer.ts
+++ b/packages/dotagents/src/subagents/writer.ts
@@ -34,7 +34,7 @@ export interface SubagentVerifyIssue {
 
 export interface SubagentReconcileOptions {
   mode: "inspect" | "apply";
-  desiredSubagents?: Pick<SubagentDeclaration, "name" | "targets">[];
+  retainedSubagents?: Pick<SubagentDeclaration, "name" | "targets">[];
   prune?: boolean;
 }
 
@@ -49,6 +49,12 @@ interface DesiredDir {
   extension: string;
   spec: SubagentConfigSpec;
   files: Set<string>;
+}
+
+interface PlannedWrite {
+  dirPath: string;
+  filePath: string;
+  content: string;
 }
 
 export function projectSubagentResolver(projectRoot: string): SubagentTargetResolver {
@@ -91,12 +97,14 @@ export async function verifySubagentConfigs(
   if (subagents.length === 0) {return [];}
   const result = await reconcileSubagentConfigs(agentIds, subagents, resolveTarget, {
     mode: "inspect",
-    prune: false,
   });
   return result.issues;
 }
 
-/** Inspect or apply agent-specific runtime projections for declared subagents. */
+/**
+ * Inspects or applies runtime projections, pruning in apply mode by default.
+ * Use retainedSubagents when pruning must preserve declarations that could not be loaded for writing.
+ */
 export async function reconcileSubagentConfigs(
   agentIds: string[],
   subagents: SubagentDeclaration[],
@@ -105,7 +113,7 @@ export async function reconcileSubagentConfigs(
 ): Promise<SubagentReconcileResult> {
   const issues: SubagentVerifyIssue[] = [];
   const warnings: SubagentWriteWarning[] = [];
-  let written = 0;
+  const plannedWrites: PlannedWrite[] = [];
   const configuredAgents = new Set(agentIds);
   const seen = new Set<string>();
 
@@ -160,9 +168,7 @@ export async function reconcileSubagentConfigs(
       if (!existsSync(filePath)) {
         issues.push({ ...issueBase, issue: `Subagent config missing: ${filePath}` });
         if (options.mode === "apply") {
-          await mkdir(dirPath, { recursive: true });
-          await writeFile(filePath, content, "utf-8");
-          written++;
+          plannedWrites.push({ dirPath, filePath, content });
         }
         continue;
       }
@@ -189,22 +195,28 @@ export async function reconcileSubagentConfigs(
       if (existing !== content) {
         issues.push({ ...issueBase, issue: `Subagent config out of date: ${filePath}` });
         if (options.mode === "apply") {
-          await writeFile(filePath, content, "utf-8");
-          written++;
+          plannedWrites.push({ dirPath, filePath, content });
         }
       }
     }
   }
 
-  const pruned = options.mode === "apply" && options.prune !== false
-    ? await pruneManagedFiles(initDesiredDirs(
+  const desiredByDir = options.mode === "apply" && options.prune !== false
+    ? initDesiredDirs(
       agentIds,
-      options.desiredSubagents ?? subagents,
+      options.retainedSubagents ?? subagents,
       resolveTarget,
-    ))
-    : [];
+    )
+    : null;
 
-  return { issues, warnings, written, pruned };
+  for (const write of plannedWrites) {
+    await mkdir(write.dirPath, { recursive: true });
+    await writeFile(write.filePath, write.content, "utf-8");
+  }
+
+  const pruned = desiredByDir ? await pruneManagedFiles(desiredByDir) : [];
+
+  return { issues, warnings, written: plannedWrites.length, pruned };
 }
 
 function initDesiredDirs(


### PR DESCRIPTION
Reconcile generated subagent runtime files through one lifecycle shared by install and sync.

Subagent orchestration previously verified, wrote, and pruned runtime files in separate passes over the same targets. The new inspect/apply operation handles desired projections and stale managed files together while retaining the compatibility wrappers.

The reconciler completes target inspection and prune-retention planning before its first write, preserving the previous sync failure ordering. Existing ownership and safety behavior remains unchanged: unmanaged identity conflicts are preserved, unsupported targets still warn, frozen installs do not prune, declared-but-unloaded subagents protect their runtime files, and apply continues to fail on unreadable filesystem state.

Garfield review removed stale warning deduplication and kept the new lifecycle API out of the legacy compatibility barrel. `pnpm check` passed all 809 tests. Docker QA passed the checked-in multi-runtime example, including install wiring and sync repair.