### PR TITLE
fix(hooks): Preserve hooks without declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For OpenCode, dotagents uses an existing config in this order: `.opencode/openco
 
 Install and sync repair currently declared MCP entries while preserving undeclared servers and unrelated content in every existing target file. When no servers are declared, existing MCP files remain unchanged because dotagents has no durable evidence that it owns them. Unreadable or structurally incompatible files are reported and left unchanged.
 
-Install and sync also repair the complete generated hook root. Unrelated settings in shared files are preserved; removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+Install and sync repair the complete generated hook root when hooks are declared. When no hooks are declared, existing hook files remain unchanged because dotagents has no durable evidence that it owns them.
 
 Custom subagents are declared with `[[subagents]]` entries. dotagents writes generated runtime-specific files during `install` and repairs them during `sync`:
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -225,7 +225,7 @@ Cursor event mapping:
 - `UserPromptSubmit` -> `beforeSubmitPrompt`
 - `Stop` -> `stop`
 
-Install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. The hook root is dotagents-owned: unrelated top-level settings in shared files are preserved, while removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+When hooks are declared, install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. Unrelated top-level settings in shared files are preserved. When no hooks are declared, existing hook files remain unchanged because dotagents has no durable evidence that it owns them.
 
 ### Subagents
 

--- a/packages/dotagents/src/cli/commands/install.test.ts
+++ b/packages/dotagents/src/cli/commands/install.test.ts
@@ -254,7 +254,34 @@ describe("runInstall", () => {
     ]);
   });
 
-  it("reconciles hook drift and removes owned hook state when declarations are removed", async () => {
+  it("leaves project-owned Claude hooks unchanged when no hooks are declared", async () => {
+    const settingsDir = join(projectRoot, ".claude");
+    const settingsPath = join(settingsDir, "settings.json");
+    await mkdir(settingsDir, { recursive: true });
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\nagents = ["claude", "codex"]\n`,
+    );
+    const content = JSON.stringify({
+      hooks: {
+        SessionStart: [{
+          matcher: "startup",
+          hooks: [{
+            type: "command",
+            command: '"$CLAUDE_PROJECT_DIR"/.claude/worktree-setup.sh',
+            timeout: 900,
+          }],
+        }],
+      },
+    }, null, 2);
+    await writeFile(settingsPath, content);
+
+    await runInstall({ scope: resolveScope("project", projectRoot) });
+
+    expect(await readFile(settingsPath, "utf-8")).toBe(content);
+  });
+
+  it("reconciles hook drift and preserves generated hook state when declarations are removed", async () => {
     const configPath = join(projectRoot, "agents.toml");
     const claudePath = join(projectRoot, ".claude", "settings.json");
     const cursorPath = join(projectRoot, ".cursor", "hooks.json");
@@ -288,8 +315,12 @@ describe("runInstall", () => {
     await runInstall({ scope });
     expect(JSON.parse(await readFile(claudePath, "utf-8"))).toEqual({
       permissions: { allow: ["Read"] },
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "check.sh" }] }] },
     });
-    expect(existsSync(cursorPath)).toBe(false);
+    expect(JSON.parse(await readFile(cursorPath, "utf-8"))).toEqual({
+      version: 1,
+      hooks: { stop: [{ command: "check.sh" }] },
+    });
   });
 
   it("returns hook warnings for unsupported agents", async () => {

--- a/packages/dotagents/src/cli/commands/sync.test.ts
+++ b/packages/dotagents/src/cli/commands/sync.test.ts
@@ -459,7 +459,7 @@ headers = { Authorization = "Bearer tok" }
     expect((await lstat(join(projectRoot, ".claude", "skills"))).isSymbolicLink()).toBe(true);
   });
 
-  it("reconciles missing, drifted, and removed hook configs", async () => {
+  it("reconciles missing and drifted hook configs without removing empty declarations", async () => {
     const configPath = join(projectRoot, "agents.toml");
     const settingsPath = join(projectRoot, ".claude", "settings.json");
     await writeFile(
@@ -491,10 +491,16 @@ headers = { Authorization = "Bearer tok" }
     });
 
     await writeFile(configPath, `version = 1\nagents = ["claude"]\n`);
-    const removed = await runSync({ scope });
-    expect(removed.hooksRepaired).toBe(1);
+    const unchanged = await runSync({ scope });
+    expect(unchanged.hooksRepaired).toBe(0);
     expect(JSON.parse(await readFile(settingsPath, "utf-8"))).toEqual({
       permissions: { allow: ["Read"] },
+      hooks: {
+        PreToolUse: [{
+          matcher: "Bash",
+          hooks: [{ type: "command", command: ".agents/hooks/block-rm.sh" }],
+        }],
+      },
     });
   });
 

--- a/packages/dotagents/src/targets/hook-writer.test.ts
+++ b/packages/dotagents/src/targets/hook-writer.test.ts
@@ -306,31 +306,34 @@ describe("reconcileHookConfigs", () => {
     });
   });
 
-  it("removes an empty shared hook root once for Claude and VS Code", async () => {
-    const filePath = join(dir, ".claude", "settings.json");
-    await mkdir(join(dir, ".claude"), { recursive: true });
-    await writeFile(filePath, JSON.stringify({
-      permissions: { allow: ["Read"] },
-      hooks: { Stop: [{ hooks: [{ type: "command", command: "stale.sh" }] }] },
-    }));
+  it.each(["inspect", "apply"] as const)(
+    "leaves an existing shared hook root unchanged in %s mode when no hooks are declared",
+    async (mode) => {
+      const filePath = join(dir, ".claude", "settings.json");
+      await mkdir(join(dir, ".claude"), { recursive: true });
+      const content = JSON.stringify({
+        permissions: { allow: ["Read"] },
+        hooks: { SessionStart: [{ hooks: [{ type: "command", command: "project-owned.sh" }] }] },
+      });
+      await writeFile(filePath, content);
 
-    const result = await reconcileHookConfigs(
-      ["claude", "vscode"],
-      [],
-      projectHookResolver(dir),
-      "apply",
-    );
+      const result = await reconcileHookConfigs(
+        ["claude", "vscode"],
+        [],
+        projectHookResolver(dir),
+        mode,
+      );
 
-    expect(result.written).toEqual([filePath]);
-    expect(JSON.parse(await readFile(filePath, "utf-8"))).toEqual({
-      permissions: { allow: ["Read"] },
-    });
-  });
+      expect(result).toEqual({ issues: [], warnings: [], written: [], removed: [] });
+      expect(await readFile(filePath, "utf-8")).toBe(content);
+    },
+  );
 
-  it("removes a dedicated Cursor hook file when no hooks remain", async () => {
+  it("leaves an existing dedicated Cursor hook file unchanged when no hooks are declared", async () => {
     const filePath = join(dir, ".cursor", "hooks.json");
     await mkdir(join(dir, ".cursor"), { recursive: true });
-    await writeFile(filePath, JSON.stringify({ version: 1, hooks: { stop: [] } }));
+    const content = JSON.stringify({ version: 1, hooks: { stop: [{ command: "project-owned.sh" }] } });
+    await writeFile(filePath, content);
 
     const result = await reconcileHookConfigs(
       ["cursor"],
@@ -339,8 +342,8 @@ describe("reconcileHookConfigs", () => {
       "apply",
     );
 
-    expect(result.removed).toEqual([filePath]);
-    expect(existsSync(filePath)).toBe(false);
+    expect(result).toEqual({ issues: [], warnings: [], written: [], removed: [] });
+    expect(await readFile(filePath, "utf-8")).toBe(content);
   });
 
   it("returns unsupported-agent warnings separately from drift", async () => {

--- a/packages/dotagents/src/targets/hook-writer.ts
+++ b/packages/dotagents/src/targets/hook-writer.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { existsSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
@@ -67,7 +67,7 @@ export async function verifyHookConfigs(
   return (await reconcileHookConfigs(agentIds, hooks, resolveTarget, "inspect")).issues;
 }
 
-/** Inspect or apply the target-specific hook root owned by dotagents. */
+/** Inspect or apply declared hooks without modifying configs for empty input. */
 export async function reconcileHookConfigs(
   agentIds: string[],
   hooks: HookDeclaration[],
@@ -79,18 +79,17 @@ export async function reconcileHookConfigs(
   const written: string[] = [];
   const removed: string[] = [];
   const seen = new Set<string>();
+  if (hooks.length === 0) {return { issues, warnings, written, removed };}
 
   for (const id of agentIds) {
     const agent = getAgent(id);
     if (!agent) {continue;}
 
     if (!agent.hooks) {
-      if (hooks.length > 0) {
-        warnings.push({
-          agent: id,
-          message: `Agent "${agent.displayName}" does not support hooks`,
-        });
-      }
+      warnings.push({
+        agent: id,
+        message: `Agent "${agent.displayName}" does not support hooks`,
+      });
       continue;
     }
 
@@ -98,28 +97,6 @@ export async function reconcileHookConfigs(
     const { filePath, shared } = resolveTarget(id, spec);
     if (seen.has(filePath)) {continue;}
     seen.add(filePath);
-
-    if (hooks.length === 0) {
-      if (!existsSync(filePath)) {continue;}
-      if (!shared) {
-        issues.push({ agent: id, issue: `Stale hook config: ${filePath}` });
-        if (mode === "apply") {
-          await rm(filePath);
-          removed.push(filePath);
-        }
-        continue;
-      }
-
-      const existing = await readForCleanup(filePath, issues, id);
-      if (!existing || !(spec.rootKey in existing)) {continue;}
-      issues.push({ agent: id, issue: `Stale hook root "${spec.rootKey}" in ${filePath}` });
-      if (mode === "apply") {
-        delete existing[spec.rootKey];
-        await writeDocument(filePath, existing);
-        written.push(filePath);
-      }
-      continue;
-    }
 
     const serialized = agent.serializeHooks(hooks);
     const expected = { ...spec.extraFields, [spec.rootKey]: serialized };
@@ -160,19 +137,6 @@ export async function reconcileHookConfigs(
   }
 
   return { issues, warnings, written, removed };
-}
-
-async function readForCleanup(
-  filePath: string,
-  issues: HookReconcileIssue[],
-  agent: string,
-): Promise<Record<string, unknown> | undefined> {
-  try {
-    return await readExisting(filePath);
-  } catch {
-    issues.push({ agent, issue: `Failed to read hook config: ${filePath}` });
-    return undefined;
-  }
 }
 
 async function writeDocument(

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -193,7 +193,7 @@ Hook declarations. Each entry defines a hook that dotagents will configure for a
 | `matcher` | No | Tool name to match (e.g. `Bash`). Only for `PreToolUse` and `PostToolUse`. |
 | `command` | Yes | Shell command to execute when the hook fires. |
 
-Install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. The hook root is dotagents-owned: unrelated top-level settings in shared files are preserved, while removing all hook declarations removes the shared hook root or the dedicated Cursor hook file.
+When hooks are declared, install and sync compare the complete serialized hook root and repair stale commands, matchers, and target event mappings. Unrelated top-level settings in shared files are preserved. When no hooks are declared, existing hook files remain unchanged because dotagents has no durable evidence that it owns them.
 
 #### `[[subagents]]`
 


### PR DESCRIPTION
Restore the pre-1.18 behavior where an empty `[[hooks]]` list leaves existing project hook configuration unchanged.

The 1.18 hook reconciler treated every existing Claude `hooks` root and Cursor hook file as dotagents-owned, even when dotagents had never written it. Running `install` or `sync` could therefore remove unrelated project automation. Dotagents does not currently persist enough ownership information to make that cleanup safely.

Empty declarations are now a no-op for both inspection and application. Declared hooks continue to use the existing reconciliation behavior. This may leave previously generated hooks behind after declarations are removed, which is safer than deleting hooks of unknown ownership.

Fixes #140