### PR TITLE
feat(cli): Add plugin-aware dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All commands accept `--user` to operate on user scope (`~/.agents/`) instead of 
 
 ## Source Formats
 
-Skills can come from GitHub, GitLab, any git server, well-known HTTPS skill sources, or local directories. Git and local sources are checked for plugins first. If any plugin is found, `add` treats the entire source as plugin-only; standalone and bundled skills in that source are not offered. Well-known HTTPS sources remain skill-only:
+Skills can come from GitHub, GitLab, any git server, well-known HTTPS skill sources, or local directories. Git and local sources are checked for plugins first. If any plugin is found, `add` treats the entire source as plugin-only; standalone and bundled skills in that source are not offered. Malformed plugin-shaped content is an error rather than a fallback to skills. Local plugin sources that overlap the project's managed `.agents/plugins` directory are rejected before configuration changes. Well-known HTTPS sources remain skill-only:
 
 ```toml
 [[skills]]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Shared tooling for coding agents. Declare skills, MCP servers, hooks, subagents,
 npx @sentry/dotagents init
 ```
 
-The interactive setup walks you through selecting agents and trust policy. Then add skills:
+The interactive setup walks you through selecting agents and trust policy. Then add skills or plugins:
 
 ```bash
 # Add a skill from a GitHub repo
@@ -29,6 +29,9 @@ npx @sentry/dotagents add getsentry/skills find-bugs code-review commit
 
 # Or add all skills from a repo
 npx @sentry/dotagents add getsentry/skills --all
+
+# Add a plugin (auto-detected from the source)
+npx @sentry/dotagents add getsentry/agent-plugins review-tools
 ```
 
 This creates an `agents.toml` at your project root and an `agents.lock` tracking installed skills, subagents, and plugins.
@@ -44,7 +47,7 @@ npx @sentry/dotagents install
 | Command | Description |
 |---------|-------------|
 | `init` | Create `agents.toml` and `.agents/skills/` |
-| `add <source> [skills...]` | Add skill dependencies |
+| `add <source> [names...]` | Discover and add plugins, otherwise skills |
 | `remove <name\|source> [-y]` | Remove a skill, plugin, or all dependencies from a source |
 | `install` | Install all dependencies from `agents.toml` |
 | `list` | Show declared skills, plugins, and their status |
@@ -57,7 +60,7 @@ All commands accept `--user` to operate on user scope (`~/.agents/`) instead of 
 
 ## Source Formats
 
-Skills can come from GitHub, GitLab, any git server, well-known HTTPS skill sources, or local directories:
+Skills can come from GitHub, GitLab, any git server, well-known HTTPS skill sources, or local directories. Git and local sources are checked for plugins first. If any plugin is found, `add` treats the entire source as plugin-only; standalone and bundled skills in that source are not offered. Well-known HTTPS sources remain skill-only:
 
 ```toml
 [[skills]]
@@ -142,7 +145,7 @@ targets = ["claude", "cursor", "codex", "grok", "opencode", "pi"]
 
 The canonical portable format is an [Agent Plugins](https://agent-plugins.org/) v1 bundle: required `plugin.json`, optional `skills/`, optional `mcp.json`, and reverse-domain client extensions. dotagents preserves those portable source files under `.agents/plugins/<name>/` and generates isolated target harnesses. Generated JSON uses adjacent ownership sidecars, while component symlinks use markers in reserved `.dotagents-managed/` directories, so client-owned JSON remains unchanged. Legacy generalized and native Claude/Cursor/Codex manifests remain discoverable during migration; native imports preserve their owning manifest and expose only core metadata and Agent Skills to other clients. Standard bundles reject legacy root components so client-specific behavior cannot leak across harnesses.
 
-Plugin declarations are project-scope only for now. `dotagents --user install` rejects `[[plugins]]` entries because user-scope runtime plugin projections are not generated yet.
+Plugin declarations are project-scope only for now. `dotagents --user add` rejects a detected plugin source without changing user configuration, and `dotagents --user install` rejects `[[plugins]]` entries because user-scope runtime plugin projections are not generated yet.
 
 Pi plugin targets are global skill projections rather than isolated plugin installs: a Pi-targeted plugin skill is added to `.agents/skills/` and is therefore visible to other clients that consume that shared directory.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -317,7 +317,7 @@ Rules:
 - `allow_all = true` = all sources allowed (explicit intent)
 - `[trust]` present without `allow_all` = allowlist mode (source must match at least one rule)
 - Local `path:` sources are always allowed
-- Trust is validated before any network operations in `add` for skills and `install` for configured skills, subagents, and plugins
+- Trust is validated before any network operations in `add` for dependencies and `install` for configured skills, subagents, and plugins
 
 ## CLI Commands
 
@@ -353,7 +353,7 @@ Install and refresh dependencies from `agents.toml`. Resolves sources, copies sk
 npx @sentry/dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]
 ```
 
-Add and install plugins or skills. Git and local sources are classified once: if any valid plugin is found, the entire source is plugin-only and skills in it are ignored; otherwise normal skill discovery runs. Well-known HTTPS catalogs remain skill-only.
+Add and install plugins or skills. Git and local sources are classified once: if any valid plugin is found, the entire source is plugin-only and skills in it are ignored; otherwise normal skill discovery runs. Malformed plugin-shaped content fails without falling back to skills. Local plugin sources that overlap the project's managed `.agents/plugins` directory are rejected before configuration changes. Well-known HTTPS catalogs remain skill-only.
 
 | Flag | Description |
 |------|-------------|
@@ -366,6 +366,8 @@ Add and install plugins or skills. Git and local sources are classified once: if
 When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds are project-only; `--user add` rejects a detected plugin source before changing user state.
 
 When adding multiple dependencies, names already declared for that kind are skipped with a warning. The command fails if all specified names already exist. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
+
+Plugin declarations persist the exact discovered source path (`.` for a source-root plugin), preventing later source inventory changes from changing selection.
 
 ### remove
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -350,21 +350,22 @@ Install and refresh dependencies from `agents.toml`. Resolves sources, copies sk
 ### add
 
 ```
-npx @sentry/dotagents add <source> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]
+npx @sentry/dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]
 ```
 
-Add one or more skill dependencies and install them. Specify skill names as positional arguments or with `--skill` flags.
+Add and install plugins or skills. Git and local sources are classified once: if any valid plugin is found, the entire source is plugin-only and skills in it are ignored; otherwise normal skill discovery runs. Well-known HTTPS catalogs remain skill-only.
 
 | Flag | Description |
 |------|-------------|
-| `<skill>...` | Positional skill names to add |
-| `--skill <name>` | Specify which skill(s) to add (repeatable, alias: `--name`) |
+| `<name>...` | Positional plugin or skill names to add |
+| `--name <name>` | Specify dependencies to add (repeatable) |
+| `--skill <name>` | Compatibility alias for `--name`; does not force skill mode |
 | `--ref <ref>` | Pin to a specific tag, branch, or commit |
-| `--all` | Add all skills from the source as a wildcard entry (`name = "*"`) |
+| `--all` | Add every current plugin explicitly, or all skills as a wildcard (`name = "*"`) |
 
-When a repo has one skill, it is added automatically. When multiple skills are found without names or `--all`, interactive mode shows a picker (TTY) or lists them (non-TTY).
+When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds are project-only; `--user add` rejects a detected plugin source before changing user state.
 
-When adding multiple skills, any that already exist in `agents.toml` are skipped with a warning. The command only fails if all specified skills already exist. Positional names and `--skill` flags cannot be mixed.
+When adding multiple dependencies, names already declared for that kind are skipped with a warning. The command fails if all specified names already exist. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
 
 ### remove
 

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -73,25 +73,26 @@ dotagents install
 ### `dotagents add`
 
 ```shell
-dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]
+dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]
 ```
 
-Add one or more skill dependencies and install them. dotagents auto-discovers
-skills in the source. When a source has one skill, it is added automatically.
-When multiple skills are found, interactive mode shows a picker. In
-non-interactive mode, pass skill names as positional arguments, use `--skill`, or
-use `--all`.
+Add and install plugins or skills. For git and local sources, dotagents discovers
+plugins first. If it finds any, the whole source is treated as plugin-only and
+skills in that source are ignored. Otherwise the existing skill discovery flow
+is used. Well-known HTTPS catalogs are always skill-only. A single dependency is
+selected automatically; multiple dependencies use a picker in interactive mode.
 
 Shorthand `owner/repo` resolves through `defaultRepositorySource` in
 `agents.toml`.
 
 Options:
 
-- `--skill <name>` specifies which skill to add. Repeatable. Alias: `--name`.
+- `--name <name>` specifies which dependency to add. Repeatable.
+- `--skill <name>` is a compatibility alias for `--name` and does not force skill mode.
 - `--ref <ref>` pins to a specific tag, branch, or commit.
-- `--all` adds all skills from the source as a wildcard entry (`name = "*"`).
+- `--all` writes every currently discovered plugin explicitly in plugin mode. In skill mode it adds the existing wildcard entry (`name = "*"`), which can include future upstream skills.
 
-Do not mix positional skill names and `--skill` or `--name` flags in the same
+Do not mix positional names and `--skill` or `--name` flags in the same
 command.
 
 Examples:
@@ -102,6 +103,12 @@ dotagents add getsentry/skills find-bugs
 
 # All skills from a repo
 dotagents add getsentry/skills --all
+
+# One plugin from a repository plugin catalog
+dotagents add getsentry/agent-plugins review-tools
+
+# Snapshot every plugin currently in a local catalog
+dotagents add path:./agent-plugins --all
 
 # Pinned to a ref
 dotagents add getsentry/warden@v1.0.0
@@ -472,6 +479,9 @@ dotagents --user install
 
 When no `agents.toml` exists and you are not inside a git repo, dotagents falls
 back to user scope automatically.
+
+Plugins remain project-only. If `--user add` detects a plugin source, it exits
+without changing the user config, lockfile, installed directories, or runtime output.
 
 ## Environment Variables
 

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -79,8 +79,10 @@ dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]
 Add and install plugins or skills. For git and local sources, dotagents discovers
 plugins first. If it finds any, the whole source is treated as plugin-only and
 skills in that source are ignored. Otherwise the existing skill discovery flow
-is used. Well-known HTTPS catalogs are always skill-only. A single dependency is
-selected automatically; multiple dependencies use a picker in interactive mode.
+is used. Malformed plugin-shaped content fails without falling back to skills.
+Local plugin sources that overlap the project's managed `.agents/plugins`
+directory are rejected before configuration changes. Well-known HTTPS catalogs are always skill-only. A single dependency is selected
+automatically; multiple dependencies use a picker in interactive mode.
 
 Shorthand `owner/repo` resolves through `defaultRepositorySource` in
 `agents.toml`.
@@ -91,6 +93,9 @@ Options:
 - `--skill <name>` is a compatibility alias for `--name` and does not force skill mode.
 - `--ref <ref>` pins to a specific tag, branch, or commit.
 - `--all` writes every currently discovered plugin explicitly in plugin mode. In skill mode it adds the existing wildcard entry (`name = "*"`), which can include future upstream skills.
+
+Plugin declarations record the exact discovered source path (`.` for a plugin
+at the source root), so later additions to the source cannot change selection.
 
 Do not mix positional names and `--skill` or `--name` flags in the same
 command.

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -675,6 +675,35 @@ describe("runAdd (local sources)", () => {
     expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
   });
 
+  it("rejects a source inside a symlinked managed plugin directory", async () => {
+    const managedAgentsDir = join(projectRoot, "managed-agents");
+    const pluginDir = join(managedAgentsDir, "plugins", "local-tools");
+    await rm(join(projectRoot, ".agents"), { recursive: true });
+    await writePlugin(pluginDir, "local-tools");
+    await symlink(managedAgentsDir, join(projectRoot, ".agents"), "dir");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:managed-agents/plugins/local-tools",
+    })).rejects.toThrow("source overlaps this project's managed plugin directory");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
+  it("adds a local plugin before the managed agents directory exists", async () => {
+    const pluginDir = join(projectRoot, "plugin-source", "review-tools");
+    await rm(join(projectRoot, ".agents"), { recursive: true });
+    await writePlugin(pluginDir, "review-tools");
+    mockRunInstall();
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-source/review-tools",
+    })).resolves.toBe("review-tools");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
+      'name = "review-tools"',
+    );
+  });
+
   it("keeps marketplace aliases distinct in the interactive plugin picker", async () => {
     const sourceDir = join(projectRoot, "aliased-plugin-picker");
     const pluginDir = join(sourceDir, "shared-plugin");

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, readFile, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as clack from "@clack/prompts";
@@ -96,6 +96,9 @@ describe("runAdd", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete process.env["DOTAGENTS_STATE_DIR"];
+    delete process.env["GIT_CONFIG_COUNT"];
+    delete process.env["GIT_CONFIG_KEY_0"];
+    delete process.env["GIT_CONFIG_VALUE_0"];
     await rm(tmpDir, { recursive: true });
   });
 
@@ -261,6 +264,10 @@ describe("runAdd", () => {
   });
 
   it("stores the original source spelling and installs once", async () => {
+    const shorthand = "local/source-spelling";
+    process.env["GIT_CONFIG_COUNT"] = "1";
+    process.env["GIT_CONFIG_KEY_0"] = `url.file://${repoDir}.insteadOf`;
+    process.env["GIT_CONFIG_VALUE_0"] = `https://github.com/${shorthand}`;
     const installSpy = vi.spyOn(installModule, "runInstall").mockResolvedValue({
       installed: [],
       installedPlugins: [],
@@ -274,14 +281,34 @@ describe("runAdd", () => {
 
     const result = await runAdd({
       scope: resolveScope("project", projectRoot),
-      specifier: `git:${repoDir}`,
+      specifier: shorthand,
       all: true,
     });
 
     expect(result).toBe("*");
     expect(installSpy).toHaveBeenCalledOnce();
     const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
-    expect(toml).toContain(`source = "git:${repoDir}"`);
+    expect(toml).toContain(`source = "${shorthand}"`);
+    expect(toml).not.toContain(`source = "https://github.com/${shorthand}"`);
+  });
+
+  it("classifies an acquired git repository as a plugin source", async () => {
+    await writePlugin(join(repoDir, "plugins", "git-plugin"), "git-plugin");
+    await exec("git", ["add", "."], { cwd: repoDir });
+    await exec("git", ["commit", "-m", "add plugin"], { cwd: repoDir });
+    mockRunInstall();
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: `git:${repoDir}`,
+      names: ["git-plugin"],
+    });
+
+    expect(result).toBe("git-plugin");
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain("[[plugins]]");
+    expect(toml).toContain('path = "plugins/git-plugin"');
+    expect(toml).not.toContain("[[skills]]");
   });
 
   it("selects explicit well-known names like git catalog names", async () => {
@@ -521,6 +548,7 @@ describe("runAdd (local sources)", () => {
     const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
     expect(toml).toContain("[[plugins]]");
     expect(toml).toContain('name = "review-plugin"');
+    expect(toml).toContain('path = "."');
     expect(toml).not.toContain("[[skills]]");
     expect(install).toHaveBeenCalledOnce();
   });
@@ -580,7 +608,7 @@ describe("runAdd (local sources)", () => {
     })).rejects.toThrow(/Multiple plugins found.*alpha, beta.*--name/);
 
     vi.mocked(clack.select).mockResolvedValue("pick");
-    vi.mocked(clack.multiselect).mockResolvedValue(["plugins/beta"]);
+    vi.mocked(clack.multiselect).mockResolvedValue([1]);
     vi.mocked(clack.isCancel).mockReturnValue(false);
     mockRunInstall();
     const result = await runAdd({
@@ -593,6 +621,88 @@ describe("runAdd (local sources)", () => {
     expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
       'path = "plugins/beta"',
     );
+  });
+
+  it("pins an interactively selected source-root plugin with a dot path", async () => {
+    const sourceDir = join(projectRoot, "root-plugin-picker");
+    await writePlugin(sourceDir, "shared");
+    await writePlugin(join(sourceDir, ".agents", "plugins", "shared"), "shared");
+    vi.mocked(clack.select).mockResolvedValue("pick");
+    vi.mocked(clack.multiselect).mockResolvedValue([0]);
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    mockRunInstall();
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:root-plugin-picker",
+      interactive: true,
+    });
+
+    expect(result).toBe("shared");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
+      'path = "."',
+    );
+  });
+
+  it("rejects a local plugin source that contains the managed install directory", async () => {
+    await writePlugin(projectRoot, "project-root");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:.",
+    })).rejects.toThrow("source overlaps this project's managed plugin directory");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
+  it("rejects a symlinked local source that resolves to the project root", async () => {
+    await writePlugin(projectRoot, "project-root");
+    await symlink(projectRoot, join(projectRoot, "source-link"), "dir");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:source-link",
+    })).rejects.toThrow("source overlaps this project's managed plugin directory");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
+  it("rejects a local plugin source inside the managed install directory", async () => {
+    await writePlugin(join(projectRoot, ".agents", "plugins", "local-tools"), "local-tools");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:.agents/plugins/local-tools",
+    })).rejects.toThrow("source overlaps this project's managed plugin directory");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
+  it("keeps marketplace aliases distinct in the interactive plugin picker", async () => {
+    const sourceDir = join(projectRoot, "aliased-plugin-picker");
+    const pluginDir = join(sourceDir, "shared-plugin");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, "plugin.json"), "{}");
+    await writeFile(join(sourceDir, "marketplace.json"), JSON.stringify({
+      name: "aliases",
+      plugins: [
+        { name: "alpha", source: "./shared-plugin" },
+        { name: "beta", source: "./shared-plugin" },
+      ],
+    }));
+    vi.mocked(clack.select).mockResolvedValue("pick");
+    vi.mocked(clack.multiselect).mockResolvedValue([0, 1]);
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    mockRunInstall();
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:aliased-plugin-picker",
+      interactive: true,
+    });
+
+    expect(result).toEqual(["alpha", "beta"]);
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain('name = "alpha"');
+    expect(toml).toContain('name = "beta"');
+    expect(toml.match(/path = "shared-plugin"/g)).toHaveLength(2);
   });
 
   it("adds every discovered plugin explicitly with --all", async () => {

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -25,6 +26,24 @@ description: Test skill ${name}
 
 # ${name}
 `;
+
+async function writePlugin(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "plugin.json"), JSON.stringify({ name }));
+}
+
+function mockRunInstall() {
+  return vi.spyOn(installModule, "runInstall").mockResolvedValue({
+    installed: [],
+    installedPlugins: [],
+    pruned: [],
+    prunedPlugins: [],
+    mcpWarnings: [],
+    hookWarnings: [],
+    subagentWarnings: [],
+    pluginWarnings: [],
+  });
+}
 
 describe("runAdd", () => {
   let tmpDir: string;
@@ -197,21 +216,21 @@ describe("runAdd", () => {
     ).rejects.toThrow("Cannot use --all with --name. Use one or the other.");
   });
 
-  it("treats shorthand and expanded GitLab sources as the same wildcard", async () => {
+  it("rejects an existing wildcard after source classification", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
-      `version = 1\ndefaultRepositorySource = "gitlab"\n\n[[skills]]\nname = "*"\nsource = "getsentry/skills"\n`,
+      `version = 1\n\n[[skills]]\nname = "*"\nsource = "git:${repoDir}"\n`,
     );
 
     const scope = resolveScope("project", projectRoot);
     await expect(
       runAdd({
         scope,
-        specifier: "getsentry/skills",
+        specifier: `git:${repoDir}`,
         all: true,
       }),
     ).rejects.toThrow(
-      'A wildcard entry for "getsentry/skills" already exists in agents.toml.',
+      `A wildcard entry for "git:${repoDir}" already exists in agents.toml.`,
     );
   });
 
@@ -242,10 +261,6 @@ describe("runAdd", () => {
   });
 
   it("stores the original source spelling and installs once", async () => {
-    await writeFile(
-      join(projectRoot, "agents.toml"),
-      `version = 1\ndefaultRepositorySource = "gitlab"\n`,
-    );
     const installSpy = vi.spyOn(installModule, "runInstall").mockResolvedValue({
       installed: [],
       installedPlugins: [],
@@ -259,15 +274,14 @@ describe("runAdd", () => {
 
     const result = await runAdd({
       scope: resolveScope("project", projectRoot),
-      specifier: "getsentry/skills",
+      specifier: `git:${repoDir}`,
       all: true,
     });
 
     expect(result).toBe("*");
     expect(installSpy).toHaveBeenCalledOnce();
     const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
-    expect(toml).toContain('source = "getsentry/skills"');
-    expect(toml).not.toContain('source = "https://gitlab.com/getsentry/skills"');
+    expect(toml).toContain(`source = "git:${repoDir}"`);
   });
 
   it("selects explicit well-known names like git catalog names", async () => {
@@ -454,6 +468,7 @@ describe("runAdd (local sources)", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     delete process.env["DOTAGENTS_STATE_DIR"];
     await rm(tmpDir, { recursive: true });
   });
@@ -486,6 +501,183 @@ describe("runAdd (local sources)", () => {
     expect(result).toBe("pdf");
     const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
     expect(toml).toContain('name = "pdf"');
+  });
+
+  it("prefers a plugin over standalone and bundled skills for the whole source", async () => {
+    const sourceDir = join(projectRoot, "mixed-source");
+    await writePlugin(sourceDir, "review-plugin");
+    await mkdir(join(sourceDir, "skills", "bundled"), { recursive: true });
+    await writeFile(join(sourceDir, "skills", "bundled", "SKILL.md"), SKILL_MD("bundled"));
+    await mkdir(join(sourceDir, "standalone"), { recursive: true });
+    await writeFile(join(sourceDir, "standalone", "SKILL.md"), SKILL_MD("standalone"));
+    const install = mockRunInstall();
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:mixed-source",
+    });
+
+    expect(result).toBe("review-plugin");
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml).toContain("[[plugins]]");
+    expect(toml).toContain('name = "review-plugin"');
+    expect(toml).not.toContain("[[skills]]");
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("does not fall back to skills when a plugin manifest is malformed", async () => {
+    const sourceDir = join(projectRoot, "broken-plugin-source");
+    await mkdir(join(sourceDir, "skills", "review"), { recursive: true });
+    await writeFile(join(sourceDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
+    await writeFile(join(sourceDir, "plugin.json"), "{");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:broken-plugin-source",
+      names: ["review"],
+    })).rejects.toThrow(join(sourceDir, "plugin.json"));
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
+  it("preflights plugin names and persists exact paths and refs in one install", async () => {
+    const sourceDir = join(projectRoot, "plugin-catalog");
+    await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
+    await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
+    const install = mockRunInstall();
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-catalog",
+      names: ["alpha", "missing"],
+    })).rejects.toThrow('Plugin "missing" not found');
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-catalog",
+      names: ["alpha", "beta"],
+      ref: "release/v1",
+    });
+
+    expect(result).toEqual(["alpha", "beta"]);
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml.match(/\[\[plugins\]\]/g)).toHaveLength(2);
+    expect(toml).toContain('path = "plugins/alpha"');
+    expect(toml).toContain('path = "plugins/beta"');
+    expect(toml.match(/ref = "release\/v1"/g)).toHaveLength(2);
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("lists plugins in non-interactive mode and supports interactive selection", async () => {
+    const sourceDir = join(projectRoot, "plugin-picker");
+    await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
+    await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-picker",
+      interactive: false,
+    })).rejects.toThrow(/Multiple plugins found.*alpha, beta.*--name/);
+
+    vi.mocked(clack.select).mockResolvedValue("pick");
+    vi.mocked(clack.multiselect).mockResolvedValue(["plugins/beta"]);
+    vi.mocked(clack.isCancel).mockReturnValue(false);
+    mockRunInstall();
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-picker",
+      interactive: true,
+    });
+
+    expect(result).toBe("beta");
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
+      'path = "plugins/beta"',
+    );
+  });
+
+  it("adds every discovered plugin explicitly with --all", async () => {
+    const sourceDir = join(projectRoot, "plugin-all");
+    await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
+    await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
+    const install = mockRunInstall();
+
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-all",
+      all: true,
+    });
+
+    expect(result).toEqual(["alpha", "beta"]);
+    const toml = await readFile(join(projectRoot, "agents.toml"), "utf-8");
+    expect(toml.match(/\[\[plugins\]\]/g)).toHaveLength(2);
+    expect(toml).not.toContain('name = "*"');
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("preserves single and multi-name duplicate behavior for plugins", async () => {
+    const sourceDir = join(projectRoot, "plugin-duplicates");
+    await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
+    await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      'version = 1\n\n[[plugins]]\nname = "alpha"\nsource = "path:plugin-duplicates"\npath = "plugins/alpha"\n',
+    );
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-duplicates",
+      names: ["alpha"],
+    })).rejects.toThrow('Plugin "alpha" already exists');
+
+    const install = mockRunInstall();
+    const result = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-duplicates",
+      names: ["alpha", "beta"],
+    });
+    expect(result).toEqual(["beta"]);
+    expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("rejects user-scope plugins before changing config or runtime state", async () => {
+    const userRoot = join(tmpDir, "user-home");
+    const sourceDir = join(userRoot, "plugin-source");
+    await mkdir(userRoot, { recursive: true });
+    await writeFile(join(userRoot, "agents.toml"), "version = 1\n");
+    await writePlugin(sourceDir, "project-only");
+    const scope = resolveScope("user");
+    scope.root = userRoot;
+    scope.configPath = join(userRoot, "agents.toml");
+    scope.lockPath = join(userRoot, "agents.lock");
+    scope.pluginsDir = join(userRoot, "plugins");
+
+    await expect(runAdd({
+      scope,
+      specifier: "path:plugin-source",
+    })).rejects.toThrow("Plugins are project-scope only");
+
+    expect(await readFile(scope.configPath, "utf-8")).toBe("version = 1\n");
+    await expect(readFile(scope.lockPath, "utf-8")).rejects.toThrow();
+    await expect(readFile(join(scope.pluginsDir, "project-only", "plugin.json"), "utf-8")).rejects.toThrow();
+  });
+
+  it("does not bootstrap a missing user config for a detected plugin", async () => {
+    const userRoot = join(tmpDir, "fresh-user-home");
+    await writePlugin(join(userRoot, "plugin-source"), "project-only");
+    const scope = resolveScope("user");
+    scope.root = userRoot;
+    scope.configPath = join(userRoot, "agents.toml");
+    scope.lockPath = join(userRoot, "agents.lock");
+    scope.pluginsDir = join(userRoot, "plugins");
+
+    await expect(runAdd({
+      scope,
+      specifier: "path:plugin-source",
+    })).rejects.toThrow("Plugins are project-scope only");
+
+    expect(existsSync(scope.configPath)).toBe(false);
+    expect(existsSync(scope.lockPath)).toBe(false);
+    expect(existsSync(scope.pluginsDir)).toBe(false);
   });
 
 });
@@ -533,6 +725,7 @@ describe("add() CLI parsing", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     delete process.env["DOTAGENTS_STATE_DIR"];
     process.exitCode = originalExitCode;
     await rm(tmpDir, { recursive: true });
@@ -576,6 +769,25 @@ describe("add() CLI parsing", () => {
     try {
       await add([`git:${repoDir}`, "pdf", "--skill", "review"]);
       expect(process.exitCode).toBe(1);
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+
+  it("treats --skill as a plugin-selection alias and prints plugin output", async () => {
+    await writePlugin(join(projectRoot, "plugin-source"), "cli-plugin");
+    mockRunInstall();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const origCwd = process.cwd();
+    process.chdir(projectRoot);
+    try {
+      await add(["path:plugin-source", "--skill", "cli-plugin"]);
+
+      expect(process.exitCode).toBeUndefined();
+      expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toContain(
+        "[[plugins]]",
+      );
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Added plugin: cli-plugin"));
     } finally {
       process.chdir(origCwd);
     }

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import * as clack from "@clack/prompts";
 import chalk from "chalk";
@@ -103,6 +103,18 @@ function containsPath(parentDir: string, childDir: string): boolean {
   const childPath = relative(resolve(parentDir), resolve(childDir));
   return childPath === "" ||
     (childPath !== ".." && !childPath.startsWith(`..${sep}`) && !isAbsolute(childPath));
+}
+
+async function physicalPath(path: string): Promise<string> {
+  let existingPath = resolve(path);
+  const missingSegments: string[] = [];
+  while (!existsSync(existingPath)) {
+    const parentPath = dirname(existingPath);
+    if (parentPath === existingPath) {return existingPath;}
+    missingSegments.unshift(basename(existingPath));
+    existingPath = parentPath;
+  }
+  return resolve(await realpath(existingPath), ...missingSegments);
 }
 
 async function acquireSource(
@@ -572,10 +584,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
       all,
     );
     if (acquired.local) {
-      const managedPluginsDir = resolve(
-        await realpath(scope.root),
-        relative(resolve(scope.root), resolve(scope.pluginsDir)),
-      );
+      const managedPluginsDir = await physicalPath(scope.pluginsDir);
       let enclosingCandidate: PluginCandidate | undefined;
       for (const candidate of selection.candidates) {
         const candidateDir = await realpath(candidate.dir);
@@ -590,7 +599,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
       if (enclosingCandidate) {
         throw new AddError(
           `Plugin "${enclosingCandidate.name}" source overlaps this project's managed plugin directory. ` +
-            "Use a plugin directory outside the project root.",
+            "Use a plugin source elsewhere inside the project, outside .agents/plugins.",
         );
       }
     }

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -1,10 +1,21 @@
+import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import * as clack from "@clack/prompts";
 import chalk from "chalk";
 import { loadConfig } from "../../config/loader.js";
-import { isWildcardDep, GITHUB_HTTPS_URL, GITLAB_HTTPS_URL } from "../../config/schema.js";
-import { addSkillToConfig, addWildcardToConfig } from "../../config/writer.js";
+import {
+  isWildcardDep,
+  GITHUB_HTTPS_URL,
+  GITLAB_HTTPS_URL,
+  PLUGIN_NAME_PATTERN,
+  agentsConfigSchema,
+} from "../../config/schema.js";
+import {
+  addPluginsToConfig,
+  addSkillToConfig,
+  addWildcardToConfig,
+} from "../../config/writer.js";
 import {
   applyDefaultRepositorySource,
   isExplicitSourceSpecifier,
@@ -29,6 +40,10 @@ import { formatGitError, formatTrustError } from "../errors.js";
 import { runInstall } from "./install.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
 import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
+import {
+  discoverPlugins,
+  type PluginCandidate,
+} from "../../plugins/store.js";
 
 /** Parent paths that are standard/expected — no need to show them in the picker */
 const STANDARD_PARENTS = new Set(["", "skills", ".agents/skills", ".claude/skills"]);
@@ -56,30 +71,41 @@ export interface AddOptions {
   interactive?: boolean;
 }
 
-type AcquiredSkills =
-  | { type: "root-skill"; name: string }
-  | { type: "catalog"; rootDir: string };
+interface AcquiredSource {
+  rootDir: string;
+  pluginEligible: boolean;
+  local: boolean;
+}
 
-type AddSelection =
+type DuplicatePolicy = "single" | "specified" | "selected";
+
+type SkillSelection =
   | { type: "wildcard" }
   | {
       type: "skills";
       names: string[];
       /** Single names reject duplicates; specified names warn; prompted selections skip silently. */
-      duplicatePolicy: "single" | "specified" | "selected";
+      duplicatePolicy: DuplicatePolicy;
     };
 
-async function acquireSkills(
+interface PluginSelection {
+  candidates: PluginCandidate[];
+  duplicatePolicy: DuplicatePolicy;
+}
+
+interface DetailedAddResult {
+  kind: "skill" | "plugin";
+  result: string | string[];
+}
+
+async function acquireSource(
   parsed: ReturnType<typeof parseSource>,
   scope: ScopeRoot,
   effectiveRef: string | undefined,
-  hasExplicitNames: boolean,
-): Promise<AcquiredSkills> {
+): Promise<AcquiredSource> {
   if (parsed.type === "local") {
     const rootDir = await resolveLocalSource(scope.root, parsed.path!);
-    if (hasExplicitNames) {return { type: "catalog", rootDir };}
-    const meta = await loadSkillMd(join(rootDir, "SKILL.md"));
-    return { type: "root-skill", name: meta.name };
+    return { rootDir, pluginEligible: true, local: true };
   }
 
   if (parsed.type === "well-known") {
@@ -98,7 +124,7 @@ async function acquireSkills(
         `No skills found at ${baseUrl}. If this is a git repository, use the git: prefix: git:${baseUrl}`,
       );
     }
-    return { type: "catalog", rootDir: cached.cacheDir };
+    return { rootDir: cached.cacheDir, pluginEligible: false, local: false };
   }
 
   const url = parsed.url!;
@@ -110,7 +136,7 @@ async function acquireSkills(
       : sanitizeCacheKey(url),
     ref: effectiveRef,
   });
-  return { type: "catalog", rootDir: cached.repoDir };
+  return { rootDir: cached.repoDir, pluginEligible: true, local: false };
 }
 
 async function verifyRequestedNames(
@@ -132,15 +158,16 @@ async function verifyRequestedNames(
 }
 
 async function selectSkills(
-  acquired: AcquiredSkills,
+  acquired: AcquiredSource,
   names: string[] | undefined,
   source: string,
   interactive: boolean | undefined,
-): Promise<AddSelection> {
-  if (acquired.type === "root-skill") {
+): Promise<SkillSelection> {
+  if (acquired.local && !names?.length) {
+    const meta = await loadSkillMd(join(acquired.rootDir, "SKILL.md"));
     return {
       type: "skills",
-      names: [acquired.name],
+      names: [meta.name],
       duplicatePolicy: "single",
     };
   }
@@ -221,7 +248,116 @@ async function selectSkills(
   };
 }
 
-export async function runAdd(opts: AddOptions): Promise<string | string[]> {
+function pluginCandidateForName(
+  candidates: PluginCandidate[],
+  name: string,
+  source: string,
+): PluginCandidate {
+  const matches = candidates.filter((candidate) => candidate.name === name);
+  if (matches.length === 0) {
+    throw new AddError(
+      `Plugin "${name}" not found in ${source}. ` +
+        `Use 'npx @sentry/dotagents add ${source}' without --name to see available plugins.`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new AddError(
+      `Plugin "${name}" is ambiguous in ${source}: ${matches.map((candidate) => candidate.path || ".").join(", ")}`,
+    );
+  }
+  return matches[0]!;
+}
+
+function assertUniquePluginNames(
+  candidates: PluginCandidate[],
+  source: string,
+): void {
+  const byName = new Map<string, PluginCandidate[]>();
+  for (const candidate of candidates) {
+    const matches = byName.get(candidate.name) ?? [];
+    matches.push(candidate);
+    byName.set(candidate.name, matches);
+  }
+  for (const [name, matches] of byName) {
+    if (matches.length > 1) {
+      throw new AddError(
+        `Plugin "${name}" is ambiguous in ${source}: ${matches.map((candidate) => candidate.path || ".").join(", ")}`,
+      );
+    }
+  }
+}
+
+async function selectPlugins(
+  candidates: PluginCandidate[],
+  names: string[] | undefined,
+  source: string,
+  interactive: boolean | undefined,
+  all: boolean | undefined,
+): Promise<PluginSelection> {
+  if (all) {
+    assertUniquePluginNames(candidates, source);
+    return { candidates, duplicatePolicy: "specified" };
+  }
+  if (names?.length) {
+    return {
+      candidates: names.map((name) => pluginCandidateForName(candidates, name, source)),
+      duplicatePolicy: names.length === 1 ? "single" : "specified",
+    };
+  }
+  if (candidates.length === 1) {
+    return { candidates, duplicatePolicy: "single" };
+  }
+  if (!interactive) {
+    const availableNames = candidates.map((candidate) => candidate.name).toSorted();
+    throw new AddError(
+      `Multiple plugins found in ${source}: ${availableNames.join(", ")}. ` +
+        "Specify plugin names as arguments, use --name to specify which ones, or --all for all plugins.",
+    );
+  }
+
+  const mode = await clack.select({
+    message: `Multiple plugins found in ${source}. How would you like to add them?`,
+    options: [
+      {
+        label: "All",
+        value: "all" as const,
+        hint: "Add every plugin currently discovered in this source",
+      },
+      {
+        label: "Select specific plugins",
+        value: "pick" as const,
+        hint: "Choose individual plugins to add",
+      },
+    ],
+  });
+  if (clack.isCancel(mode)) {throw new AddCancelledError();}
+  if (mode === "all") {
+    assertUniquePluginNames(candidates, source);
+    return { candidates, duplicatePolicy: "selected" };
+  }
+
+  const byPath = new Map(candidates.map((candidate) => [candidate.path, candidate]));
+  const selectedPaths = await clack.multiselect({
+    message: "Select which plugins to add:",
+    options: candidates
+      .toSorted((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path))
+      .map((candidate) => ({
+        label: candidate.name,
+        value: candidate.path,
+        hint: candidate.path ? chalk.dim(`(${candidate.path})`) : "Source root",
+      })),
+    required: true,
+  });
+  if (clack.isCancel(selectedPaths)) {throw new AddCancelledError();}
+  const selected = selectedPaths.map((path) => byPath.get(path)!);
+  assertUniquePluginNames(selected, source);
+  return {
+    candidates: selected,
+    duplicatePolicy: selected.length === 1 ? "single" : "selected",
+  };
+}
+
+async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
   const {
     scope,
     specifier: rawSpecifier,
@@ -233,7 +369,10 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
   const specifier = stripLeadingAt(rawSpecifier);
   const namesOverride = rawNames ? [...new Set(rawNames)] : rawNames;
   const { configPath } = scope;
-  const config = await loadConfig(configPath);
+  const needsUserBootstrap = scope.scope === "user" && !existsSync(configPath);
+  const config = needsUserBootstrap
+    ? agentsConfigSchema.parse({ version: 1 })
+    : await loadConfig(configPath);
 
   const hintedSpecifier = applyDefaultRepositorySource(
     specifier,
@@ -267,17 +406,8 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
     throw new AddError("Cannot use --all with --name. Use one or the other.");
   }
 
-  if (namesOverride?.length) {
-    for (const name of namesOverride) {
-      if (!VALID_SKILL_NAME.test(name)) {
-        throw new AddError(
-          `Invalid skill name "${name}". Names must start with alphanumeric and contain only alphanumeric, dots, underscores, or hyphens.`,
-        );
-      }
-    }
-  }
-
-  async function persist(selection: AddSelection): Promise<string | string[]> {
+  async function persistSkills(selection: SkillSelection): Promise<DetailedAddResult> {
+    if (needsUserBootstrap) {await ensureUserScopeBootstrapped(scope);}
     if (selection.type === "wildcard") {
       if (
         config.skills.some(
@@ -295,7 +425,7 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         exclude: [],
       });
       await runInstall({ scope });
-      return "*";
+      return { kind: "skill", result: "*" };
     }
 
     if (selection.duplicatePolicy === "single") {
@@ -310,7 +440,7 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
         ...refOpts,
       });
       await runInstall({ scope });
-      return name;
+      return { kind: "skill", result: name };
     }
 
     const toAdd: string[] = [];
@@ -340,26 +470,116 @@ export async function runAdd(opts: AddOptions): Promise<string | string[]> {
       });
     }
     await runInstall({ scope });
-    return toAdd;
+    return { kind: "skill", result: toAdd };
   }
 
-  if (all) {
-    return persist({ type: "wildcard" });
+  async function persistPlugins(selection: PluginSelection): Promise<DetailedAddResult> {
+    const existingNames = new Set(config.plugins.map((plugin) => plugin.name));
+    if (selection.duplicatePolicy === "single") {
+      const candidate = selection.candidates[0]!;
+      if (existingNames.has(candidate.name)) {
+        throw new AddError(
+          `Plugin "${candidate.name}" already exists in agents.toml. Remove it first to re-add.`,
+        );
+      }
+      await addPluginsToConfig(configPath, [{
+        name: candidate.name,
+        source: sourceForStorage,
+        ...refOpts,
+        ...(candidate.path ? { path: candidate.path } : {}),
+      }]);
+      await runInstall({ scope });
+      return { kind: "plugin", result: candidate.name };
+    }
+
+    const toAdd: PluginCandidate[] = [];
+    for (const candidate of selection.candidates) {
+      if (existingNames.has(candidate.name)) {
+        if (selection.duplicatePolicy === "specified") {
+          console.warn(
+            chalk.yellow(`Skipping "${candidate.name}": already exists in agents.toml`),
+          );
+        }
+        continue;
+      }
+      toAdd.push(candidate);
+    }
+    if (toAdd.length === 0) {
+      const qualifier = selection.duplicatePolicy === "selected"
+        ? "selected"
+        : "specified";
+      throw new AddError(`All ${qualifier} plugins already exist in agents.toml.`);
+    }
+    await addPluginsToConfig(
+      configPath,
+      toAdd.map((candidate) => ({
+        name: candidate.name,
+        source: sourceForStorage,
+        ...refOpts,
+        ...(candidate.path ? { path: candidate.path } : {}),
+      })),
+    );
+    await runInstall({ scope });
+    return { kind: "plugin", result: toAdd.map((candidate) => candidate.name) };
   }
 
-  const acquired = await acquireSkills(
-    parsed,
-    scope,
-    effectiveRef,
-    !!namesOverride?.length,
-  );
+  const acquired = await acquireSource(parsed, scope, effectiveRef);
+  let plugins: PluginCandidate[] = [];
+  if (acquired.pluginEligible) {
+    try {
+      plugins = await discoverPlugins(acquired.rootDir);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new AddError(message);
+    }
+  }
+
+  if (plugins.length > 0) {
+    if (scope.scope === "user") {
+      throw new AddError(
+        "Plugins are project-scope only. Rerun this command from a project without --user.",
+      );
+    }
+    if (namesOverride?.length) {
+      for (const name of namesOverride) {
+        if (!PLUGIN_NAME_PATTERN.test(name)) {
+          throw new AddError(
+            `Invalid plugin name "${name}". Plugin names must be 1-64 lowercase letters, numbers, hyphens, or dots, have alphanumeric ends, and not contain '--' or '..'.`,
+          );
+        }
+      }
+    }
+    const selection = await selectPlugins(
+      plugins,
+      namesOverride,
+      sourceForStorage,
+      interactive,
+      all,
+    );
+    return persistPlugins(selection);
+  }
+
+  if (namesOverride?.length) {
+    for (const name of namesOverride) {
+      if (!VALID_SKILL_NAME.test(name)) {
+        throw new AddError(
+          `Invalid skill name "${name}". Names must start with alphanumeric and contain only alphanumeric, dots, underscores, or hyphens.`,
+        );
+      }
+    }
+  }
+  if (all) {return persistSkills({ type: "wildcard" });}
   const selection = await selectSkills(
     acquired,
     namesOverride,
     sourceForStorage,
     interactive,
   );
-  return persist(selection);
+  return persistSkills(selection);
+}
+
+export async function runAdd(opts: AddOptions): Promise<string | string[]> {
+  return (await executeAdd(opts)).result;
 }
 
 export default async function add(
@@ -382,21 +602,21 @@ export default async function add(
   if (!specifier) {
     console.error(
       chalk.red(
-        "Usage: npx @sentry/dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]",
+        "Usage: npx @sentry/dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]",
       ),
     );
     process.exitCode = 1;
     return;
   }
 
-  // Collect skill names from positional args and flags
+  // Collect dependency names from positional args and flags.
   const positionalNames = positionals.slice(1);
   const flagNames = [...(values["name"] ?? []), ...(values["skill"] ?? [])];
 
   if (positionalNames.length > 0 && flagNames.length > 0) {
     console.error(
       chalk.red(
-        "Cannot mix positional skill names with --skill/--name flags. Use one or the other.",
+        "Cannot mix positional names with --name/--skill flags. Use one or the other.",
       ),
     );
     process.exitCode = 1;
@@ -410,10 +630,9 @@ export default async function add(
     const scope = flags?.user
       ? resolveScope("user")
       : resolveDefaultScope(resolve("."));
-    await ensureUserScopeBootstrapped(scope);
     const interactive =
       process.stdout.isTTY === true && !names && !values["all"];
-    const result = await runAdd({
+    const { kind, result } = await executeAdd({
       scope,
       specifier,
       ref: values["ref"],
@@ -421,12 +640,12 @@ export default async function add(
       all: values["all"],
       interactive,
     });
-    if (result === "*") {
+    if (kind === "skill" && result === "*") {
       console.log(chalk.green(`Added all skills from ${specifier}`));
     } else if (Array.isArray(result)) {
-      console.log(chalk.green(`Added skills: ${result.join(", ")}`));
+      console.log(chalk.green(`Added ${kind}s: ${result.join(", ")}`));
     } else {
-      console.log(chalk.green(`Added skill: ${result}`));
+      console.log(chalk.green(`Added ${kind}: ${result}`));
     }
   } catch (err) {
     if (err instanceof AddCancelledError) {return;}

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import * as clack from "@clack/prompts";
 import chalk from "chalk";
@@ -96,6 +97,12 @@ interface PluginSelection {
 interface DetailedAddResult {
   kind: "skill" | "plugin";
   result: string | string[];
+}
+
+function containsPath(parentDir: string, childDir: string): boolean {
+  const childPath = relative(resolve(parentDir), resolve(childDir));
+  return childPath === "" ||
+    (childPath !== ".." && !childPath.startsWith(`..${sep}`) && !isAbsolute(childPath));
 }
 
 async function acquireSource(
@@ -336,20 +343,25 @@ async function selectPlugins(
     return { candidates, duplicatePolicy: "selected" };
   }
 
-  const byPath = new Map(candidates.map((candidate) => [candidate.path, candidate]));
-  const selectedPaths = await clack.multiselect({
+  const pickerCandidates = candidates.toSorted((a, b) =>
+    a.name.localeCompare(b.name) || a.path.localeCompare(b.path)
+  );
+  const selectedIndices = await clack.multiselect({
     message: "Select which plugins to add:",
-    options: candidates
-      .toSorted((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path))
-      .map((candidate) => ({
+    options: pickerCandidates
+      .map((candidate, index) => ({
         label: candidate.name,
-        value: candidate.path,
+        value: index,
         hint: candidate.path ? chalk.dim(`(${candidate.path})`) : "Source root",
       })),
     required: true,
   });
-  if (clack.isCancel(selectedPaths)) {throw new AddCancelledError();}
-  const selected = selectedPaths.map((path) => byPath.get(path)!);
+  if (clack.isCancel(selectedIndices)) {throw new AddCancelledError();}
+  const selected = selectedIndices.map((index) => {
+    const candidate = pickerCandidates[index];
+    if (!candidate) {throw new AddError("Invalid plugin selection.");}
+    return candidate;
+  });
   assertUniquePluginNames(selected, source);
   return {
     candidates: selected,
@@ -369,6 +381,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
   const specifier = stripLeadingAt(rawSpecifier);
   const namesOverride = rawNames ? [...new Set(rawNames)] : rawNames;
   const { configPath } = scope;
+  // Defer user bootstrap until classification so rejected plugins cannot mutate user state.
   const needsUserBootstrap = scope.scope === "user" && !existsSync(configPath);
   const config = needsUserBootstrap
     ? agentsConfigSchema.parse({ version: 1 })
@@ -486,7 +499,8 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         name: candidate.name,
         source: sourceForStorage,
         ...refOpts,
-        ...(candidate.path ? { path: candidate.path } : {}),
+        // Pin every discovered directory so later source inventory changes cannot alter selection.
+        path: candidate.path || ".",
       }]);
       await runInstall({ scope });
       return { kind: "plugin", result: candidate.name };
@@ -516,7 +530,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         name: candidate.name,
         source: sourceForStorage,
         ...refOpts,
-        ...(candidate.path ? { path: candidate.path } : {}),
+        path: candidate.path || ".",
       })),
     );
     await runInstall({ scope });
@@ -534,6 +548,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
     }
   }
 
+  // Plugin presence classifies the entire source; bundled and standalone skills stay hidden.
   if (plugins.length > 0) {
     if (scope.scope === "user") {
       throw new AddError(
@@ -556,6 +571,29 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
       interactive,
       all,
     );
+    if (acquired.local) {
+      const managedPluginsDir = resolve(
+        await realpath(scope.root),
+        relative(resolve(scope.root), resolve(scope.pluginsDir)),
+      );
+      let enclosingCandidate: PluginCandidate | undefined;
+      for (const candidate of selection.candidates) {
+        const candidateDir = await realpath(candidate.dir);
+        if (
+          containsPath(candidateDir, managedPluginsDir) ||
+          containsPath(managedPluginsDir, candidateDir)
+        ) {
+          enclosingCandidate = candidate;
+          break;
+        }
+      }
+      if (enclosingCandidate) {
+        throw new AddError(
+          `Plugin "${enclosingCandidate.name}" source overlaps this project's managed plugin directory. ` +
+            "Use a plugin directory outside the project root.",
+        );
+      }
+    }
     return persistPlugins(selection);
   }
 
@@ -609,7 +647,6 @@ export default async function add(
     return;
   }
 
-  // Collect dependency names from positional args and flags.
   const positionalNames = positionals.slice(1);
   const flagNames = [...(values["name"] ?? []), ...(values["skill"] ?? [])];
 

--- a/packages/dotagents/src/cli/help.test.ts
+++ b/packages/dotagents/src/cli/help.test.ts
@@ -33,4 +33,15 @@ describe("getCommandHelp", () => {
   it("does not intercept normal command arguments", () => {
     expect(getCommandHelp("add", ["getsentry/skills", "find-bugs"])).toBeUndefined();
   });
+
+  it("describes dependency-neutral plugin-first add behavior", () => {
+    const help = getCommandHelp("add", ["--help"]);
+
+    expect(help).toContain("add <source> [name...]");
+    expect(help).toContain("Discover plugins first, otherwise skills");
+    expect(help).toContain("--name <name>");
+    expect(help).toContain("Compatibility alias");
+    expect(help).toContain("Add plugins explicitly, or all skills as a wildcard");
+    expect(help).not.toContain("--plugin");
+  });
 });

--- a/packages/dotagents/src/cli/help.ts
+++ b/packages/dotagents/src/cli/help.ts
@@ -14,15 +14,15 @@ Install or refresh dependencies declared in agents.toml.
 Options:
   --frozen        Deprecated compatibility flag; normal install still runs
   --help, -h      Show this help message`,
-  add: `Usage: npx @sentry/dotagents [--user] add <source> [skill...] [options]
+  add: `Usage: npx @sentry/dotagents [--user] add <source> [name...] [options]
 
-Add skill dependencies to agents.toml and install them immediately.
+Discover plugins first, otherwise skills, then add and install the selected dependencies.
 
 Options:
-  --skill <name>  Skill name to add; repeatable
-  --name <name>   Alias for --skill; repeatable
+  --name <name>   Dependency name to add; repeatable
+  --skill <name>  Compatibility alias for --name; repeatable
   --ref <ref>     Git tag, branch, or commit
-  --all           Add every discovered skill as a wildcard dependency
+  --all           Add plugins explicitly, or all skills as a wildcard dependency
   --help, -h      Show this help message`,
   remove: `Usage: npx @sentry/dotagents [--user] remove <name|source> [options]
 

--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -263,6 +263,15 @@ describe("writer", () => {
       expect(content).toContain('ref = "release/v1"');
       expect(content).toContain('path = "plugins/review-tools"');
       expect(content).not.toContain('path = ""');
+      expect((await loadConfig(configPath)).plugins).toEqual([
+        {
+          name: "review-tools",
+          source: 'git:https://example.com/org/"review-tools"',
+          ref: "release/v1",
+          path: "plugins/review-tools",
+        },
+        { name: "root-plugin", source: "path:./plugins" },
+      ]);
     });
   });
 

--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   addSkillToConfig,
+  addPluginsToConfig,
   addWildcardToConfig,
   addExcludeToWildcard,
   removeSkillFromConfig,
@@ -237,6 +238,31 @@ describe("writer", () => {
       expect(config.skills.find((skill) => skill.name === "pdf")).toMatchObject({
         source: "anthropics/skills",
       });
+    });
+  });
+
+  describe("addPluginsToConfig", () => {
+    it("appends one or more escaped plugin blocks without rewriting existing TOML", async () => {
+      const prefix = "version = 1\n# keep this comment\n\n[misc]\nvalue = 'unchanged'\n";
+      await writeFile(configPath, prefix);
+
+      await addPluginsToConfig(configPath, [
+        {
+          name: "review-tools",
+          source: 'git:https://example.com/org/"review-tools"',
+          ref: "release/v1",
+          path: "plugins/review-tools",
+        },
+        { name: "root-plugin", source: "path:./plugins" },
+      ]);
+
+      const content = await readFile(configPath, "utf-8");
+      expect(content.startsWith(prefix.trimEnd())).toBe(true);
+      expect(content.match(/\[\[plugins\]\]/g)).toHaveLength(2);
+      expect(content).toContain('source = "git:https://example.com/org/\\"review-tools\\""');
+      expect(content).toContain('ref = "release/v1"');
+      expect(content).toContain('path = "plugins/review-tools"');
+      expect(content).not.toContain('path = ""');
     });
   });
 

--- a/packages/dotagents/src/config/writer.ts
+++ b/packages/dotagents/src/config/writer.ts
@@ -4,6 +4,7 @@ import type {
   WildcardSkillDependency,
   TrustConfig,
   McpConfig,
+  PluginConfig,
 } from "./schema.js";
 import { sourcesMatch } from "@sentry/dotagents-lib";
 
@@ -34,6 +35,30 @@ export async function addSkillToConfig(
 
   const newContent = `${content.trimEnd()}\n\n${section.trimEnd()}\n`;
   await writeFile(filePath, newContent, "utf-8");
+}
+
+/** Appends preflighted plugin declarations with a single config-file mutation. */
+export async function addPluginsToConfig(
+  filePath: string,
+  plugins: Array<Pick<PluginConfig, "name" | "source" | "ref" | "path">>,
+): Promise<void> {
+  if (plugins.length === 0) {return;}
+  const content = await readFile(filePath, "utf-8");
+  const entries = plugins.map((plugin) => {
+    const entry: Record<string, string> = {
+      name: plugin.name,
+      source: plugin.source,
+    };
+    if (plugin.ref) {entry["ref"] = plugin.ref;}
+    if (plugin.path) {entry["path"] = plugin.path;}
+    return entry;
+  });
+  const section = stringify({ plugins: entries });
+  await writeFile(
+    filePath,
+    `${content.trimEnd()}\n\n${section.trimEnd()}\n`,
+    "utf-8",
+  );
 }
 
 /**

--- a/packages/dotagents/src/config/writer.ts
+++ b/packages/dotagents/src/config/writer.ts
@@ -42,7 +42,9 @@ export async function addPluginsToConfig(
   filePath: string,
   plugins: Array<Pick<PluginConfig, "name" | "source" | "ref" | "path">>,
 ): Promise<void> {
-  if (plugins.length === 0) {return;}
+  if (plugins.length === 0) {
+    throw new Error("Cannot append an empty plugin batch.");
+  }
   const content = await readFile(filePath, "utf-8");
   const entries = plugins.map((plugin) => {
     const entry: Record<string, string> = {

--- a/packages/dotagents/src/plugins/store.test.ts
+++ b/packages/dotagents/src/plugins/store.test.ts
@@ -608,7 +608,7 @@ describe("plugin store", () => {
     }
   });
 
-  it("rejects a malformed root plugin instead of falling through to conventional plugins", async () => {
+  it("keeps named resolution tolerant of an unrelated malformed root plugin", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
     try {
       const sourceRoot = join(projectRoot, "source");
@@ -621,16 +621,17 @@ describe("plugin store", () => {
         "utf-8",
       );
 
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(join(sourceRoot, "plugin.json"));
       await expect(resolvePlugin(
         { name: "review-tools", source: "path:source" },
         { stateDir: join(projectRoot, "state"), projectRoot },
-      )).rejects.toThrow(join(sourceRoot, "plugin.json"));
+      )).resolves.toMatchObject({ plugin: { pluginDir } });
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
   });
 
-  it("rejects a malformed conventional plugin candidate", async () => {
+  it("keeps named resolution tolerant of an unrelated malformed conventional candidate", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
     try {
       const sourceRoot = join(projectRoot, "source");
@@ -644,10 +645,11 @@ describe("plugin store", () => {
         "utf-8",
       );
 
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(join(containerDir, "plugin.json"));
       await expect(resolvePlugin(
         { name: "review-tools", source: "path:source" },
         { stateDir: join(projectRoot, "state"), projectRoot },
-      )).rejects.toThrow(join(containerDir, "plugin.json"));
+      )).resolves.toMatchObject({ plugin: { pluginDir } });
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -722,6 +724,181 @@ describe("plugin store", () => {
       await expect(discoverPlugins(sourceRoot)).resolves.toEqual([]);
     } finally {
       await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates a contained symlink alias and its physical plugin directory", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const pluginsDir = join(sourceRoot, "plugins");
+      const pluginDir = join(pluginsDir, "review-tools");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(join(pluginDir, "plugin.json"), JSON.stringify({ name: "review-tools" }));
+      await symlink("review-tools", join(pluginsDir, "review-tools-alias"));
+
+      const candidates = await discoverPlugins(sourceRoot);
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]!.name).toBe("review-tools");
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves distinct marketplace aliases for one nameless legacy plugin", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const pluginDir = join(sourceRoot, "shared-plugin");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(join(pluginDir, "plugin.json"), "{}");
+      await writeFile(join(sourceRoot, "marketplace.json"), JSON.stringify({
+        name: "aliases",
+        plugins: [
+          { name: "alpha", source: "./shared-plugin" },
+          { name: "beta", source: "./shared-plugin" },
+        ],
+      }));
+
+      const candidates = await discoverPlugins(sourceRoot);
+      const alpha = await resolvePlugin(
+        { name: "alpha", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      );
+      const beta = await resolvePlugin(
+        { name: "beta", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      );
+
+      expect(candidates.map((candidate) => candidate.name).toSorted()).toEqual(["alpha", "beta"]);
+      expect(alpha.plugin.pluginDir).toBe(pluginDir);
+      expect(beta.plugin.pluginDir).toBe(pluginDir);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves first-match ordering for repeated marketplace selectors", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const pluginDir = join(sourceRoot, "review-tools");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(join(pluginDir, "plugin.json"), "{}");
+      await writeFile(join(sourceRoot, "marketplace.json"), JSON.stringify({
+        name: "ordered",
+        plugins: [
+          { name: "review-tools", source: "./review-tools" },
+          { name: "review-tools", source: "../outside" },
+        ],
+      }));
+
+      await expect(resolvePlugin(
+        { name: "review-tools", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      )).resolves.toMatchObject({ plugin: { pluginDir } });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("still scans below a manifestless marketplace target during named resolution", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const pluginDir = join(sourceRoot, "plugins", "collection", "review-tools");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(
+        join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "review-tools" }),
+      );
+      await writeFile(join(sourceRoot, "marketplace.json"), JSON.stringify({
+        name: "catalog",
+        plugins: [{ name: "collection", source: "./plugins/collection" }],
+      }));
+
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(
+        'Marketplace plugin "collection"',
+      );
+      await expect(resolvePlugin(
+        { name: "review-tools", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      )).resolves.toMatchObject({ plugin: { pluginDir } });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed marketplace files with their path", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const marketplacePath = join(sourceRoot, "marketplace.json");
+      await writeFile(marketplacePath, "{");
+
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(marketplacePath);
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects plugin bundle symlinks during strict discovery", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const pluginDir = join(sourceRoot, "plugins", "review-tools");
+      const outsideFile = join(projectRoot, "secret.txt");
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(join(pluginDir, "plugin.json"), JSON.stringify({ name: "review-tools" }));
+      await writeFile(outsideFile, "secret");
+      await symlink(outsideFile, join(pluginDir, "secret-link"));
+
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(
+        "Plugin bundle symlink resolves outside the plugin directory",
+      );
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects local marketplace entries without a plugin manifest", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      await mkdir(join(sourceRoot, "missing-manifest"), { recursive: true });
+      await writeFile(join(sourceRoot, "marketplace.json"), JSON.stringify({
+        name: "broken",
+        plugins: [{ name: "broken", source: "./missing-manifest" }],
+      }));
+
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow(
+        /Marketplace plugin "broken".*has no supported plugin manifest.*missing-manifest/,
+      );
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses an explicit dot path to select a same-named root plugin", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const canonicalDir = join(sourceRoot, ".agents", "plugins", "shared");
+      await mkdir(canonicalDir, { recursive: true });
+      await writeFile(join(sourceRoot, "plugin.json"), JSON.stringify({ name: "shared" }));
+      await writeFile(join(canonicalDir, "plugin.json"), JSON.stringify({ name: "shared" }));
+
+      const explicitRoot = await resolvePlugin(
+        { name: "shared", source: "path:source", path: "." },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      );
+      const implicit = await resolvePlugin(
+        { name: "shared", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      );
+
+      expect(explicitRoot.plugin.pluginDir).toBe(sourceRoot);
+      expect(implicit.plugin.pluginDir).toBe(canonicalDir);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/dotagents/src/plugins/store.test.ts
+++ b/packages/dotagents/src/plugins/store.test.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  discoverPlugins,
   installPluginBundle,
   isSameProjectPluginConfig,
   loadInstalledPlugins,
@@ -607,7 +608,7 @@ describe("plugin store", () => {
     }
   });
 
-  it("continues conventional discovery when the source root manifest is malformed", async () => {
+  it("rejects a malformed root plugin instead of falling through to conventional plugins", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
     try {
       const sourceRoot = join(projectRoot, "source");
@@ -620,18 +621,16 @@ describe("plugin store", () => {
         "utf-8",
       );
 
-      const resolved = await resolvePlugin(
+      await expect(resolvePlugin(
         { name: "review-tools", source: "path:source" },
         { stateDir: join(projectRoot, "state"), projectRoot },
-      );
-
-      expect(resolved.plugin.pluginDir).toBe(pluginDir);
+      )).rejects.toThrow(join(sourceRoot, "plugin.json"));
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
   });
 
-  it("continues recursive discovery through a directory with a malformed manifest", async () => {
+  it("rejects a malformed conventional plugin candidate", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
     try {
       const sourceRoot = join(projectRoot, "source");
@@ -645,12 +644,10 @@ describe("plugin store", () => {
         "utf-8",
       );
 
-      const resolved = await resolvePlugin(
+      await expect(resolvePlugin(
         { name: "review-tools", source: "path:source" },
         { stateDir: join(projectRoot, "state"), projectRoot },
-      );
-
-      expect(resolved.plugin.pluginDir).toBe(pluginDir);
+      )).rejects.toThrow(join(containerDir, "plugin.json"));
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -667,6 +664,64 @@ describe("plugin store", () => {
       )).rejects.toThrow('Plugin "review-tools" not found');
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers root, conventional, native, and local marketplace plugins with safe paths", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      const canonicalDir = join(sourceRoot, ".agents", "plugins", "canonical");
+      const conventionalDir = join(sourceRoot, "plugins", "conventional");
+      const marketplaceDir = join(sourceRoot, "catalog", "marketplace");
+      await mkdir(join(sourceRoot, ".codex-plugin"), { recursive: true });
+      await mkdir(canonicalDir, { recursive: true });
+      await mkdir(conventionalDir, { recursive: true });
+      await mkdir(marketplaceDir, { recursive: true });
+      await writeFile(
+        join(sourceRoot, ".codex-plugin", "plugin.json"),
+        JSON.stringify({ name: "root-plugin" }),
+      );
+      await writeFile(join(canonicalDir, "plugin.json"), JSON.stringify({ name: "canonical" }));
+      await writeFile(join(conventionalDir, "plugin.json"), JSON.stringify({ name: "conventional" }));
+      await writeFile(join(marketplaceDir, "plugin.json"), JSON.stringify({ name: "marketplace" }));
+      await writeFile(
+        join(sourceRoot, "marketplace.json"),
+        JSON.stringify({
+          name: "test",
+          plugins: [
+            { name: "marketplace", source: "./catalog/marketplace" },
+            { name: "conventional", source: "./plugins/conventional" },
+          ],
+        }),
+      );
+
+      const candidates = await discoverPlugins(sourceRoot);
+
+      expect(candidates.map((candidate) => ({
+        name: candidate.manifest.name,
+        path: candidate.path,
+        nativeSource: candidate.nativeSource,
+      }))).toEqual(expect.arrayContaining([
+        { name: "root-plugin", path: "", nativeSource: "codex" },
+        { name: "canonical", path: ".agents/plugins/canonical", nativeSource: undefined },
+        { name: "conventional", path: "plugins/conventional", nativeSource: undefined },
+        { name: "marketplace", path: "catalog/marketplace", nativeSource: undefined },
+      ]));
+      expect(candidates).toHaveLength(4);
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty catalog when a source has skills but no plugin markers", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-catalog-"));
+    try {
+      await mkdir(join(sourceRoot, "skills", "review"), { recursive: true });
+      await writeFile(join(sourceRoot, "skills", "review", "SKILL.md"), "# Review\n");
+
+      await expect(discoverPlugins(sourceRoot)).resolves.toEqual([]);
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/dotagents/src/plugins/store.ts
+++ b/packages/dotagents/src/plugins/store.ts
@@ -13,7 +13,7 @@ import {
   type RepositorySource,
   type TrustPolicy,
 } from "@sentry/dotagents-lib";
-import type { PluginConfig } from "../config/schema.js";
+import { PLUGIN_NAME_PATTERN, type PluginConfig } from "../config/schema.js";
 import type { LockedPlugin } from "../lockfile/schema.js";
 import {
   parsePluginManifest,
@@ -54,7 +54,8 @@ interface ResolvedGitPlugin {
 
 export type ResolvedPlugin = ResolvedLocalPlugin | ResolvedGitPlugin;
 
-interface PluginCandidate {
+export interface PluginCandidate {
+  name: string;
   dir: string;
   path: string;
   manifest: PluginManifest;
@@ -98,7 +99,7 @@ export async function resolvePlugin(
 
   if (parsed.type === "local") {
     const sourceDir = await resolveLocalSource(opts.projectRoot, parsed.path!);
-    const discovered = await discoverPlugin(sourceDir, config);
+    const discovered = await resolvePluginCandidate(sourceDir, config);
     if (!discovered) {
       throw new Error(`Plugin "${config.name}" not found in ${config.source}.`);
     }
@@ -129,7 +130,7 @@ export async function resolvePlugin(
     minimumReleaseAge: excluded ? undefined : opts.minimumReleaseAge,
   });
 
-  const discovered = await discoverPlugin(cached.repoDir, config);
+  const discovered = await resolvePluginCandidate(cached.repoDir, config);
   if (!discovered) {
     throw new Error(`Plugin "${config.name}" not found in ${config.source}.`);
   }
@@ -365,7 +366,7 @@ export function isSameProjectPluginConfig(
   }
 }
 
-async function discoverPlugin(
+async function resolvePluginCandidate(
   sourceDir: string,
   config: PluginConfig,
 ): Promise<PluginCandidate | null> {
@@ -374,34 +375,25 @@ async function discoverPlugin(
     return loadPluginCandidate(sourceDir, dir, { name: config.name });
   }
 
-  const matches: PluginCandidate[] = [];
-  const canonicalDir = await resolveInside(sourceDir, join(".agents", "plugins", config.name), "Canonical plugin source");
-  const canonical = await loadPluginCandidate(sourceDir, canonicalDir);
+  const candidates = await discoverPlugins(sourceDir);
+  const canonicalPath = posix.join(".agents", "plugins", config.name);
+  const canonical = candidates.find((candidate) => candidate.path === canonicalPath);
   if (canonical && candidateMatches(config.name, canonical)) {
     return canonical;
   }
 
   const unsupportedMarketplaceSources: string[] = [];
-  const fromMarketplace = await discoverFromMarketplaces(sourceDir, config.name, unsupportedMarketplaceSources);
+  const marketplacePaths = await discoverMarketplaceCandidatePaths(
+    sourceDir,
+    config.name,
+    unsupportedMarketplaceSources,
+  );
+  const fromMarketplace = candidates.find(
+    (candidate) => marketplacePaths.includes(candidate.path) && candidateMatches(config.name, candidate),
+  );
   if (fromMarketplace) {return fromMarketplace;}
 
-  let sourceRootError: unknown;
-  try {
-    const sourceCandidate = await loadPluginCandidate(sourceDir, sourceDir);
-    if (sourceCandidate && candidateMatches(config.name, sourceCandidate)) {matches.push(sourceCandidate);}
-  } catch (err) {
-    sourceRootError = err;
-  }
-
-  const namedCandidate = await loadPluginCandidate(sourceDir, join(sourceDir, "plugins", config.name));
-  if (namedCandidate && candidateMatches(config.name, namedCandidate)) {
-    matches.push(namedCandidate);
-  }
-
-  const recursive = await scanPluginDirectories(sourceDir, join(sourceDir, "plugins"), config.name);
-  matches.push(...recursive);
-
-  const unique = rankedCandidates(config.name, matches);
+  const unique = rankedCandidates(config.name, candidates);
   if (unique.length > 1) {
     throw new Error(
       `Plugin "${config.name}" is ambiguous in ${config.source}: ${unique.map((m) => m.path).join(", ")}`,
@@ -412,8 +404,29 @@ async function discoverPlugin(
       `Plugin "${config.name}" not found in ${config.source}. Matching marketplace entries use unsupported source types: ${[...new Set(unsupportedMarketplaceSources)].join(", ")}. Only local marketplace sources are supported.`,
     );
   }
-  if (unique.length === 0 && sourceRootError) {throw sourceRootError;}
   return unique[0] ?? null;
+}
+
+/** Enumerates every valid plugin in a local or acquired repository source. */
+export async function discoverPlugins(sourceDir: string): Promise<PluginCandidate[]> {
+  const candidates: PluginCandidate[] = [];
+
+  const root = await loadPluginCandidate(sourceDir, sourceDir);
+  if (root) {candidates.push(root);}
+
+  candidates.push(...await discoverFromMarketplaces(sourceDir));
+  candidates.push(...await scanPluginDirectories(
+    sourceDir,
+    join(sourceDir, ".agents", "plugins"),
+    2,
+    "Canonical plugin source",
+  ));
+  candidates.push(...await scanPluginDirectories(
+    sourceDir,
+    join(sourceDir, "plugins"),
+  ));
+
+  return dedupeCandidates(candidates);
 }
 
 /**
@@ -423,9 +436,49 @@ async function discoverPlugin(
  */
 async function discoverFromMarketplaces(
   sourceDir: string,
+): Promise<PluginCandidate[]> {
+  const candidates: PluginCandidate[] = [];
+  for (const marketplacePath of MARKETPLACE_PATHS) {
+    const filePath = join(sourceDir, marketplacePath);
+    if (!existsSync(filePath)) {continue;}
+
+    let marketplace: ReturnType<typeof parsePluginMarketplace>;
+    try {
+      marketplace = parsePluginMarketplace(await readJson(filePath), filePath);
+    } catch {
+      continue;
+    }
+    const root = typeof marketplace.metadata?.pluginRoot === "string"
+      ? marketplace.metadata.pluginRoot
+      : ".";
+    for (const entry of marketplace.plugins) {
+      const path = localMarketplacePath(entry);
+      if (!path) {continue;}
+      const marketplaceRoot = dirname(filePath);
+      const pluginDir = await resolveMarketplaceSource(
+        sourceDir,
+        marketplaceRoot,
+        join(root, path),
+        "Marketplace plugin source",
+      );
+      const candidate = await loadPluginCandidate(
+        sourceDir,
+        pluginDir,
+        marketplaceManifestOverlay(entry),
+        "Marketplace plugin source",
+      );
+      if (candidate) {candidates.push(candidate);}
+    }
+  }
+  return candidates;
+}
+
+async function discoverMarketplaceCandidatePaths(
+  sourceDir: string,
   name: string,
   unsupportedSources: string[],
-): Promise<PluginCandidate | null> {
+): Promise<string[]> {
+  const paths: string[] = [];
   for (const marketplacePath of MARKETPLACE_PATHS) {
     const filePath = join(sourceDir, marketplacePath);
     if (!existsSync(filePath)) {continue;}
@@ -450,39 +503,32 @@ async function discoverFromMarketplaces(
 
       const marketplaceRoot = dirname(filePath);
       const pluginDir = await resolveMarketplaceSource(sourceDir, marketplaceRoot, join(root, path), "Marketplace plugin source");
-      const candidate = await loadPluginCandidate(sourceDir, pluginDir, marketplaceManifestOverlay(entry));
-      if (candidate) {return candidate;}
+      paths.push(relativePath(sourceDir, pluginDir));
     }
   }
 
-  return null;
+  return paths;
 }
 
 async function scanPluginDirectories(
   sourceRoot: string,
   dir: string,
-  name: string,
   depth = 2,
+  label = "Plugin source",
 ): Promise<PluginCandidate[]> {
   if (depth <= 0 || !await isDirectory(dir)) {return [];}
 
   const matches: PluginCandidate[] = [];
   const entries = await readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith(".")) {continue;}
+    if ((!entry.isDirectory() && !entry.isSymbolicLink()) || entry.name.startsWith(".")) {continue;}
     const childDir = join(dir, entry.name);
-    let candidate: PluginCandidate | null;
-    try {
-      candidate = await loadPluginCandidate(sourceRoot, childDir);
-    } catch (err) {
-      if (entry.name === name) {throw err;}
-      candidate = null;
-    }
-    if (candidate && candidateMatches(name, candidate)) {
+    const candidate = await loadPluginCandidate(sourceRoot, childDir, {}, label);
+    if (candidate) {
       matches.push(candidate);
       continue;
     }
-    matches.push(...await scanPluginDirectories(sourceRoot, childDir, name, depth - 1));
+    matches.push(...await scanPluginDirectories(sourceRoot, childDir, depth - 1, label));
   }
   return matches;
 }
@@ -500,9 +546,10 @@ async function loadPluginCandidate(
   sourceRoot: string,
   pluginDir: string,
   overlay: Partial<LegacyPluginManifest> = {},
+  label = "Plugin source",
 ): Promise<PluginCandidate | null> {
   if (!existsSync(pluginDir)) {return null;}
-  await assertInsideSourceRoot(sourceRoot, pluginDir, "Plugin source");
+  await assertInsideSourceRoot(sourceRoot, pluginDir, label);
 
   const loaded = await loadManifest(pluginDir);
   if (!loaded) {return null;}
@@ -517,7 +564,14 @@ async function loadPluginCandidate(
   const combined = manifest && isStandardPluginManifest(manifest)
     ? manifest
     : normalizeManifest(name, { ...overlay, ...manifest } as LegacyPluginManifest);
+  if (!PLUGIN_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid plugin name "${name}" in ${relativePath(sourceRoot, pluginDir) || "."}. ` +
+        "Plugin names must be 1-64 lowercase letters, numbers, hyphens, or dots, have alphanumeric ends, and not contain '--' or '..'.",
+    );
+  }
   return {
+    name,
     dir: pluginDir,
     path: relativePath(sourceRoot, pluginDir),
     manifest: combined,
@@ -658,7 +712,7 @@ function normalizeManifest(
 }
 
 function candidateMatches(name: string, candidate: PluginCandidate): boolean {
-  return basename(candidate.dir) === name || candidate.manifest["name"] === name;
+  return basename(candidate.dir) === name || candidate.name === name;
 }
 
 /** Applies discovery precedence: directory-name matches win before manifest-name fallback. */
@@ -667,7 +721,7 @@ function rankedCandidates(name: string, candidates: PluginCandidate[]): PluginCa
   const directoryMatches = unique.filter((candidate) => basename(candidate.dir) === name);
   return directoryMatches.length > 0
     ? directoryMatches
-    : unique.filter((candidate) => candidate.manifest["name"] === name);
+    : unique.filter((candidate) => candidate.name === name);
 }
 
 function dedupeCandidates(candidates: PluginCandidate[]): PluginCandidate[] {
@@ -792,7 +846,13 @@ function isNotDirectoryError(err: unknown): boolean {
 
 async function readJson(filePath: string): Promise<Record<string, unknown>> {
   const raw = await readFile(filePath, "utf-8");
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid JSON ${filePath}: ${message}`, { cause: err });
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`Expected JSON object in ${filePath}`);
   }

--- a/packages/dotagents/src/plugins/store.ts
+++ b/packages/dotagents/src/plugins/store.ts
@@ -54,12 +54,31 @@ interface ResolvedGitPlugin {
 
 export type ResolvedPlugin = ResolvedLocalPlugin | ResolvedGitPlugin;
 
+type PluginCandidateOrigin = "explicit" | "root" | "marketplace" | "canonical" | "conventional";
+
 export interface PluginCandidate {
   name: string;
   dir: string;
   path: string;
   manifest: PluginManifest;
   nativeSource?: NativePluginSource;
+  origin: PluginCandidateOrigin;
+}
+
+interface PluginCatalog {
+  candidates: PluginCandidate[];
+  unsupportedMarketplaceSources: Map<string, string[]>;
+  marketplaceOutcomes: Map<string, Array<
+    | { candidate: PluginCandidate }
+    | { error: Error }
+  >>;
+  issues: Array<{
+    name?: string;
+    path?: string;
+    origin: Exclude<PluginCandidateOrigin, "explicit">;
+    error: Error;
+    blocksNamedResolution: boolean;
+  }>;
 }
 
 const MARKETPLACE_PATHS = [
@@ -372,61 +391,108 @@ async function resolvePluginCandidate(
 ): Promise<PluginCandidate | null> {
   if (config.path) {
     const dir = await resolveInside(sourceDir, config.path, "Plugin path");
-    return loadPluginCandidate(sourceDir, dir, { name: config.name });
+    return loadPluginCandidate(sourceDir, dir, { name: config.name }, "Plugin source", "explicit");
   }
 
-  const candidates = await discoverPlugins(sourceDir);
+  const catalog = await discoverPluginCatalog(sourceDir);
+  const { candidates } = catalog;
   const canonicalPath = posix.join(".agents", "plugins", config.name);
   const canonical = candidates.find((candidate) => candidate.path === canonicalPath);
   if (canonical && candidateMatches(config.name, canonical)) {
     return canonical;
   }
 
-  const unsupportedMarketplaceSources: string[] = [];
-  const marketplacePaths = await discoverMarketplaceCandidatePaths(
-    sourceDir,
-    config.name,
-    unsupportedMarketplaceSources,
+  const canonicalIssue = catalog.issues.find(
+    (issue) => issue.origin === "canonical" && issue.path === canonicalPath,
   );
-  const fromMarketplace = candidates.find(
-    (candidate) => marketplacePaths.includes(candidate.path) && candidateMatches(config.name, candidate),
-  );
-  if (fromMarketplace) {return fromMarketplace;}
+  if (canonicalIssue) {throw canonicalIssue.error;}
 
-  const unique = rankedCandidates(config.name, candidates);
+  const marketplaceOutcome = catalog.marketplaceOutcomes.get(config.name)?.[0];
+  if (marketplaceOutcome && "error" in marketplaceOutcome) {
+    throw marketplaceOutcome.error;
+  }
+  if (marketplaceOutcome) {return marketplaceOutcome.candidate;}
+
+  const conventionalIssue = catalog.issues.find(
+    (issue) => issue.origin === "conventional" &&
+      issue.blocksNamedResolution && issue.name === config.name,
+  );
+  if (conventionalIssue) {throw conventionalIssue.error;}
+
+  const unique = rankedCandidates(
+    config.name,
+    candidates.filter((candidate) => candidate.origin !== "marketplace"),
+  );
   if (unique.length > 1) {
     throw new Error(
       `Plugin "${config.name}" is ambiguous in ${config.source}: ${unique.map((m) => m.path).join(", ")}`,
     );
   }
+  const unsupportedMarketplaceSources = catalog.unsupportedMarketplaceSources.get(config.name) ?? [];
   if (unique.length === 0 && unsupportedMarketplaceSources.length > 0) {
     throw new Error(
       `Plugin "${config.name}" not found in ${config.source}. Matching marketplace entries use unsupported source types: ${[...new Set(unsupportedMarketplaceSources)].join(", ")}. Only local marketplace sources are supported.`,
     );
   }
+  const rootIssue = catalog.issues.find((issue) => issue.origin === "root");
+  if (unique.length === 0 && rootIssue) {throw rootIssue.error;}
   return unique[0] ?? null;
 }
 
-/** Enumerates every valid plugin in a local or acquired repository source. */
+/** Discovers valid plugins from supported source locations. */
 export async function discoverPlugins(sourceDir: string): Promise<PluginCandidate[]> {
+  const catalog = await discoverPluginCatalog(sourceDir);
+  if (catalog.issues[0]) {throw catalog.issues[0].error;}
+  for (const candidate of catalog.candidates) {
+    await assertPluginBundleSymlinksContained(candidate.dir);
+  }
+  return catalog.candidates;
+}
+
+async function discoverPluginCatalog(sourceDir: string): Promise<PluginCatalog> {
   const candidates: PluginCandidate[] = [];
+  const issues: PluginCatalog["issues"] = [];
 
-  const root = await loadPluginCandidate(sourceDir, sourceDir);
-  if (root) {candidates.push(root);}
+  try {
+    const root = await loadPluginCandidate(sourceDir, sourceDir, {}, "Plugin source", "root");
+    if (root) {candidates.push(root);}
+  } catch (err) {
+    issues.push({
+      path: "",
+      origin: "root",
+      error: err instanceof Error ? err : new Error(String(err)),
+      blocksNamedResolution: false,
+    });
+  }
 
-  candidates.push(...await discoverFromMarketplaces(sourceDir));
+  const marketplace = await discoverFromMarketplaces(sourceDir);
+  candidates.push(...marketplace.candidates);
+  issues.push(...marketplace.issues);
   candidates.push(...await scanPluginDirectories(
     sourceDir,
     join(sourceDir, ".agents", "plugins"),
     2,
     "Canonical plugin source",
+    "canonical",
+    issues,
+    marketplace.referencedDirs,
   ));
   candidates.push(...await scanPluginDirectories(
     sourceDir,
     join(sourceDir, "plugins"),
+    2,
+    "Plugin source",
+    "conventional",
+    issues,
+    marketplace.referencedDirs,
   ));
 
-  return dedupeCandidates(candidates);
+  return {
+    candidates: await dedupeCandidates(candidates),
+    unsupportedMarketplaceSources: marketplace.unsupportedSources,
+    marketplaceOutcomes: marketplace.outcomes,
+    issues,
+  };
 }
 
 /**
@@ -436,8 +502,18 @@ export async function discoverPlugins(sourceDir: string): Promise<PluginCandidat
  */
 async function discoverFromMarketplaces(
   sourceDir: string,
-): Promise<PluginCandidate[]> {
+): Promise<{
+  candidates: PluginCandidate[];
+  unsupportedSources: Map<string, string[]>;
+  outcomes: PluginCatalog["marketplaceOutcomes"];
+  issues: PluginCatalog["issues"];
+  referencedDirs: Set<string>;
+}> {
   const candidates: PluginCandidate[] = [];
+  const unsupportedSources = new Map<string, string[]>();
+  const outcomes: PluginCatalog["marketplaceOutcomes"] = new Map();
+  const issues: PluginCatalog["issues"] = [];
+  const referencedDirs = new Set<string>();
   for (const marketplacePath of MARKETPLACE_PATHS) {
     const filePath = join(sourceDir, marketplacePath);
     if (!existsSync(filePath)) {continue;}
@@ -445,69 +521,74 @@ async function discoverFromMarketplaces(
     let marketplace: ReturnType<typeof parsePluginMarketplace>;
     try {
       marketplace = parsePluginMarketplace(await readJson(filePath), filePath);
-    } catch {
+    } catch (err) {
+      issues.push({
+        origin: "marketplace",
+        error: err instanceof Error ? err : new Error(String(err)),
+        blocksNamedResolution: false,
+      });
       continue;
     }
     const root = typeof marketplace.metadata?.pluginRoot === "string"
       ? marketplace.metadata.pluginRoot
       : ".";
     for (const entry of marketplace.plugins) {
-      const path = localMarketplacePath(entry);
-      if (!path) {continue;}
-      const marketplaceRoot = dirname(filePath);
-      const pluginDir = await resolveMarketplaceSource(
-        sourceDir,
-        marketplaceRoot,
-        join(root, path),
-        "Marketplace plugin source",
-      );
-      const candidate = await loadPluginCandidate(
-        sourceDir,
-        pluginDir,
-        marketplaceManifestOverlay(entry),
-        "Marketplace plugin source",
-      );
-      if (candidate) {candidates.push(candidate);}
-    }
-  }
-  return candidates;
-}
-
-async function discoverMarketplaceCandidatePaths(
-  sourceDir: string,
-  name: string,
-  unsupportedSources: string[],
-): Promise<string[]> {
-  const paths: string[] = [];
-  for (const marketplacePath of MARKETPLACE_PATHS) {
-    const filePath = join(sourceDir, marketplacePath);
-    if (!existsSync(filePath)) {continue;}
-
-    let marketplace: ReturnType<typeof parsePluginMarketplace>;
-    try {
-      marketplace = parsePluginMarketplace(await readJson(filePath), filePath);
-    } catch {
-      continue;
-    }
-    const root = typeof marketplace.metadata?.pluginRoot === "string"
-      ? marketplace.metadata.pluginRoot
-      : ".";
-    for (const entry of marketplace.plugins) {
-      if (entry.name !== name) {continue;}
-
       const path = localMarketplacePath(entry);
       if (!path) {
-        unsupportedSources.push(marketplaceSourceType(entry));
+        const sources = unsupportedSources.get(entry.name) ?? [];
+        sources.push(marketplaceSourceType(entry));
+        unsupportedSources.set(entry.name, sources);
         continue;
       }
-
       const marketplaceRoot = dirname(filePath);
-      const pluginDir = await resolveMarketplaceSource(sourceDir, marketplaceRoot, join(root, path), "Marketplace plugin source");
-      paths.push(relativePath(sourceDir, pluginDir));
+      let pluginDir: string;
+      let candidate: PluginCandidate | null;
+      try {
+        pluginDir = await resolveMarketplaceSource(
+          sourceDir,
+          marketplaceRoot,
+          join(root, path),
+          "Marketplace plugin source",
+        );
+        candidate = await loadPluginCandidate(
+          sourceDir,
+          pluginDir,
+          marketplaceManifestOverlay(entry),
+          "Marketplace plugin source",
+          "marketplace",
+        );
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        issues.push({
+          name: entry.name,
+          origin: "marketplace",
+          error,
+          blocksNamedResolution: true,
+        });
+        const namedOutcomes = outcomes.get(entry.name) ?? [];
+        namedOutcomes.push({ error });
+        outcomes.set(entry.name, namedOutcomes);
+        continue;
+      }
+      if (!candidate) {
+        issues.push({
+          name: entry.name,
+          origin: "marketplace",
+          error: new Error(
+            `Marketplace plugin "${entry.name}" in ${filePath} has no supported plugin manifest at ${relativePath(sourceDir, pluginDir)}.`,
+          ),
+          blocksNamedResolution: false,
+        });
+        continue;
+      }
+      referencedDirs.add(resolve(pluginDir));
+      candidates.push(candidate);
+      const namedOutcomes = outcomes.get(entry.name) ?? [];
+      namedOutcomes.push({ candidate });
+      outcomes.set(entry.name, namedOutcomes);
     }
   }
-
-  return paths;
+  return { candidates, unsupportedSources, outcomes, issues, referencedDirs };
 }
 
 async function scanPluginDirectories(
@@ -515,6 +596,9 @@ async function scanPluginDirectories(
   dir: string,
   depth = 2,
   label = "Plugin source",
+  origin: PluginCandidateOrigin = "conventional",
+  issues: PluginCatalog["issues"] = [],
+  skippedDirs: ReadonlySet<string> = new Set(),
 ): Promise<PluginCandidate[]> {
   if (depth <= 0 || !await isDirectory(dir)) {return [];}
 
@@ -523,12 +607,33 @@ async function scanPluginDirectories(
   for (const entry of entries) {
     if ((!entry.isDirectory() && !entry.isSymbolicLink()) || entry.name.startsWith(".")) {continue;}
     const childDir = join(dir, entry.name);
-    const candidate = await loadPluginCandidate(sourceRoot, childDir, {}, label);
+    if (skippedDirs.has(resolve(childDir))) {continue;}
+    let candidate: PluginCandidate | null;
+    try {
+      candidate = await loadPluginCandidate(sourceRoot, childDir, {}, label, origin);
+    } catch (err) {
+      issues.push({
+        name: entry.name,
+        path: relativePath(sourceRoot, childDir),
+        origin: origin === "canonical" ? "canonical" : "conventional",
+        error: err instanceof Error ? err : new Error(String(err)),
+        blocksNamedResolution: true,
+      });
+      candidate = null;
+    }
     if (candidate) {
       matches.push(candidate);
       continue;
     }
-    matches.push(...await scanPluginDirectories(sourceRoot, childDir, depth - 1, label));
+    matches.push(...await scanPluginDirectories(
+      sourceRoot,
+      childDir,
+      depth - 1,
+      label,
+      origin,
+      issues,
+      skippedDirs,
+    ));
   }
   return matches;
 }
@@ -547,6 +652,7 @@ async function loadPluginCandidate(
   pluginDir: string,
   overlay: Partial<LegacyPluginManifest> = {},
   label = "Plugin source",
+  origin: PluginCandidateOrigin = "root",
 ): Promise<PluginCandidate | null> {
   if (!existsSync(pluginDir)) {return null;}
   await assertInsideSourceRoot(sourceRoot, pluginDir, label);
@@ -576,6 +682,7 @@ async function loadPluginCandidate(
     path: relativePath(sourceRoot, pluginDir),
     manifest: combined,
     nativeSource: loaded?.nativeSource,
+    origin,
   };
 }
 
@@ -717,18 +824,17 @@ function candidateMatches(name: string, candidate: PluginCandidate): boolean {
 
 /** Applies discovery precedence: directory-name matches win before manifest-name fallback. */
 function rankedCandidates(name: string, candidates: PluginCandidate[]): PluginCandidate[] {
-  const unique = dedupeCandidates(candidates);
-  const directoryMatches = unique.filter((candidate) => basename(candidate.dir) === name);
+  const directoryMatches = candidates.filter((candidate) => basename(candidate.dir) === name);
   return directoryMatches.length > 0
     ? directoryMatches
-    : unique.filter((candidate) => candidate.name === name);
+    : candidates.filter((candidate) => candidate.name === name);
 }
 
-function dedupeCandidates(candidates: PluginCandidate[]): PluginCandidate[] {
+async function dedupeCandidates(candidates: PluginCandidate[]): Promise<PluginCandidate[]> {
   const seen = new Set<string>();
   const result: PluginCandidate[] = [];
   for (const candidate of candidates) {
-    const key = resolve(candidate.dir);
+    const key = `${await realpath(candidate.dir)}\0${candidate.name}`;
     if (seen.has(key)) {continue;}
     seen.add(key);
     result.push(candidate);

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -143,7 +143,7 @@ allow_all = true
 - `git_domains` entries match by prefix: `gitlab.com` matches all repos on GitLab, `gitlab.com/myorg` matches repos under that org, `gitlab.com/myorg/repo` matches only that repo
 - Local `path:` sources are always allowed (already sandboxed to project root)
 
-Trust is checked before any network work in `dotagents add` for skills and `dotagents install` for configured skills, subagents, and plugins.
+Trust is checked before any network work in `dotagents add` for dependencies and `dotagents install` for configured skills, subagents, and plugins.
 
 #### `[project]`
 
@@ -538,7 +538,7 @@ dotagents add getsentry/skills --skill find-bugs --skill code-review
 dotagents add getsentry/warden warden-skill --ref v1.0.0
 dotagents add getsentry/skills --all
 dotagents add getsentry/agent-plugins review-tools
-dotagents add path:../agent-plugins --all
+dotagents add path:./agent-plugins --all
 dotagents add path:../shared-skills/my-skill
 dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
 ```
@@ -557,7 +557,8 @@ dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
    - Plugin `--all` selects every current plugin explicitly
    - Skill `--all` keeps the wildcard entry that can include future upstream skills
 6. Preflight every requested name and duplicate before changing config. A single duplicate errors; multi-name additions skip duplicates and fail only when all are already declared.
-7. Append explicit `[[plugins]]` entries (including a safe non-root `path`) or the selected `[[skills]]` entries
+   - Reject local plugin sources that overlap the project's managed `.agents/plugins` directory before changing config
+7. Append explicit `[[plugins]]` entries (including the exact safe `path`, with `.` for a source-root plugin) or the selected `[[skills]]` entries
 8. Run install exactly once and update `agents.lock`
 
 Plugins are project-only. If user scope is active and plugin discovery succeeds,

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -522,12 +522,12 @@ dotagents install
 
 The deprecated `--frozen` option is accepted for compatibility, prints a warning, and follows this normal install flow. Use explicit `ref` values to pin sources.
 
-### `dotagents add <specifier>`
+### `dotagents add <source>`
 
-Add one or more skill dependencies.
+Discover and add plugins, otherwise skills, then install them.
 
 ```
-dotagents add <specifier> [<skill>...] [--skill <name>...] [--ref <ref>] [--all]
+dotagents add <source> [<name>...] [--name <name>...] [--ref <ref>] [--all]
 ```
 
 **Examples:**
@@ -537,6 +537,8 @@ dotagents add getsentry/skills find-bugs code-review commit
 dotagents add getsentry/skills --skill find-bugs --skill code-review
 dotagents add getsentry/warden warden-skill --ref v1.0.0
 dotagents add getsentry/skills --all
+dotagents add getsentry/agent-plugins review-tools
+dotagents add path:../agent-plugins --all
 dotagents add path:../shared-skills/my-skill
 dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
 ```
@@ -544,23 +546,32 @@ dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
 **Behavior:**
 1. Validate source against trust policy before any network operations
 2. Parse specifier to determine source type
-3. Clone/fetch repo to cache
-4. Discover skill(s) in the repo
-   - If skill names are given (positional or `--skill`), verify each exists in the source
-   - If `--all`, add a wildcard entry for the entire source
-   - If repo has exactly one skill, use it automatically
-   - If repo has multiple skills and no names given, show interactive picker (TTY) or list them (non-TTY)
-5. When adding multiple skills, skip any that already exist in `agents.toml` (with a warning). Error only if all specified skills already exist.
-6. Add `[[skills]]` entry to `agents.toml` for each new skill
-7. Run install to fetch and place the skills
-8. Update `agents.lock`
+3. Clone/fetch a git source once, or resolve the local source; well-known HTTPS catalogs remain skill-only
+4. For git and local sources, enumerate valid plugins before discovering skills
+   - Any plugin makes the entire invocation plugin-only; do not expose standalone or bundled skills from that source
+   - Invalid plugin-shaped content is an error and does not fall back to skills
+   - With no plugins, preserve normal skill discovery
+5. Interpret positional names, `--name`, and compatibility `--skill` within the selected kind
+   - One dependency is selected automatically
+   - Multiple dependencies use an interactive picker or non-interactive selection guidance
+   - Plugin `--all` selects every current plugin explicitly
+   - Skill `--all` keeps the wildcard entry that can include future upstream skills
+6. Preflight every requested name and duplicate before changing config. A single duplicate errors; multi-name additions skip duplicates and fail only when all are already declared.
+7. Append explicit `[[plugins]]` entries (including a safe non-root `path`) or the selected `[[skills]]` entries
+8. Run install exactly once and update `agents.lock`
+
+Plugins are project-only. If user scope is active and plugin discovery succeeds,
+`add` exits before changing user configuration, the lockfile, installed files,
+or generated runtime state. Mixed plugin-and-skill selection from one source is
+intentionally unsupported; plugin presence wins for the whole source.
 
 **Flags:**
 - `--ref <ref>`: Pin to a specific tag/branch/commit
-- `--skill <name>` (repeatable): Specify which skill(s) to add. Alternative to positional arguments.
-- `--all`: Add all skills from the source as a wildcard entry
+- `--name <name>` (repeatable): Specify which dependency to add. Alternative to positional arguments.
+- `--skill <name>` (repeatable): Compatibility alias for `--name`; it does not force skill mode.
+- `--all`: Add current plugins explicitly, or all skills as a wildcard entry
 
-Positional skill names and `--skill` flags cannot be mixed.
+Positional names and `--name`/`--skill` flags cannot be mixed.
 
 ### `dotagents remove <name|source> [-y]`
 

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -28,8 +28,8 @@ The portable source bundle is an Agent Plugin. dotagents is responsible for:
    clients' formats.
 
 Marketplaces, source repositories, lockfiles, target selection, trust policy,
-and generated runtime files remain dotagents concerns. They are not part of the
-portable Agent Plugins bundle format.
+CLI source discovery, generated runtime files, and config persistence remain
+dotagents concerns. They are not part of the portable Agent Plugins bundle format.
 
 ## Bidirectional Contract
 
@@ -286,6 +286,20 @@ targets = ["claude", "cursor", "codex", "grok", "opencode", "pi"]
 `targets` controls deployment. It is not written into `plugin.json`.
 
 ## Discovery and Installation
+
+`dotagents add <source>` uses this discovery as a management operation for git
+and local sources. It enumerates root manifests, conventional plugin directories,
+supported local marketplace entries, and native manifests before looking for
+skills. If any plugin is valid, the source is plugin-only for that invocation;
+invalid plugin-shaped content is reported instead of triggering skill fallback.
+Well-known HTTPS catalogs remain skill-only.
+
+Selected plugins are persisted as individual `[[plugins]]` declarations. A
+non-root candidate includes its validated source-relative `path`, so subsequent
+installs select the same directory even if the repository gains more plugins.
+There is no plugin wildcard: `add --all` records a snapshot of every plugin
+currently discovered, while skill `--all` retains its dynamic wildcard meaning.
+CLI plugin add is project-scope only.
 
 For each `[[plugins]]` declaration:
 

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -294,12 +294,14 @@ skills. If any plugin is valid, the source is plugin-only for that invocation;
 invalid plugin-shaped content is reported instead of triggering skill fallback.
 Well-known HTTPS catalogs remain skill-only.
 
-Selected plugins are persisted as individual `[[plugins]]` declarations. A
-non-root candidate includes its validated source-relative `path`, so subsequent
-installs select the same directory even if the repository gains more plugins.
+Selected plugins are persisted as individual `[[plugins]]` declarations with
+their validated source-relative `path` (`.` for a source-root plugin), so
+subsequent installs select the same directory even if the repository gains more plugins.
 There is no plugin wildcard: `add --all` records a snapshot of every plugin
 currently discovered, while skill `--all` retains its dynamic wildcard meaning.
 CLI plugin add is project-scope only.
+Local plugin sources that overlap the project's managed `.agents/plugins`
+directory are rejected before configuration changes.
 
 For each `[[plugins]]` declaration:
 


### PR DESCRIPTION
Teach `dotagents add` to install plugins without requiring users to edit
`agents.toml` manually. Git and local sources are classified once with plugin
precedence: when plugins are present, positional names, `--name`, the legacy
`--skill` alias, and `--all` select plugins; otherwise the existing skill flow
and wildcard behavior remain unchanged.

Plugin discovery now exposes a validated source catalog shared with install-time
resolution. Selected plugins are persisted together as explicit `[[plugins]]`
entries with stable source-relative paths, then the existing install pipeline
runs once. Malformed plugin-shaped content blocks skill fallback, and detected
plugins are rejected in user scope before any user state is created or changed.

The source-wide plugin preference is intentional: repositories containing both
plugins and standalone skills are treated as plugin sources, avoiding mixed
selection and removal semantics. Well-known HTTPS catalogs remain skill-only.
