### PR TITLE
feat(skills): Add npm: source type for installed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ name = "local"
 source = "path:./my-skills/local-skill"  # Local directory
 
 [[skills]]
+name = "ui-kit-upgrade"
+source = "npm:@acme/ui-kit/skills/upgrade" # Inside an installed npm package
+
+[[skills]]
 name = "*"
 source = "getsentry/skills"
 path = "skills/engineering"              # All skills under one subdirectory

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -329,6 +329,7 @@ Status output:
 | GitLab SSH | `git@gitlab.com:group/repo.git` | GitLab over SSH |
 | Well-known HTTPS | `https://cli.sentry.dev` | HTTP source using .well-known skill discovery |
 | Local | `path:./my-skills/custom` | Local directory, relative to project root |
+| npm package | `npm:@acme/ui-kit/skills/upgrade` | Directory inside an installed npm package, resolved with Node module resolution (works with pnpm/hoisting/PnP; skills refresh whenever the dependency is updated) |
 
 <a id="configuration"></a>
 

--- a/docs/src/content/docs/security.mdx
+++ b/docs/src/content/docs/security.mdx
@@ -43,7 +43,9 @@ git_domains = ["git.corp.example.com"]
 | `github_repos` | Exact `owner/repo` match | `"external-org/one-approved-repo"` |
 | `git_domains` | Domain extracted from `git:` URLs | `"git.corp.example.com"` matches `git:https://git.corp.example.com/team/repo` |
 
-Local `path:` sources are always allowed regardless of trust configuration.
+Local `path:` and `npm:` sources are always allowed regardless of trust
+configuration — both resolve to directories already on disk (npm packages are
+vetted by your package manager's own supply-chain controls at install time).
 
 You can also manage trusted sources from the CLI instead of editing TOML
 directly:

--- a/packages/dotagents-lib/src/index.ts
+++ b/packages/dotagents-lib/src/index.ts
@@ -66,6 +66,11 @@ export {
 export type { CacheResult } from "./sources/cache.js";
 export { ensureWellKnownCached } from "./sources/wellknown.js";
 export { resolveLocalSource, LocalSourceError } from "./sources/local.js";
+export {
+  resolveNpmSource,
+  parseNpmSpecifier,
+  NpmSourceError,
+} from "./sources/npm.js";
 
 // Source-host primitives
 export {

--- a/packages/dotagents-lib/src/skills/resolver.ts
+++ b/packages/dotagents-lib/src/skills/resolver.ts
@@ -10,6 +10,7 @@ import {
 import { ensureCached, sanitizeCacheKey } from "../sources/cache.js";
 import { ensureWellKnownCached } from "../sources/wellknown.js";
 import { resolveLocalSource } from "../sources/local.js";
+import { resolveNpmSource } from "../sources/npm.js";
 import { discoverSkill, discoverAllSkills, type DiscoveredSkill } from "./discovery.js";
 import { loadSkillMd } from "./loader.js";
 import { stripTrailingSlashes } from "../utils/fs.js";
@@ -92,6 +93,7 @@ export type ResolvedSkill = ResolvedGitSkill | ResolvedLocalSkill | ResolvedWell
 export function isExplicitSourceSpecifier(specifier: string): boolean {
   return (
     specifier.startsWith("path:") ||
+    specifier.startsWith("npm:") ||
     specifier.startsWith("git:") ||
     specifier.startsWith("http://") ||
     specifier.startsWith("https://") ||
@@ -169,7 +171,7 @@ export function applyDefaultRepositorySource(
  * Parse a source string into its components.
  */
 export function parseSource(source: string): {
-  type: "github" | "git" | "local" | "well-known";
+  type: "github" | "git" | "local" | "npm" | "well-known";
   url?: string;
   /** Original URL to use for cloning (preserves SSH/HTTPS protocol). Undefined for owner/repo shorthand. */
   cloneUrl?: string;
@@ -180,6 +182,10 @@ export function parseSource(source: string): {
 } {
   if (source.startsWith("path:")) {
     return { type: "local", path: source.slice(5) };
+  }
+
+  if (source.startsWith("npm:")) {
+    return { type: "npm", path: source.slice(4) };
   }
 
   if (source.startsWith("git:")) {
@@ -355,6 +361,14 @@ async function acquireSkillSource(
   if (parsed.type === "local") {
     const projectRoot = opts.projectRoot || process.cwd();
     const skillDir = await resolveLocalSource(projectRoot, parsed.path!);
+    return { type: "local", skillDir };
+  }
+
+  // npm packages resolve to an installed directory on disk; from here on they
+  // behave exactly like local sources.
+  if (parsed.type === "npm") {
+    const projectRoot = opts.projectRoot || process.cwd();
+    const skillDir = await resolveNpmSource(projectRoot, parsed.path!);
     return { type: "local", skillDir };
   }
 

--- a/packages/dotagents-lib/src/sources/npm.test.ts
+++ b/packages/dotagents-lib/src/sources/npm.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, realpath } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseNpmSpecifier, resolveNpmSource, NpmSourceError } from "./npm.js";
+import {
+  parseSource,
+  isExplicitSourceSpecifier,
+  resolveSkill,
+  resolveWildcardSkills,
+} from "../skills/resolver.js";
+import { validateTrustedSource } from "../trust/validator.js";
+import type { TrustPolicy } from "../trust/policy.js";
+
+async function writeSkill(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} test skill\n---\n\n# ${name}\n`,
+  );
+}
+
+describe("parseNpmSpecifier", () => {
+  it("parses a scoped package with subpath", () => {
+    expect(parseNpmSpecifier("@acme/ui-kit/skills/upgrade")).toEqual({
+      packageName: "@acme/ui-kit",
+      subpath: "skills/upgrade",
+    });
+  });
+
+  it("parses an unscoped package without subpath", () => {
+    expect(parseNpmSpecifier("ui-kit")).toEqual({ packageName: "ui-kit" });
+  });
+
+  it("rejects a bare scope", () => {
+    expect(() => parseNpmSpecifier("@acme")).toThrow(NpmSourceError);
+  });
+
+  it("rejects invalid package names", () => {
+    expect(() => parseNpmSpecifier("UpperCase/skills")).toThrow(NpmSourceError);
+    expect(() => parseNpmSpecifier("")).toThrow(NpmSourceError);
+    expect(() => parseNpmSpecifier("../escape")).toThrow(NpmSourceError);
+  });
+});
+
+describe("parseSource npm:", () => {
+  it("classifies npm: as its own source type", () => {
+    expect(parseSource("npm:@acme/ui-kit/skills/upgrade")).toEqual({
+      type: "npm",
+      path: "@acme/ui-kit/skills/upgrade",
+    });
+  });
+
+  it("treats npm: as an explicit specifier (never owner/repo shorthand)", () => {
+    expect(isExplicitSourceSpecifier("npm:@acme/ui-kit")).toBe(true);
+  });
+});
+
+describe("trust", () => {
+  it("always allows npm: sources, like local paths", () => {
+    const restrictive: TrustPolicy = {
+      allow_all: false,
+      github_orgs: [],
+      github_repos: [],
+      git_domains: [],
+    };
+    expect(() =>
+      validateTrustedSource("npm:@acme/ui-kit/skills/upgrade", restrictive),
+    ).not.toThrow();
+  });
+});
+
+describe("resolveNpmSource", () => {
+  let tmpDir: string;
+  let projectRoot: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    // realpath so expectations match require.resolve, which returns canonical
+    // paths (macOS tmpdir lives behind a /var → /private/var symlink).
+    tmpDir = await realpath(await mkdtemp(join(tmpdir(), "dotagents-npm-")));
+    projectRoot = join(tmpDir, "project");
+    stateDir = join(tmpDir, "state");
+    await mkdir(projectRoot, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(projectRoot, "package.json"), JSON.stringify({ name: "consumer" }));
+
+    // Scoped package whose exports map does NOT expose ./package.json —
+    // exercises the node_modules walk fallback.
+    const scoped = join(projectRoot, "node_modules", "@acme", "ui-kit");
+    await mkdir(scoped, { recursive: true });
+    await writeFile(
+      join(scoped, "package.json"),
+      JSON.stringify({ name: "@acme/ui-kit", version: "70.0.0", exports: { ".": "./index.js" } }),
+    );
+    await writeSkill(join(scoped, "skills", "ui-kit-upgrade"), "ui-kit-upgrade");
+    await writeSkill(join(scoped, "skills", "input-migration"), "input-migration");
+
+    // Unscoped package without an exports map — resolves via require.resolve.
+    const plain = join(projectRoot, "node_modules", "plainlib");
+    await mkdir(plain, { recursive: true });
+    await writeFile(
+      join(plain, "package.json"),
+      JSON.stringify({ name: "plainlib", version: "1.0.0", main: "index.js" }),
+    );
+    await writeFile(join(plain, "index.js"), "module.exports = {};\n");
+    await writeSkill(join(plain, "skill"), "plain-skill");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves a subdirectory of an installed scoped package", async () => {
+    const dir = await resolveNpmSource(projectRoot, "@acme/ui-kit/skills/ui-kit-upgrade");
+    expect(dir).toBe(
+      join(projectRoot, "node_modules", "@acme", "ui-kit", "skills", "ui-kit-upgrade"),
+    );
+  });
+
+  it("resolves an unscoped package via require.resolve", async () => {
+    const dir = await resolveNpmSource(projectRoot, "plainlib/skill");
+    expect(dir).toBe(join(projectRoot, "node_modules", "plainlib", "skill"));
+  });
+
+  it("rejects packages that are not installed", async () => {
+    await expect(resolveNpmSource(projectRoot, "@acme/missing")).rejects.toThrow(
+      /not installed/,
+    );
+  });
+
+  it("rejects subpaths that escape the package", async () => {
+    await expect(
+      resolveNpmSource(projectRoot, "@acme/ui-kit/skills/../../ui-kit-sibling"),
+    ).rejects.toThrow(NpmSourceError);
+  });
+
+  it("rejects subpaths that do not exist", async () => {
+    await expect(
+      resolveNpmSource(projectRoot, "@acme/ui-kit/skills/nope"),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("resolves a named skill end-to-end through resolveSkill", async () => {
+    const resolved = await resolveSkill(
+      "ui-kit-upgrade",
+      { source: "npm:@acme/ui-kit/skills/ui-kit-upgrade" },
+      { stateDir, projectRoot },
+    );
+    expect(resolved.type).toBe("local");
+    expect(resolved.skillDir).toBe(
+      join(projectRoot, "node_modules", "@acme", "ui-kit", "skills", "ui-kit-upgrade"),
+    );
+  });
+
+  it("resolves wildcard skills scoped by path", async () => {
+    const resolved = await resolveWildcardSkills(
+      { source: "npm:@acme/ui-kit", path: "skills" },
+      { stateDir, projectRoot },
+    );
+    expect(resolved.map((r) => r.name).toSorted()).toEqual([
+      "input-migration",
+      "ui-kit-upgrade",
+    ]);
+    for (const skill of resolved) {
+      expect(skill.resolved.type).toBe("local");
+    }
+  });
+});

--- a/packages/dotagents-lib/src/sources/npm.ts
+++ b/packages/dotagents-lib/src/sources/npm.ts
@@ -1,0 +1,104 @@
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { stat } from "node:fs/promises";
+
+export class NpmSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NpmSourceError";
+  }
+}
+
+/** npm package name grammar (scoped or unscoped), per the npm registry rules. */
+const VALID_PACKAGE_NAME = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * Split an `npm:` specifier body into package name and optional subpath.
+ * `@scope/pkg/skills/review` → { packageName: "@scope/pkg", subpath: "skills/review" }
+ * `pkg` → { packageName: "pkg" }
+ */
+export function parseNpmSpecifier(specifier: string): {
+  packageName: string;
+  subpath?: string;
+} {
+  const parts = specifier.split("/");
+  const nameSegments = specifier.startsWith("@") ? 2 : 1;
+  const packageName = parts.slice(0, nameSegments).join("/");
+
+  if (parts.length < nameSegments || !VALID_PACKAGE_NAME.test(packageName)) {
+    throw new NpmSourceError(`Invalid npm package specifier: "npm:${specifier}"`);
+  }
+
+  const subpath = parts.slice(nameSegments).join("/");
+  return subpath ? { packageName, subpath } : { packageName };
+}
+
+/**
+ * Locate the root directory of an installed package using Node's own module
+ * resolution, so pnpm symlink layouts, workspace hoisting, and Yarn PnP all
+ * work. Packages whose `exports` map doesn't expose `./package.json` fall back
+ * to a manual node_modules walk (the same ancestor chain Node itself uses).
+ */
+async function resolvePackageRoot(
+  projectRoot: string,
+  packageName: string,
+): Promise<string> {
+  const requireFromProject = createRequire(join(projectRoot, "package.json"));
+  try {
+    return dirname(requireFromProject.resolve(`${packageName}/package.json`));
+  } catch {
+    // ERR_PACKAGE_PATH_NOT_EXPORTED (or a missing main entry) — walk node_modules.
+  }
+
+  for (let dir = projectRoot; ; dir = dirname(dir)) {
+    const candidate = join(dir, "node_modules", ...packageName.split("/"));
+    try {
+      if ((await stat(join(candidate, "package.json"))).isFile()) {
+        return candidate;
+      }
+    } catch {
+      // keep walking
+    }
+    if (dirname(dir) === dir) {break;}
+  }
+
+  throw new NpmSourceError(
+    `npm package "${packageName}" is not installed (resolved from ${projectRoot}). ` +
+      `Install it with your package manager first.`,
+  );
+}
+
+/**
+ * Resolve an `npm:` source (sans prefix) to an absolute directory inside the
+ * installed package. Mirrors `path:` semantics: the specifier points at a
+ * directory; wildcard discovery and `path` scoping happen downstream.
+ */
+export async function resolveNpmSource(
+  projectRoot: string,
+  specifier: string,
+): Promise<string> {
+  const { packageName, subpath } = parseNpmSpecifier(specifier);
+  const packageRoot = await resolvePackageRoot(resolve(projectRoot), packageName);
+
+  const absPath = subpath ? resolve(packageRoot, subpath) : packageRoot;
+
+  // Prevent subpath traversal outside the package
+  if (absPath !== packageRoot && !absPath.startsWith(`${packageRoot}/`)) {
+    throw new NpmSourceError(
+      `npm source "npm:${specifier}" resolves outside package "${packageName}"`,
+    );
+  }
+
+  let s;
+  try {
+    s = await stat(absPath);
+  } catch {
+    throw new NpmSourceError(`npm source not found: ${absPath}`);
+  }
+
+  if (!s.isDirectory()) {
+    throw new NpmSourceError(`npm source is not a directory: ${absPath}`);
+  }
+
+  return absPath;
+}

--- a/packages/dotagents-lib/src/trust/validator.ts
+++ b/packages/dotagents-lib/src/trust/validator.ts
@@ -120,7 +120,7 @@ function formatAllowed(trust: TrustPolicy): string {
  *
  * - No trust config → allow all (backward compat)
  * - allow_all = true → allow all
- * - Local path: sources → always allowed
+ * - Local path: and npm: sources → always allowed
  * - Otherwise → must match at least one rule (org, repo, or domain)
  */
 export function validateTrustedSource(
@@ -135,8 +135,10 @@ export function validateTrustedSource(
 
   const parsed = parseSource(source);
 
-  // Local sources are always allowed
-  if (parsed.type === "local") {return;}
+  // Local and npm sources are always allowed — both resolve to directories
+  // already on disk (npm packages are vetted by the package manager's own
+  // supply-chain controls at install time).
+  if (parsed.type === "local" || parsed.type === "npm") {return;}
 
   if (parsed.type === "github") {
     const owner = parsed.owner!.toLowerCase();

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -16,6 +16,7 @@ import {
   discoverAllSkills,
   discoverSkill,
   resolveLocalSource,
+  resolveNpmSource,
   loadSkillMd,
   ensureCached,
   ensureWellKnownCached,
@@ -77,6 +78,13 @@ async function acquireSkills(
 ): Promise<AcquiredSkills> {
   if (parsed.type === "local") {
     const rootDir = await resolveLocalSource(scope.root, parsed.path!);
+    if (hasExplicitNames) {return { type: "catalog", rootDir };}
+    const meta = await loadSkillMd(join(rootDir, "SKILL.md"));
+    return { type: "root-skill", name: meta.name };
+  }
+
+  if (parsed.type === "npm") {
+    const rootDir = await resolveNpmSource(scope.root, parsed.path!);
     if (hasExplicitNames) {return { type: "catalog", rootDir };}
     const meta = await loadSkillMd(join(rootDir, "SKILL.md"));
     return { type: "root-skill", name: meta.name };

--- a/packages/dotagents/src/lockfile/schema.test.ts
+++ b/packages/dotagents/src/lockfile/schema.test.ts
@@ -39,6 +39,19 @@ describe("lockfileSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("locks npm sources like local sources", () => {
+    const result = lockfileSchema.safeParse({
+      version: 1,
+      skills: {
+        "ui-kit-upgrade": {
+          source: "npm:@acme/ui-kit/skills/ui-kit-upgrade",
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects empty resolved paths", () => {
     const result = lockfileSchema.safeParse({
       version: 1,

--- a/packages/dotagents/src/lockfile/schema.ts
+++ b/packages/dotagents/src/lockfile/schema.ts
@@ -5,7 +5,10 @@ import { parseSource } from "@sentry/dotagents-lib";
 function sourceType(source: string): "git" | "local" | "well-known" | undefined {
   try {
     const type = parseSource(source).type;
-    return type === "github" || type === "git" ? "git" : type;
+    if (type === "github" || type === "git") {return "git";}
+    // npm sources resolve to installed directories and lock like local sources.
+    if (type === "npm") {return "local";}
+    return type;
   } catch {
     return undefined;
   }

--- a/packages/dotagents/src/subagents/store.ts
+++ b/packages/dotagents/src/subagents/store.ts
@@ -9,6 +9,7 @@ import {
   loadMarkdownFrontmatter,
   parseSource,
   resolveLocalSource,
+  resolveNpmSource,
   sanitizeCacheKey,
   validateTrustedSource,
   type RepositorySource,
@@ -99,6 +100,12 @@ export async function resolveSubagent(
 
   if (parsed.type === "local") {
     const sourceDir = await resolveLocalSource(opts.projectRoot, parsed.path!);
+    const subagent = await loadSubagentFromSource(sourceDir, config);
+    return { type: "local", source: config.source, subagent };
+  }
+
+  if (parsed.type === "npm") {
+    const sourceDir = await resolveNpmSource(opts.projectRoot, parsed.path!);
     const subagent = await loadSubagentFromSource(sourceDir, config);
     return { type: "local", source: config.source, subagent };
   }


### PR DESCRIPTION
Closes #149

## What

Adds an `npm:` source type so skills that ship **inside installed npm packages** can be declared without hardcoding the `node_modules` layout:

```toml
# named skill — the specifier points at the skill directory, like path:
[[skills]]
name = "ui-kit-upgrade"
source = "npm:@acme/ui-kit/skills/ui-kit-upgrade"

# wildcard — package root, scoped by path
[[skills]]
name = "*"
source = "npm:@acme/ui-kit"
path = "skills"
```

## Why

Libraries have started shipping agent skills in their packages so the skill content is versioned with the library (e.g. migration guides that must match the installed version). Today the only way to consume them is `path:./node_modules/@acme/ui-kit/...`, which hardcodes a layout that isn't guaranteed (Yarn PnP has no `node_modules`; hoisting moves packages), leaks package internals into every consumer's `agents.toml`, and a bare `@acme/ui-kit/...` specifier misparses as GitHub `owner/repo` shorthand. Details in #149.

## Design

`npm:` behaves **exactly like `path:`, except the root is the resolved installed package**:

- `resolveNpmSource` locates the package with Node's own module resolution — `createRequire(projectRoot).resolve("<pkg>/package.json")` — so pnpm symlink layouts, workspace hoisting, and PnP all work. Packages whose `exports` map doesn't expose `./package.json` (common) fall back to a node_modules ancestor walk. Subpath traversal outside the package is rejected; the final directory is stat-checked, mirroring `local.ts`.
- After resolution it re-enters the existing **local** flow (`acquireSkillSource` returns `{type: "local"}`), so `resolveSkill`, wildcard discovery, `path` scoping, install, and copy logic need no changes.
- **No network access** — the package manager fetches; dotagents only locates and copies. The consumer's lockfile is effectively the pin, and skills refresh automatically whenever the dependency is updated (since `install` re-copies local sources every run).
- **Trust:** npm sources are always allowed, like `path:` — they resolve to directories already on disk, vetted by the package manager's own supply-chain controls at install time.
- **Lockfile:** npm sources lock as local entries (one mapping in `sourceType`).
- `dotagents add npm:...` and subagent sources get the same treatment for parity.

## Testing

- 13 new tests in `sources/npm.test.ts`: specifier grammar (scoped/unscoped/invalid), explicit-specifier classification, trust bypass, resolution via both branches (exports-restricted → walk fallback; plain → `require.resolve`), not-installed error, traversal rejection, and end-to-end `resolveSkill` + wildcard-with-`path` through the real resolver.
- Lockfile schema case for npm entries.
- `pnpm check` green: oxlint 0 warnings, 303/303 lib tests, 581/581 host tests.
- Also validated the flow shape in a real consumer repo (a design-system package shipping migration skills, consumed via the equivalent `path:./node_modules/...` form).

Docs updated: source-formats table (`cli.mdx`), trust note (`security.mdx`), README example.