### PR TITLE
feat(cli): Support user-scoped plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ npx @sentry/dotagents install
 | `sync` | Reconcile state offline: adopt local skills, prune stale managed ones, repair configs |
 | `mcp` | Manage MCP server declarations |
 | `trust` | Manage trusted sources |
-| `doctor` | Check project health and fix issues |
+| `doctor` | Check project health, including plugin runtime projections, and fix supported issues |
 
-All commands accept `--user` to operate on user scope (`~/.agents/`) instead of the current project.
+All commands accept `--user` or its `--global` alias to operate on user scope (`~/.agents/`) instead of the current project.
 
 ## Source Formats
 
@@ -145,7 +145,7 @@ targets = ["claude", "cursor", "codex", "grok", "opencode", "pi"]
 
 The canonical portable format is an [Agent Plugins](https://agent-plugins.org/) v1 bundle: required `plugin.json`, optional `skills/`, optional `mcp.json`, and reverse-domain client extensions. dotagents preserves those portable source files under `.agents/plugins/<name>/` and generates isolated target harnesses. Generated JSON uses adjacent ownership sidecars, while component symlinks use markers in reserved `.dotagents-managed/` directories, so client-owned JSON remains unchanged. Legacy generalized and native Claude/Cursor/Codex manifests remain discoverable during migration; native imports preserve their owning manifest and expose only core metadata and Agent Skills to other clients. Standard bundles reject legacy root components so client-specific behavior cannot leak across harnesses.
 
-Plugin declarations are project-scope only for now. `dotagents --user add` rejects a detected plugin source without changing user configuration, and `dotagents --user install` rejects `[[plugins]]` entries because user-scope runtime plugin projections are not generated yet.
+User-scope plugins install canonical bundles under `~/.agents/plugins/`. Claude and Cursor marketplaces are generated under `~/.agents/`, the Codex marketplace is generated at `~/.agents/plugins/marketplace.json`, OpenCode skills are linked into `~/.config/opencode/skills/`, and Pi skills are linked into `~/.agents/skills/`. `--global` is an alias for `--user`.
 
 Pi plugin targets are global skill projections rather than isolated plugin installs: a Pi-targeted plugin skill is added to `.agents/skills/` and is therefore visible to other clients that consume that shared directory.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -299,7 +299,7 @@ Generated project-scope plugin outputs:
 
 Generated plugin JSON is deterministic: object keys and plugin entries are sorted, output is two-space indented, and files end with one trailing newline. Generated marketplaces and Claude/Cursor/Codex manifests use adjacent `.dotagents-managed` sidecars so client-owned JSON remains schema-native; legacy `metadata.managedBy` output remains recognizable during migration. Managed Grok copies and OpenCode/Pi component symlinks are pruned when their plugin or target is removed. Plugin sources that resolve to this project's `.agents/plugins/<name>/` install destination are rejected so dotagents never installs a same-repo plugin onto itself. Existing plugin install destinations are overwritten only when their on-disk `.dotagents-managed` marker proves ownership.
 
-Plugin declarations are project-scope only for now. `install --user` rejects `[[plugins]]` entries and `sync --user` reports them as unsupported because user-scope runtime plugin projections are not generated yet.
+User-scope plugins install under `~/.agents/plugins/`. Claude and Cursor marketplaces are generated below `~/.agents/`, Codex uses `~/.agents/plugins/marketplace.json` with paths rooted at the user's home, OpenCode projections use `~/.config/opencode/`, and Pi skill projections use `~/.agents/skills/`.
 
 ### Trust
 
@@ -322,7 +322,7 @@ Rules:
 ## CLI Commands
 
 Global flags (before command name):
-- `--user` -- Operate on user scope (`~/.agents/`) instead of the current project
+- `--user`, `--global` -- Operate on user scope (`~/.agents/`) instead of the current project
 - `--help`, `-h` -- Show help
 - `--version`, `-V` -- Show version
 
@@ -345,7 +345,7 @@ Create `agents.toml` and `.agents/skills/` directory. Automatically includes the
 npx @sentry/dotagents install
 ```
 
-Install and refresh dependencies from `agents.toml`. Resolves sources, copies skills, installs subagents and project-scope plugins, writes the lockfile, creates symlinks, and generates MCP, hook, subagent, and plugin configs. There is no separate update command. The deprecated `--frozen` flag prints a warning and performs the same normal install; use explicit `ref` values to pin sources. `install --user` rejects plugin declarations because user-scope plugin projections are not generated yet.
+Install and refresh dependencies from `agents.toml`. Resolves sources, copies skills, installs subagents and plugins in the active scope, writes the lockfile, creates symlinks, and generates MCP, hook, subagent, and plugin configs. There is no separate update command. The deprecated `--frozen` flag prints a warning and performs the same normal install; use explicit `ref` values to pin sources.
 
 ### add
 
@@ -363,11 +363,11 @@ Add and install plugins or skills. Git and local sources are classified once: if
 | `--ref <ref>` | Pin to a specific tag, branch, or commit |
 | `--all` | Add every current plugin explicitly, or all skills as a wildcard (`name = "*"`) |
 
-When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds are project-only; `--user add` rejects a detected plugin source before changing user state.
+When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds support project and user scope.
 
 When adding multiple dependencies, names already declared for that kind are skipped with a warning. The command fails if all specified names already exist. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
 
-Plugin declarations persist the exact discovered source path (`.` for a source-root plugin), preventing later source inventory changes from changing selection.
+Plugin declarations persist the exact discovered source path (`.` for a source-root plugin), preventing later source inventory changes from changing selection. If config mutation or installation fails, `add` restores the previous `agents.toml` content so the failed dependency is not left declared.
 
 ### remove
 
@@ -469,7 +469,7 @@ Skills from wildcard entries are marked with a wildcard indicator.
 npx @sentry/dotagents doctor [--fix]
 ```
 
-Check project health: gitignore setup, installed skills and plugins, symlinks, and legacy config fields. Use `--fix` to auto-repair issues; use `sync` to repair generated runtime config drift.
+Check project health: gitignore setup, installed skills and plugins, plugin runtime projections, symlinks, and legacy config fields. Use `--fix` to auto-repair issues; use `sync` to repair generated runtime config drift.
 
 | Flag | Description |
 |------|-------------|
@@ -499,13 +499,14 @@ Operates on the current project directory. Requires `agents.toml` at the project
 - Skills: `<project>/.agents/skills/`
 - Lockfile: `<project>/agents.lock`
 
-### User Scope (`--user`)
+### User Scope (`--user` or `--global`)
 
 Operates on the user's home directory. For skills shared across all projects.
 
 - Config: `~/.agents/agents.toml`
 - Skills: `~/.agents/skills/`
 - Lockfile: `~/.agents/agents.lock`
+- Plugins: `~/.agents/plugins/`
 - Override location: `DOTAGENTS_HOME` environment variable
 
 User-scope symlinks: `~/.claude/skills/` for Claude and Cursor.

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -6,12 +6,13 @@ description: dotagents CLI reference.
 ## Usage
 
 ```shell
-dotagents [--user] <command> [options]
+dotagents [--user|--global] <command> [options]
 ```
 
 ## Global Options
 
 - `--user` operates on user scope (`~/.agents/`) instead of the current project.
+- `--global` is an alias for `--user`.
 - `--help`, `-h` shows help.
 - `--version`, `-V` shows version.
 
@@ -35,7 +36,7 @@ agents can discover CLI guidance. It then runs `install` best-effort.
 Options:
 
 - `--agents <list>` comma-separated agent targets (`claude`, `cursor`, `codex`,
-  `vscode`, `opencode`).
+  `vscode`, `opencode`, `grok`, `pi`).
 - `--force` overwrites existing `agents.toml`.
 
 Examples:
@@ -57,10 +58,9 @@ dotagents install
 Install and refresh skill, subagent, and plugin dependencies from `agents.toml`.
 Resolves sources, copies canonical artifacts, writes the lockfile, creates
 symlinks, and generates MCP, hook, subagent, and plugin runtime configs. There
-is no separate update command. Plugins are project-scope only; `dotagents
---user install` rejects configs that declare `[[plugins]]`. The deprecated
-`--frozen` flag prints a warning and performs the same normal install; use
-explicit `ref` values to pin sources.
+is no separate update command. Plugins install into the active project or user
+scope. The deprecated `--frozen` flag prints a warning and performs the same
+normal install; use explicit `ref` values to pin sources.
 
 Example:
 
@@ -96,6 +96,8 @@ Options:
 
 Plugin declarations record the exact discovered source path (`.` for a plugin
 at the source root), so later additions to the source cannot change selection.
+If config mutation or installation fails, `add` restores the previous
+`agents.toml` content rather than leaving a failed dependency declared.
 
 Do not mix positional names and `--skill` or `--name` flags in the same
 command.
@@ -302,10 +304,10 @@ dotagents doctor [--fix]
 ```
 
 Check project health and fix issues. Verifies gitignore setup, installed
-skills/plugins, symlinks, and detects legacy config fields. Use `dotagents sync`
-to repair generated runtime configs. User-scope plugin declarations and
-same-project plugin declarations are reported because plugin runtime projections
-are project-scoped.
+skills/plugins, plugin runtime projections, symlinks, and legacy config fields.
+Use `dotagents sync` to repair generated runtime configs. Same-project plugin
+declarations are reported because a project cannot install a plugin onto its
+own managed destination.
 
 Options:
 
@@ -460,8 +462,8 @@ manifests, Grok plugin directories, OpenCode skill links, and Pi skill links.
 Generalized legacy bundles can also project Markdown agents into OpenCode;
 standard extension agents are preserved but not projected yet. dotagents rejects
 plugin sources that resolve to the same project's
-`.agents/plugins/<name>/` install destination, and user-scope plugins are not
-supported yet.
+`.agents/plugins/<name>/` install destination. User-scope plugins use
+`~/.agents/plugins/<name>/` and global harness projections.
 
 ## Scopes
 
@@ -472,7 +474,7 @@ Skills go to `.agents/skills/` and the lockfile goes to `agents.lock`.
 
 ### User Scope
 
-Manages skills shared across all projects. Files live in `~/.agents/`, and you
+Manages skills and plugins shared across all projects. Files live in `~/.agents/`, and you
 can override that with `DOTAGENTS_HOME`. Claude and Cursor share the
 `~/.claude/skills/` symlink.
 
@@ -480,13 +482,16 @@ can override that with `DOTAGENTS_HOME`. Claude and Cursor share the
 dotagents --user init
 dotagents --user add getsentry/skills --all
 dotagents --user install
+dotagents --global add getsentry/agent-plugin
 ```
 
 When no `agents.toml` exists and you are not inside a git repo, dotagents falls
 back to user scope automatically.
 
-Plugins remain project-only. If `--user add` detects a plugin source, it exits
-without changing the user config, lockfile, installed directories, or runtime output.
+User plugins install into `~/.agents/plugins/`. Claude and Cursor marketplaces
+are generated below `~/.agents/`, Codex uses `~/.agents/plugins/marketplace.json`,
+OpenCode skills use `~/.config/opencode/skills/`, and Pi skills use
+`~/.agents/skills/`.
 
 ## Environment Variables
 

--- a/docs/src/content/docs/guide.mdx
+++ b/docs/src/content/docs/guide.mdx
@@ -141,16 +141,18 @@ Project skills live in `agents.toml` and are shared with your team. Personal
 skills apply to all your projects. Use them for tools and workflows only you
 need.
 
-Use `--user` to manage personal skills:
+Use `--user` (or its `--global` alias) to manage personal skills and plugins:
 
 ```shell
 dotagents --user init
 dotagents --user add getsentry/skills --all
 dotagents --user install
+dotagents --global add getsentry/agent-plugin
 ```
 
-Personal skills live in `~/.agents/` and symlink to `~/.claude/skills/` for
-Claude and Cursor. Override the location with `DOTAGENTS_HOME`.
+Personal skills and canonical plugins live in `~/.agents/`. Plugin projections
+target the global Claude, Codex, OpenCode, and Pi locations. Override the
+dotagents location with `DOTAGENTS_HOME`.
 
 When you run dotagents outside a git repo without an `agents.toml`, it falls
 back to user scope automatically.

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, writeFile, rm, readFile, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -778,7 +777,7 @@ describe("runAdd (local sources)", () => {
     expect(install).toHaveBeenCalledOnce();
   });
 
-  it("rejects user-scope plugins before changing config or runtime state", async () => {
+  it("adds user-scope plugins and runs installation", async () => {
     const userRoot = join(tmpDir, "user-home");
     const sourceDir = join(userRoot, "plugin-source");
     await mkdir(userRoot, { recursive: true });
@@ -790,17 +789,32 @@ describe("runAdd (local sources)", () => {
     scope.lockPath = join(userRoot, "agents.lock");
     scope.pluginsDir = join(userRoot, "plugins");
 
+    const install = mockRunInstall();
     await expect(runAdd({
       scope,
       specifier: "path:plugin-source",
-    })).rejects.toThrow("Plugins are project-scope only");
+    })).resolves.toBe("project-only");
 
-    expect(await readFile(scope.configPath, "utf-8")).toBe("version = 1\n");
-    await expect(readFile(scope.lockPath, "utf-8")).rejects.toThrow();
-    await expect(readFile(join(scope.pluginsDir, "project-only", "plugin.json"), "utf-8")).rejects.toThrow();
+    expect(await readFile(scope.configPath, "utf-8")).toContain('name = "project-only"');
+    expect(install).toHaveBeenCalledWith({ scope });
   });
 
-  it("does not bootstrap a missing user config for a detected plugin", async () => {
+  it("restores agents.toml when plugin installation fails", async () => {
+    const sourceDir = join(projectRoot, "plugin-source");
+    await writePlugin(sourceDir, "review-tools");
+    const originalConfig = "version = 1\n# Keep this comment.\n";
+    await writeFile(join(projectRoot, "agents.toml"), originalConfig);
+    vi.spyOn(installModule, "runInstall").mockRejectedValue(new Error("install failed"));
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-source",
+    })).rejects.toThrow("install failed");
+
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe(originalConfig);
+  });
+
+  it("bootstraps a missing user config for a detected plugin", async () => {
     const userRoot = join(tmpDir, "fresh-user-home");
     await writePlugin(join(userRoot, "plugin-source"), "project-only");
     const scope = resolveScope("user");
@@ -809,14 +823,14 @@ describe("runAdd (local sources)", () => {
     scope.lockPath = join(userRoot, "agents.lock");
     scope.pluginsDir = join(userRoot, "plugins");
 
+    const install = mockRunInstall();
     await expect(runAdd({
       scope,
       specifier: "path:plugin-source",
-    })).rejects.toThrow("Plugins are project-scope only");
+    })).resolves.toBe("project-only");
 
-    expect(existsSync(scope.configPath)).toBe(false);
-    expect(existsSync(scope.lockPath)).toBe(false);
-    expect(existsSync(scope.pluginsDir)).toBe(false);
+    expect(await readFile(scope.configPath, "utf-8")).toContain('name = "project-only"');
+    expect(install).toHaveBeenCalledWith({ scope });
   });
 
 });

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -566,6 +566,24 @@ describe("runAdd (local sources)", () => {
     expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
   });
 
+  it("does not fall back to skills when a named marketplace plugin has no manifest", async () => {
+    const sourceDir = join(projectRoot, "broken-marketplace-source");
+    await mkdir(join(sourceDir, "plugins", "review"), { recursive: true });
+    await mkdir(join(sourceDir, "skills", "review"), { recursive: true });
+    await writeFile(join(sourceDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
+    await writeFile(join(sourceDir, "marketplace.json"), JSON.stringify({
+      name: "broken",
+      plugins: [{ name: "review", source: "./plugins/review" }],
+    }));
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:broken-marketplace-source",
+      names: ["review"],
+    })).rejects.toThrow(/Marketplace plugin "review".*has no supported plugin manifest/);
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe("version = 1\n");
+  });
+
   it("preflights plugin names and persists exact paths and refs in one install", async () => {
     const sourceDir = join(projectRoot, "plugin-catalog");
     await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { realpath } from "node:fs/promises";
+import { readFile, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import * as clack from "@clack/prompts";
@@ -431,8 +431,19 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
     throw new AddError("Cannot use --all with --name. Use one or the other.");
   }
 
-  async function persistSkills(selection: SkillSelection): Promise<DetailedAddResult> {
+  async function persistAndInstall(mutateConfig: () => Promise<void>): Promise<void> {
     if (needsUserBootstrap) {await ensureUserScopeBootstrapped(scope);}
+    const previousConfig = await readFile(configPath, "utf-8");
+    try {
+      await mutateConfig();
+      await runInstall({ scope });
+    } catch (err) {
+      await writeFile(configPath, previousConfig, "utf-8");
+      throw err;
+    }
+  }
+
+  async function persistSkills(selection: SkillSelection): Promise<DetailedAddResult> {
     if (selection.type === "wildcard") {
       if (
         config.skills.some(
@@ -445,11 +456,12 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           `A wildcard entry for "${sourceForStorage}" already exists in agents.toml.`,
         );
       }
-      await addWildcardToConfig(configPath, sourceForStorage, {
-        ...refOpts,
-        exclude: [],
+      await persistAndInstall(async () => {
+        await addWildcardToConfig(configPath, sourceForStorage, {
+          ...refOpts,
+          exclude: [],
+        });
       });
-      await runInstall({ scope });
       return { kind: "skill", result: "*" };
     }
 
@@ -460,11 +472,12 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           `Skill "${name}" already exists in agents.toml. Remove it first to re-add.`,
         );
       }
-      await addSkillToConfig(configPath, name, {
-        source: sourceForStorage,
-        ...refOpts,
+      await persistAndInstall(async () => {
+        await addSkillToConfig(configPath, name, {
+          source: sourceForStorage,
+          ...refOpts,
+        });
       });
-      await runInstall({ scope });
       return { kind: "skill", result: name };
     }
 
@@ -488,13 +501,14 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         `All ${qualifier} skills already exist in agents.toml.`,
       );
     }
-    for (const name of toAdd) {
-      await addSkillToConfig(configPath, name, {
-        source: sourceForStorage,
-        ...refOpts,
-      });
-    }
-    await runInstall({ scope });
+    await persistAndInstall(async () => {
+      for (const name of toAdd) {
+        await addSkillToConfig(configPath, name, {
+          source: sourceForStorage,
+          ...refOpts,
+        });
+      }
+    });
     return { kind: "skill", result: toAdd };
   }
 
@@ -507,14 +521,15 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           `Plugin "${candidate.name}" already exists in agents.toml. Remove it first to re-add.`,
         );
       }
-      await addPluginsToConfig(configPath, [{
-        name: candidate.name,
-        source: sourceForStorage,
-        ...refOpts,
-        // Pin every discovered directory so later source inventory changes cannot alter selection.
-        path: candidate.path || ".",
-      }]);
-      await runInstall({ scope });
+      await persistAndInstall(async () => {
+        await addPluginsToConfig(configPath, [{
+          name: candidate.name,
+          source: sourceForStorage,
+          ...refOpts,
+          // Pin every discovered directory so later source inventory changes cannot alter selection.
+          path: candidate.path || ".",
+        }]);
+      });
       return { kind: "plugin", result: candidate.name };
     }
 
@@ -536,16 +551,17 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         : "specified";
       throw new AddError(`All ${qualifier} plugins already exist in agents.toml.`);
     }
-    await addPluginsToConfig(
-      configPath,
-      toAdd.map((candidate) => ({
-        name: candidate.name,
-        source: sourceForStorage,
-        ...refOpts,
-        path: candidate.path || ".",
-      })),
-    );
-    await runInstall({ scope });
+    await persistAndInstall(async () => {
+      await addPluginsToConfig(
+        configPath,
+        toAdd.map((candidate) => ({
+          name: candidate.name,
+          source: sourceForStorage,
+          ...refOpts,
+          path: candidate.path || ".",
+        })),
+      );
+    });
     return { kind: "plugin", result: toAdd.map((candidate) => candidate.name) };
   }
 
@@ -553,7 +569,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
   let plugins: PluginCandidate[] = [];
   if (acquired.pluginEligible) {
     try {
-      plugins = await discoverPlugins(acquired.rootDir);
+      plugins = await discoverPlugins(acquired.rootDir, namesOverride);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new AddError(message);
@@ -562,11 +578,6 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
 
   // Plugin presence classifies the entire source; bundled and standalone skills stay hidden.
   if (plugins.length > 0) {
-    if (scope.scope === "user") {
-      throw new AddError(
-        "Plugins are project-scope only. Rerun this command from a project without --user.",
-      );
-    }
     if (namesOverride?.length) {
       for (const name of namesOverride) {
         if (!PLUGIN_NAME_PATTERN.test(name)) {

--- a/packages/dotagents/src/cli/commands/doctor.test.ts
+++ b/packages/dotagents/src/cli/commands/doctor.test.ts
@@ -189,7 +189,7 @@ source = "path:external-review-tools"
     expect(check?.message).toContain("1 symlink(s)");
   });
 
-  it("reports user-scope plugins as unsupported", async () => {
+  it("reports missing user-scope plugins as installable", async () => {
     const previousHome = process.env["DOTAGENTS_HOME"];
     const userRoot = join(tmpDir, "user-agents");
     process.env["DOTAGENTS_HOME"] = userRoot;
@@ -209,8 +209,42 @@ source = "getsentry/plugins"
       const result = await runDoctor({ scope });
       const check = result.checks.find((c) => c.name === "installed plugins");
       expect(check?.status).toBe("error");
-      expect(check?.message).toContain("User-scope plugins are not supported yet");
-      expect(check?.message).not.toContain("Run 'npx @sentry/dotagents install'");
+      expect(check?.message).toContain("1 plugin(s) not installed: review-tools");
+      expect(check?.message).toContain("Run 'npx @sentry/dotagents install'");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env["DOTAGENTS_HOME"];
+      } else {
+        process.env["DOTAGENTS_HOME"] = previousHome;
+      }
+    }
+  });
+
+  it("detects missing user-scope plugin runtime projections", async () => {
+    const previousHome = process.env["DOTAGENTS_HOME"];
+    const userRoot = join(tmpDir, "user-agents");
+    process.env["DOTAGENTS_HOME"] = userRoot;
+    const scope = resolveScope("user");
+    const pluginDir = join(scope.pluginsDir, "review-tools");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, "plugin.json"), JSON.stringify({ name: "review-tools" }));
+    await writeFile(
+      scope.configPath,
+      `version = 1
+agents = ["codex"]
+
+[[plugins]]
+name = "review-tools"
+source = "getsentry/plugins"
+`,
+    );
+
+    try {
+      const result = await runDoctor({ scope });
+      const check = result.checks.find((c) => c.name === "plugin runtime");
+      expect(check?.status).toBe("warn");
+      expect(check?.message).toContain("Plugin marketplace missing");
+      expect(check?.message).toContain("dotagents sync");
     } finally {
       if (previousHome === undefined) {
         delete process.env["DOTAGENTS_HOME"];

--- a/packages/dotagents/src/cli/commands/doctor.ts
+++ b/packages/dotagents/src/cli/commands/doctor.ts
@@ -16,7 +16,8 @@ import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from ".
 import { exec } from "@sentry/dotagents-lib";
 import { isInPlaceSkill } from "../../utils/fs.js";
 import { isInPlacePluginSource, isSameProjectPluginConfig, loadInstalledPlugins } from "../../plugins/store.js";
-import { projectedPiSkillNames } from "../../plugins/runtime/writer.js";
+import { pluginRuntimeLayout } from "../../plugins/runtime/layout.js";
+import { projectedPiSkillNames, verifyPluginOutputs } from "../../plugins/runtime/writer.js";
 
 export interface DoctorCheck {
   name: string;
@@ -210,9 +211,6 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
   }
 
   // 9. Declared plugins are installed
-  const userScopePlugins = scope.scope === "user"
-    ? config.plugins.map((plugin) => plugin.name)
-    : [];
   const sameProjectPlugins = scope.scope === "project"
     ? config.plugins
       .filter((plugin) => isSameProjectPluginConfig(plugin, scope.pluginsDir, scope.root))
@@ -223,21 +221,15 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
     .filter((plugin) => !existsSync(`${scope.pluginsDir}/${plugin.name}`))
     .map((plugin) => plugin.name);
   const pluginErrors: string[] = [];
-  if (userScopePlugins.length > 0) {
+  if (sameProjectPlugins.length > 0) {
     pluginErrors.push(
-      `${userScopePlugins.length} plugin(s) declared in user scope: ${userScopePlugins.join(", ")}. User-scope plugins are not supported yet; declare plugins in a project agents.toml instead.`,
+      `${sameProjectPlugins.length} plugin(s) resolve inside this project's .agents/plugins/ tree: ${sameProjectPlugins.join(", ")}. Same-project plugins cannot be installed into the same project; use an external source path or a separate repo.`,
     );
-  } else {
-    if (sameProjectPlugins.length > 0) {
-      pluginErrors.push(
-        `${sameProjectPlugins.length} plugin(s) resolve inside this project's .agents/plugins/ tree: ${sameProjectPlugins.join(", ")}. Same-project plugins cannot be installed into the same project; use an external source path or a separate repo.`,
-      );
-    }
-    if (missingPlugins.length > 0) {
-      pluginErrors.push(
-        `${missingPlugins.length} plugin(s) not installed: ${missingPlugins.join(", ")}. Run 'npx @sentry/dotagents install'.`,
-      );
-    }
+  }
+  if (missingPlugins.length > 0) {
+    pluginErrors.push(
+      `${missingPlugins.length} plugin(s) not installed: ${missingPlugins.join(", ")}. Run 'npx @sentry/dotagents install'.`,
+    );
   }
   if (pluginErrors.length > 0) {
     checks.push({
@@ -249,6 +241,22 @@ export async function runDoctor(opts: DoctorOptions): Promise<DoctorResult> {
     checks.push({ name: "installed plugins", status: "ok", message: `All ${config.plugins.length} declared plugin(s) installed.` });
   } else {
     checks.push({ name: "installed plugins", status: "ok", message: "No plugins declared." });
+  }
+
+  if (config.plugins.length > 0 && pluginErrors.length === 0) {
+    const installed = await loadInstalledPlugins(scope.pluginsDir, config.plugins);
+    const runtimeIssues = installed.issues.length === 0
+      ? await verifyPluginOutputs(config.agents, installed.plugins, pluginRuntimeLayout(scope))
+      : installed.issues.map(({ name, issue }) => ({ agent: "dotagents", name, issue }));
+    if (runtimeIssues.length > 0) {
+      checks.push({
+        name: "plugin runtime",
+        status: "warn",
+        message: `${runtimeIssues.length} plugin runtime artifact(s) broken or missing. Run 'npx @sentry/dotagents sync' to repair. ${runtimeIssues.map(({ issue }) => issue).join(" ")}`,
+      });
+    } else {
+      checks.push({ name: "plugin runtime", status: "ok", message: "All plugin runtime artifacts intact." });
+    }
   }
 
   // 10. Symlinks (project scope only)

--- a/packages/dotagents/src/cli/commands/init.test.ts
+++ b/packages/dotagents/src/cli/commands/init.test.ts
@@ -113,6 +113,13 @@ describe("runInit", () => {
     expect(config.agents).toEqual(["claude", "cursor"]);
   });
 
+  it("accepts plugin-only Pi and Grok targets", async () => {
+    await runInit({ scope: resolveScope("project", dir), agents: ["pi", "grok"] });
+
+    const config = await loadConfig(join(dir, "agents.toml"));
+    expect(config.agents).toEqual(["pi", "grok"]);
+  });
+
   it("creates agent-specific symlinks when --agents is provided (cursor shares .claude)", async () => {
     await runInit({ scope: resolveScope("project", dir), agents: ["claude", "cursor"] });
 

--- a/packages/dotagents/src/cli/commands/init.ts
+++ b/packages/dotagents/src/cli/commands/init.ts
@@ -15,6 +15,7 @@ import type { TrustConfig } from "../../config/schema.js";
 import { GitError, TrustError } from "@sentry/dotagents-lib";
 import { formatGitError, formatTrustError } from "../errors.js";
 import { runInstall } from "./install.js";
+import { allPluginOnlyAgentIds } from "../../plugins/targets.js";
 
 const BOOTSTRAP_SKILL = { name: "dotagents", source: "getsentry/dotagents" } as const;
 
@@ -37,7 +38,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   }
 
   // Validate agent IDs before writing config
-  const validIds = allAgentIds();
+  const validIds = [...allAgentIds(), ...allPluginOnlyAgentIds()];
   if (agents) {
     const unknown = agents.filter((id) => !validIds.includes(id));
     if (unknown.length > 0) {
@@ -201,7 +202,11 @@ async function runInteractiveInit(scope: ScopeRoot, force?: boolean): Promise<vo
   const selectedAgents = prompt(
     await clack.multiselect({
       message: "Which agents do you use? (space to select, enter to confirm)",
-      options: allAgents().map((a) => ({ label: a.displayName, value: a.id })),
+      options: [
+        ...allAgents().map((a) => ({ label: a.displayName, value: a.id })),
+        { label: "Grok Build (plugins)", value: "grok" },
+        { label: "Pi (plugin skills)", value: "pi" },
+      ],
       required: true,
     }),
   );

--- a/packages/dotagents/src/cli/commands/install.test.ts
+++ b/packages/dotagents/src/cli/commands/install.test.ts
@@ -1080,16 +1080,26 @@ source = "path:./.agents/plugins/local-tools/source"
     expect(existsSync(sourceDir)).toBe(true);
   });
 
-  it("rejects user-scope plugin declarations", async () => {
+  it("installs user-scope plugins and writes global runtime projections", async () => {
     const previousHome = process.env["DOTAGENTS_HOME"];
+    const previousOsHome = process.env["HOME"];
     const dotagentsHome = join(tmpDir, "user-agents");
+    const userHome = join(tmpDir, "home");
     process.env["DOTAGENTS_HOME"] = dotagentsHome;
+    process.env["HOME"] = userHome;
     try {
       const scope = resolveScope("user");
-      await mkdir(scope.root, { recursive: true });
+      const sourceDir = join(scope.root, "plugin-source", "review-tools");
+      await mkdir(join(sourceDir, "skills", "review"), { recursive: true });
+      await writeFile(
+        join(sourceDir, "plugin.json"),
+        JSON.stringify({ name: "review-tools", version: "1.0.0" }),
+      );
+      await writeFile(join(sourceDir, "skills", "review", "SKILL.md"), SKILL_MD("review"));
       await writeFile(
         scope.configPath,
         `version = 1
+agents = ["claude", "codex", "opencode", "pi"]
 
 [[plugins]]
 name = "review-tools"
@@ -1097,13 +1107,25 @@ source = "path:plugin-source/review-tools"
 `,
       );
 
-      await expect(runInstall({ scope })).rejects.toThrow(/User-scope plugins are not supported yet/);
-      expect(existsSync(scope.pluginsDir)).toBe(false);
+      const result = await runInstall({ scope });
+      expect(result.installedPlugins).toEqual(["review-tools"]);
+      expect(existsSync(join(scope.pluginsDir, "review-tools", "plugin.json"))).toBe(true);
+      expect(existsSync(join(scope.root, ".claude-plugin", "marketplace.json"))).toBe(true);
+      expect(existsSync(join(scope.root, ".agents", "plugins", "marketplace.json"))).toBe(true);
+      expect(await readlink(join(scope.skillsDir, "review"))).toBe("../plugins/review-tools/skills/review");
+      expect(await readlink(join(userHome, ".config", "opencode", "skills", "review"))).toContain(
+        join("user-agents", "plugins", "review-tools", "skills", "review"),
+      );
     } finally {
       if (previousHome === undefined) {
         delete process.env["DOTAGENTS_HOME"];
       } else {
         process.env["DOTAGENTS_HOME"] = previousHome;
+      }
+      if (previousOsHome === undefined) {
+        delete process.env["HOME"];
+      } else {
+        process.env["HOME"] = previousOsHome;
       }
     }
   });

--- a/packages/dotagents/src/cli/commands/install.ts
+++ b/packages/dotagents/src/cli/commands/install.ts
@@ -45,13 +45,6 @@ export interface InstallResult {
 export async function runInstall(opts: InstallOptions): Promise<InstallResult> {
   const { scope } = opts;
   const config = await loadConfig(scope.configPath);
-  if (scope.scope === "user" && config.plugins.length > 0) {
-    throw new InstallError(
-      "User-scope plugins are not supported yet because plugin runtime projections are project-scoped. " +
-        "Declare plugins in a project agents.toml instead.",
-    );
-  }
-
   const lockfile = await loadLockfile(scope.lockPath);
   const skills = await installSkills(config, lockfile, scope);
   const subagents = await installSubagents(config, scope);

--- a/packages/dotagents/src/cli/commands/install/agent-runtime.ts
+++ b/packages/dotagents/src/cli/commands/install/agent-runtime.ts
@@ -11,6 +11,7 @@ import {
   userSubagentResolver,
 } from "../../../subagents/writer.js";
 import { reconcilePluginOutputs } from "../../../plugins/runtime/writer.js";
+import { pluginRuntimeLayout } from "../../../plugins/runtime/layout.js";
 import type { PluginDeclaration } from "../../../plugins/types.js";
 import type { SubagentDeclaration } from "../../../subagents/types.js";
 
@@ -76,13 +77,16 @@ export async function writeSubagentRuntime(
   return result.warnings;
 }
 
-/** Writes project-scoped plugin runtime projections. */
+/** Writes plugin runtime projections for the active scope. */
 export async function writePluginRuntime(
   config: AgentsConfig,
   scope: ScopeRoot,
   plugins: PluginDeclaration[],
 ): Promise<{ agent: string; name: string; message: string }[]> {
-  if (scope.scope !== "project") {return [];}
-  const { result } = await reconcilePluginOutputs(config.agents, plugins, scope.root);
+  const { result } = await reconcilePluginOutputs(
+    config.agents,
+    plugins,
+    pluginRuntimeLayout(scope),
+  );
   return result.warnings;
 }

--- a/packages/dotagents/src/cli/commands/remove.ts
+++ b/packages/dotagents/src/cli/commands/remove.ts
@@ -34,6 +34,7 @@ import {
   pruneInstalledPlugins,
 } from "../../plugins/store.js";
 import { projectedPiSkillNames, prunePluginOutputs } from "../../plugins/runtime/writer.js";
+import { pluginRuntimeLayout } from "../../plugins/runtime/layout.js";
 
 export class RemoveError extends Error {
   constructor(message: string) {
@@ -257,9 +258,7 @@ async function removePluginArtifacts(
       managedPluginNames.add(name);
     }
   }
-  if (scope.scope === "project") {
-    await pruneInstalledPlugins(scope.pluginsDir, managedPluginNames);
-  }
+  await pruneInstalledPlugins(scope.pluginsDir, managedPluginNames);
 
   if (lockfile) {
     for (const name of pluginNames) {
@@ -268,19 +267,21 @@ async function removePluginArtifacts(
     await writeLockfile(scope.lockPath, lockfile);
   }
 
-  if (scope.scope === "project") {
-    const config = await loadConfig(scope.configPath);
-    const remainingPluginConfigs = config.plugins
-      .filter((plugin) => !isSameProjectPluginConfig(plugin, scope.pluginsDir, scope.root))
-      .filter((plugin) => existsSync(join(scope.pluginsDir, plugin.name)));
-    const installedPlugins = await loadInstalledPlugins(scope.pluginsDir, remainingPluginConfigs);
-    if (installedPlugins.issues.length === 0) {
-      await prunePluginOutputs(config.agents, installedPlugins.plugins, scope.root);
-    } else {
-      console.log(chalk.yellow(
-        `Warning: Plugin runtime cleanup was skipped because these remaining plugins could not be loaded: ${installedPlugins.issues.map((issue) => issue.name).join(", ")}.`,
-      ));
-    }
+  const config = await loadConfig(scope.configPath);
+  const remainingPluginConfigs = config.plugins
+    .filter((plugin) => !isSameProjectPluginConfig(plugin, scope.pluginsDir, scope.root))
+    .filter((plugin) => existsSync(join(scope.pluginsDir, plugin.name)));
+  const installedPlugins = await loadInstalledPlugins(scope.pluginsDir, remainingPluginConfigs);
+  if (installedPlugins.issues.length === 0) {
+    await prunePluginOutputs(
+      config.agents,
+      installedPlugins.plugins,
+      pluginRuntimeLayout(scope),
+    );
+  } else {
+    console.log(chalk.yellow(
+      `Warning: Plugin runtime cleanup was skipped because these remaining plugins could not be loaded: ${installedPlugins.issues.map((issue) => issue.name).join(", ")}.`,
+    ));
   }
 
   await updateProjectGitignore(scope);

--- a/packages/dotagents/src/cli/commands/sync.ts
+++ b/packages/dotagents/src/cli/commands/sync.ts
@@ -18,6 +18,7 @@ import { projectSubagentResolver, reconcileSubagentConfigs, userSubagentResolver
 import { loadInstalledSubagents, pruneInstalledSubagents } from "../../subagents/store.js";
 import { isInPlacePluginSource, isSameProjectPluginConfig, loadInstalledPlugins, pruneInstalledPlugins } from "../../plugins/store.js";
 import { projectedPiSkillNames, reconcilePluginOutputs, verifyPluginOutputs } from "../../plugins/runtime/writer.js";
+import { pluginRuntimeLayout } from "../../plugins/runtime/layout.js";
 import { userMcpResolver } from "../../targets/paths.js";
 import { resolveScope, resolveDefaultScope, ScopeError, type ScopeRoot } from "../../scope.js";
 import { ensureUserScopeBootstrapped } from "../ensure-user-scope.js";
@@ -78,12 +79,9 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
         .map((plugin) => plugin.name)
       : [],
   );
-  const userScopePluginNames = scope.scope === "user"
-    ? config.plugins.map((plugin) => plugin.name)
-    : [];
-  const runtimePluginConfigs = scope.scope === "user"
-    ? []
-    : config.plugins.filter((plugin) => !selfInstalledPluginNames.has(plugin.name));
+  const runtimePluginConfigs = config.plugins.filter(
+    (plugin) => !selfInstalledPluginNames.has(plugin.name),
+  );
 
   for (const name of selfInstalledPluginNames) {
     issues.push({
@@ -92,14 +90,6 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
       message: `Plugin "${name}" resolves to .agents/plugins/${name}. Same-project plugins cannot be installed into the same project; use an external source path or a separate repo.`,
     });
   }
-  for (const name of userScopePluginNames) {
-    issues.push({
-      type: "plugins",
-      name,
-      message: `Plugin "${name}" is declared in user scope, but user-scope plugins are not supported yet. Declare plugins in a project agents.toml instead.`,
-    });
-  }
-
   // 1. Adopt orphaned skills (installed but not in agents.toml)
   if (existsSync(skillsDir)) {
     const adoptedLockEntries: Record<string, { source: string }> = {};
@@ -342,14 +332,15 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
   const prunedInstalledPlugins = await pruneInstalledPlugins(pluginsDir, staleManagedPluginNames);
   let pluginIssues: Awaited<ReturnType<typeof verifyPluginOutputs>> = [];
 
-  if (scope.scope === "project" && installedPluginResult.issues.length === 0) {
+  const runtimeLayout = pluginRuntimeLayout(scope);
+  if (installedPluginResult.issues.length === 0) {
     const { result: pluginResult, pruned: prunedPluginOutputs } = await reconcilePluginOutputs(
       config.agents,
       pluginDecls,
-      scope.root,
+      runtimeLayout,
     );
     pluginsRepaired = pluginResult.written + prunedPluginOutputs.length + prunedInstalledPlugins.length;
-    pluginIssues = await verifyPluginOutputs(config.agents, pluginDecls, scope.root);
+    pluginIssues = await verifyPluginOutputs(config.agents, pluginDecls, runtimeLayout);
 
     for (const warning of pluginResult.warnings) {
       issues.push({
@@ -358,7 +349,7 @@ export async function runSync(opts: SyncOptions): Promise<SyncResult> {
         message: warning.message,
       });
     }
-  } else if (scope.scope === "project") {
+  } else {
     pluginsRepaired = prunedInstalledPlugins.length;
   }
 

--- a/packages/dotagents/src/cli/help.ts
+++ b/packages/dotagents/src/cli/help.ts
@@ -1,5 +1,5 @@
 const COMMAND_HELP: Record<string, string> = {
-  init: `Usage: npx @sentry/dotagents [--user] init [options]
+  init: `Usage: npx @sentry/dotagents [--user|--global] init [options]
 
 Initialize agents.toml and the managed .agents directory.
 
@@ -7,14 +7,14 @@ Options:
   --agents <ids>  Comma-separated agent IDs for non-interactive setup
   --force         Replace an existing configuration
   --help, -h      Show this help message`,
-  install: `Usage: npx @sentry/dotagents [--user] install [options]
+  install: `Usage: npx @sentry/dotagents [--user|--global] install [options]
 
 Install or refresh dependencies declared in agents.toml.
 
 Options:
   --frozen        Deprecated compatibility flag; normal install still runs
   --help, -h      Show this help message`,
-  add: `Usage: npx @sentry/dotagents [--user] add <source> [name...] [options]
+  add: `Usage: npx @sentry/dotagents [--user|--global] add <source> [name...] [options]
 
 Discover plugins first, otherwise skills, then add and install the selected dependencies.
 
@@ -24,34 +24,34 @@ Options:
   --ref <ref>     Git tag, branch, or commit
   --all           Add plugins explicitly, or all skills as a wildcard dependency
   --help, -h      Show this help message`,
-  remove: `Usage: npx @sentry/dotagents [--user] remove <name|source> [options]
+  remove: `Usage: npx @sentry/dotagents [--user|--global] remove <name|source> [options]
 
 Remove a skill or plugin, or remove every dependency from a source.
 
 Options:
   -y, --yes       Skip confirmation when excluding or removing by source
   --help, -h      Show this help message`,
-  sync: `Usage: npx @sentry/dotagents [--user] sync [options]
+  sync: `Usage: npx @sentry/dotagents [--user|--global] sync [options]
 
 Reconcile local state without fetching dependency updates.
 
 Options:
   --help, -h      Show this help message`,
-  list: `Usage: npx @sentry/dotagents [--user] list [options]
+  list: `Usage: npx @sentry/dotagents [--user|--global] list [options]
 
 Show declared skills and plugins with installation status.
 
 Options:
   --json          Print structured output
   --help, -h      Show this help message`,
-  doctor: `Usage: npx @sentry/dotagents [--user] doctor [options]
+  doctor: `Usage: npx @sentry/dotagents [--user|--global] doctor [options]
 
 Check configuration, managed state, symlinks, and generated files.
 
 Options:
   --fix           Apply supported repairs
   --help, -h      Show this help message`,
-  mcp: `Usage: npx @sentry/dotagents [--user] mcp <subcommand>
+  mcp: `Usage: npx @sentry/dotagents [--user|--global] mcp <subcommand>
 
 Manage MCP server declarations.
 
@@ -61,7 +61,7 @@ Subcommands:
   list            Show declared MCP servers
 
 Run 'npx @sentry/dotagents mcp <subcommand> --help' for details.`,
-  "mcp add": `Usage: npx @sentry/dotagents [--user] mcp add <name> (--command <cmd> | --url <url>) [options]
+  "mcp add": `Usage: npx @sentry/dotagents [--user|--global] mcp add <name> (--command <cmd> | --url <url>) [options]
 
 Add an MCP server declaration to agents.toml.
 
@@ -71,20 +71,20 @@ Options:
   --header <Key:Value>  HTTP header; repeatable and URL transport only
   --env <VAR>           Environment variable name; repeatable
   --help, -h            Show this help message`,
-  "mcp remove": `Usage: npx @sentry/dotagents [--user] mcp remove <name> [options]
+  "mcp remove": `Usage: npx @sentry/dotagents [--user|--global] mcp remove <name> [options]
 
 Remove an MCP server declaration from agents.toml.
 
 Options:
   --help, -h      Show this help message`,
-  "mcp list": `Usage: npx @sentry/dotagents [--user] mcp list [options]
+  "mcp list": `Usage: npx @sentry/dotagents [--user|--global] mcp list [options]
 
 Show MCP server declarations from agents.toml.
 
 Options:
   --json          Print structured output
   --help, -h      Show this help message`,
-  trust: `Usage: npx @sentry/dotagents [--user] trust <subcommand>
+  trust: `Usage: npx @sentry/dotagents [--user|--global] trust <subcommand>
 
 Manage trusted skill sources.
 
@@ -94,19 +94,19 @@ Subcommands:
   list            Show trusted sources
 
 Run 'npx @sentry/dotagents trust <subcommand> --help' for details.`,
-  "trust add": `Usage: npx @sentry/dotagents [--user] trust add <source> [options]
+  "trust add": `Usage: npx @sentry/dotagents [--user|--global] trust add <source> [options]
 
 Add a trusted GitHub org, owner/repo, or Git domain.
 
 Options:
   --help, -h      Show this help message`,
-  "trust remove": `Usage: npx @sentry/dotagents [--user] trust remove <source> [options]
+  "trust remove": `Usage: npx @sentry/dotagents [--user|--global] trust remove <source> [options]
 
 Remove a trusted source from agents.toml.
 
 Options:
   --help, -h      Show this help message`,
-  "trust list": `Usage: npx @sentry/dotagents [--user] trust list [options]
+  "trust list": `Usage: npx @sentry/dotagents [--user|--global] trust list [options]
 
 Show trusted sources from agents.toml.
 

--- a/packages/dotagents/src/cli/index.test.ts
+++ b/packages/dotagents/src/cli/index.test.ts
@@ -31,4 +31,12 @@ describe("CLI help dispatch", () => {
 
     expect(sync).toHaveBeenCalledWith([], { user: true });
   });
+
+  it("accepts both user scope aliases together", async () => {
+    const { main } = await import("./main.js");
+
+    await main(["--user", "--global", "sync"]);
+
+    expect(sync).toHaveBeenCalledWith([], { user: true });
+  });
 });

--- a/packages/dotagents/src/cli/index.test.ts
+++ b/packages/dotagents/src/cli/index.test.ts
@@ -23,4 +23,12 @@ describe("CLI help dispatch", () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining("Reconcile local state"));
     log.mockRestore();
   });
+
+  it.each(["--user", "--global"])("passes %s as user scope", async (scopeFlag) => {
+    const { main } = await import("./main.js");
+
+    await main([scopeFlag, "sync"]);
+
+    expect(sync).toHaveBeenCalledWith([], { user: true });
+  });
 });

--- a/packages/dotagents/src/cli/main.ts
+++ b/packages/dotagents/src/cli/main.ts
@@ -23,7 +23,7 @@ type Command = keyof typeof COMMANDS;
 function printUsage(): void {
   console.log(`dotagents - shared tooling for coding agents
 
-Usage: npx @sentry/dotagents [--user] <command> [options]
+Usage: npx @sentry/dotagents [--user|--global] <command> [options]
 
 Commands:
   init        Initialize agents.toml and .agents/skills/
@@ -38,13 +38,14 @@ Commands:
 
 Options:
   --user      Operate on user-scope (~/.agents/) instead of project
+  --global    Alias for --user
   --help, -h  Show this help message
   --version   Show version`);
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = [...argv];
-  const userIndex = args.indexOf("--user");
+  const userIndex = args.findIndex((arg) => arg === "--user" || arg === "--global");
   const isUser = userIndex !== -1;
   if (isUser) {args.splice(userIndex, 1);}
 

--- a/packages/dotagents/src/cli/main.ts
+++ b/packages/dotagents/src/cli/main.ts
@@ -44,10 +44,8 @@ Options:
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
-  const args = [...argv];
-  const userIndex = args.findIndex((arg) => arg === "--user" || arg === "--global");
-  const isUser = userIndex !== -1;
-  if (isUser) {args.splice(userIndex, 1);}
+  const isUser = argv.some((arg) => arg === "--user" || arg === "--global");
+  const args = argv.filter((arg) => arg !== "--user" && arg !== "--global");
 
   const first = args[0];
   if (!first || first === "--help" || first === "-h") {

--- a/packages/dotagents/src/plugins/runtime/layout.ts
+++ b/packages/dotagents/src/plugins/runtime/layout.ts
@@ -1,0 +1,66 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { ScopeRoot } from "../../scope.js";
+
+export interface PluginRuntimeLayout {
+  claudeMarketplaceRoot: string;
+  cursorMarketplaceRoot: string;
+  codexMarketplaceRoot: string;
+  claudeMarketplacePath: string;
+  cursorMarketplacePath: string;
+  codexMarketplacePath: string;
+  canonicalPluginsDir: string;
+  grokPluginsDir: string;
+  opencodeSkillsDir: string;
+  opencodeAgentsDir: string;
+  piSkillsDir: string;
+}
+
+export type PluginRuntimeRoot = string | PluginRuntimeLayout;
+
+export function projectPluginRuntimeLayout(root: string): PluginRuntimeLayout {
+  return {
+    claudeMarketplaceRoot: root,
+    cursorMarketplaceRoot: root,
+    codexMarketplaceRoot: root,
+    claudeMarketplacePath: join(root, ".claude-plugin", "marketplace.json"),
+    cursorMarketplacePath: join(root, ".cursor-plugin", "marketplace.json"),
+    codexMarketplacePath: join(root, ".agents", "plugins", "marketplace.json"),
+    canonicalPluginsDir: join(root, ".agents", "plugins"),
+    grokPluginsDir: join(root, ".grok", "plugins"),
+    opencodeSkillsDir: join(root, ".opencode", "skills"),
+    opencodeAgentsDir: join(root, ".opencode", "agents"),
+    piSkillsDir: join(root, ".agents", "skills"),
+  };
+}
+
+export function userPluginRuntimeLayout(root: string): PluginRuntimeLayout {
+  const home = homedir();
+  const defaultRoot = join(home, ".agents");
+  const usesDefaultRoot = resolve(root) === resolve(defaultRoot);
+  return {
+    claudeMarketplaceRoot: root,
+    cursorMarketplaceRoot: root,
+    codexMarketplaceRoot: usesDefaultRoot ? home : root,
+    claudeMarketplacePath: join(root, ".claude-plugin", "marketplace.json"),
+    cursorMarketplacePath: join(root, ".cursor-plugin", "marketplace.json"),
+    codexMarketplacePath: usesDefaultRoot
+      ? join(root, "plugins", "marketplace.json")
+      : join(root, ".agents", "plugins", "marketplace.json"),
+    canonicalPluginsDir: join(root, "plugins"),
+    grokPluginsDir: join(home, ".grok", "plugins"),
+    opencodeSkillsDir: join(home, ".config", "opencode", "skills"),
+    opencodeAgentsDir: join(home, ".config", "opencode", "agents"),
+    piSkillsDir: join(root, "skills"),
+  };
+}
+
+export function pluginRuntimeLayout(scope: ScopeRoot): PluginRuntimeLayout {
+  return scope.scope === "user"
+    ? userPluginRuntimeLayout(scope.root)
+    : projectPluginRuntimeLayout(scope.root);
+}
+
+export function normalizePluginRuntimeLayout(root: PluginRuntimeRoot): PluginRuntimeLayout {
+  return typeof root === "string" ? projectPluginRuntimeLayout(root) : root;
+}

--- a/packages/dotagents/src/plugins/runtime/marketplace.ts
+++ b/packages/dotagents/src/plugins/runtime/marketplace.ts
@@ -1,26 +1,29 @@
-import { join, relative } from "node:path";
+import { relative } from "node:path";
 import type { PluginDeclaration } from "../types.js";
 import { selectedAgentIds } from "../targets.js";
 import { stableJson } from "../managed-files.js";
 import { legacyManifestString, manifestString } from "./manifest-values.js";
 import type { RuntimeOutput } from "./types.js";
+import { normalizePluginRuntimeLayout, type PluginRuntimeRoot } from "./layout.js";
 
 /** Lists managed plugin marketplace files that may be generated or pruned. */
-export function marketplaceOutputPaths(projectRoot: string): string[] {
+export function marketplaceOutputPaths(root: PluginRuntimeRoot): string[] {
+  const layout = normalizePluginRuntimeLayout(root);
   return [
-    join(projectRoot, ".agents", "plugins", "marketplace.json"),
-    join(projectRoot, ".claude-plugin", "marketplace.json"),
-    join(projectRoot, ".cursor-plugin", "marketplace.json"),
+    layout.codexMarketplacePath,
+    layout.claudeMarketplacePath,
+    layout.cursorMarketplacePath,
   ];
 }
 
 /** Builds target-specific marketplace JSON outputs for selected plugins. */
 export function marketplaceOutputs(
   agentIds: string[],
-  projectRoot: string,
+  root: PluginRuntimeRoot,
   plugins: PluginDeclaration[],
 ): RuntimeOutput[] {
   if (plugins.length === 0) {return [];}
+  const layout = normalizePluginRuntimeLayout(root);
 
   const outputs: RuntimeOutput[] = [];
   const claudePlugins = plugins.filter((plugin) => selectedAgentIds(agentIds, plugin).includes("claude"));
@@ -28,27 +31,27 @@ export function marketplaceOutputs(
   const codexPlugins = plugins.filter((plugin) => selectedAgentIds(agentIds, plugin).includes("codex"));
 
   if (claudePlugins.length > 0) {
-    const filePath = join(projectRoot, ".claude-plugin", "marketplace.json");
+    const filePath = layout.claudeMarketplacePath;
     outputs.push({
       agent: "claude",
       filePath,
-      content: stableJson(pathMarketplace(projectRoot, "dotagents", claudePlugins)),
+      content: stableJson(pathMarketplace(layout.claudeMarketplaceRoot, "dotagents", claudePlugins)),
     });
   }
   if (cursorPlugins.length > 0) {
-    const filePath = join(projectRoot, ".cursor-plugin", "marketplace.json");
+    const filePath = layout.cursorMarketplacePath;
     outputs.push({
       agent: "cursor",
       filePath,
-      content: stableJson(pathMarketplace(projectRoot, "dotagents", cursorPlugins)),
+      content: stableJson(pathMarketplace(layout.cursorMarketplaceRoot, "dotagents", cursorPlugins)),
     });
   }
   if (codexPlugins.length > 0) {
-    const filePath = join(projectRoot, ".agents", "plugins", "marketplace.json");
+    const filePath = layout.codexMarketplacePath;
     outputs.push({
       agent: "codex",
       filePath,
-      content: stableJson(codexMarketplace(projectRoot, "dotagents-local", codexPlugins)),
+      content: stableJson(codexMarketplace(layout.codexMarketplaceRoot, "dotagents-local", codexPlugins)),
     });
   }
 

--- a/packages/dotagents/src/plugins/runtime/writer.ts
+++ b/packages/dotagents/src/plugins/runtime/writer.ts
@@ -21,6 +21,11 @@ import {
 } from "../managed-files.js";
 import { NATIVE_PLUGIN_MANIFEST_TARGETS, writePluginManifests } from "./manifests.js";
 import { isSafeComponentPath } from "./component-paths.js";
+import {
+  normalizePluginRuntimeLayout,
+  type PluginRuntimeLayout,
+  type PluginRuntimeRoot,
+} from "./layout.js";
 
 // Owns deterministic runtime plugin projections. Existing runtime artifacts are
 // overwritten only when they carry dotagents managed metadata or a managed marker.
@@ -65,8 +70,9 @@ export async function projectedPiSkillNames(
 export async function writePluginOutputs(
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  root: PluginRuntimeRoot,
 ): Promise<PluginWriteResult> {
+  const layout = normalizePluginRuntimeLayout(root);
   const warnings: PluginWriteWarning[] = [];
   let written = 0;
   const selected = selectPlugins(agentIds, plugins);
@@ -75,20 +81,20 @@ export async function writePluginOutputs(
     warnings.push(warning);
   }
 
-  for (const output of marketplaceOutputs(agentIds, projectRoot, selected)) {
+  for (const output of marketplaceOutputs(agentIds, layout, selected)) {
     if (await writeManagedJsonOutput(output, warnings)) {written++;}
   }
 
   for (const plugin of selected) {
     const agents = selectedAgentIds(agentIds, plugin);
     written += await writePluginManifests(plugin, agents, warnings);
-    if (agents.includes("grok") && await writeGrokProjection(projectRoot, plugin, warnings)) {
+    if (agents.includes("grok") && await writeGrokProjection(layout, plugin, warnings)) {
       written++;
     }
   }
 
-  written += await writeComponentProjections("opencode", agentIds, selected, projectRoot, warnings);
-  written += await writeComponentProjections("pi", agentIds, selected, projectRoot, warnings);
+  written += await writeComponentProjections("opencode", agentIds, selected, layout, warnings);
+  written += await writeComponentProjections("pi", agentIds, selected, layout, warnings);
 
   return { warnings, written };
 }
@@ -97,10 +103,10 @@ export async function writePluginOutputs(
 export async function reconcilePluginOutputs(
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  root: PluginRuntimeRoot,
 ): Promise<{ result: PluginWriteResult; pruned: string[] }> {
-  const pruned = await prunePluginOutputs(agentIds, plugins, projectRoot);
-  const result = await writePluginOutputs(agentIds, plugins, projectRoot);
+  const pruned = await prunePluginOutputs(agentIds, plugins, root);
+  const result = await writePluginOutputs(agentIds, plugins, root);
   return { result, pruned };
 }
 
@@ -108,12 +114,13 @@ export async function reconcilePluginOutputs(
 export async function verifyPluginOutputs(
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  root: PluginRuntimeRoot,
 ): Promise<PluginVerifyIssue[]> {
+  const layout = normalizePluginRuntimeLayout(root);
   const issues: PluginVerifyIssue[] = [];
   const selected = selectPlugins(agentIds, plugins);
 
-  for (const output of marketplaceOutputs(agentIds, projectRoot, selected)) {
+  for (const output of marketplaceOutputs(agentIds, layout, selected)) {
     if (!existsSync(output.filePath)) {
       issues.push({ agent: output.agent, name: "marketplace", issue: `Plugin marketplace missing: ${output.filePath}` });
       continue;
@@ -138,19 +145,19 @@ export async function verifyPluginOutputs(
       }
     }
     if (agents.includes("grok")) {
-      const filePath = join(projectRoot, ".grok", "plugins", plugin.name);
+      const filePath = join(layout.grokPluginsDir, plugin.name);
       if (!existsSync(filePath)) {
         issues.push({ agent: "grok", name: plugin.name, issue: `Grok plugin projection missing: ${filePath}` });
       }
     }
   }
 
-  for (const link of await desiredComponentLinks("opencode", agentIds, selected, projectRoot, [])) {
+  for (const link of await desiredComponentLinks("opencode", agentIds, selected, layout, [])) {
     if (!await symlinkPointsTo(link.destPath, link.sourcePath) || !await isManagedComponentLink(link.destPath)) {
       issues.push({ agent: link.agent, name: link.name, issue: `OpenCode plugin ${link.kind} projection missing: ${link.destPath}` });
     }
   }
-  for (const link of await desiredComponentLinks("pi", agentIds, selected, projectRoot, [])) {
+  for (const link of await desiredComponentLinks("pi", agentIds, selected, layout, [])) {
     if (!await symlinkPointsTo(link.destPath, link.sourcePath) || !await isManagedComponentLink(link.destPath)) {
       issues.push({ agent: link.agent, name: link.name, issue: `Pi plugin ${link.kind} projection missing: ${link.destPath}` });
     }
@@ -163,13 +170,14 @@ export async function verifyPluginOutputs(
 export async function prunePluginOutputs(
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  root: PluginRuntimeRoot,
 ): Promise<string[]> {
+  const layout = normalizePluginRuntimeLayout(root);
   const pruned: string[] = [];
   const desiredMarketplacePaths = new Set(
-    marketplaceOutputs(agentIds, projectRoot, plugins).map((output) => output.filePath),
+    marketplaceOutputs(agentIds, layout, plugins).map((output) => output.filePath),
   );
-  for (const filePath of marketplaceOutputPaths(projectRoot)) {
+  for (const filePath of marketplaceOutputPaths(layout)) {
     if (desiredMarketplacePaths.has(filePath)) {continue;}
     if (!await isManagedJsonFile(filePath)) {continue;}
     await removeManagedJsonFile(filePath);
@@ -181,7 +189,7 @@ export async function prunePluginOutputs(
       .filter((plugin) => selectedAgentIds(agentIds, plugin).includes("grok"))
       .map((plugin) => plugin.name),
   );
-  const grokDir = join(projectRoot, ".grok", "plugins");
+  const grokDir = layout.grokPluginsDir;
   if (existsSync(grokDir)) {
     const entries = await readdir(grokDir, { withFileTypes: true });
     for (const entry of entries) {
@@ -195,17 +203,17 @@ export async function prunePluginOutputs(
   }
 
   const desiredOpenCodeLinks = new Set(
-    (await desiredComponentLinks("opencode", agentIds, plugins, projectRoot, [])).map((link) => link.destPath),
+    (await desiredComponentLinks("opencode", agentIds, plugins, layout, [])).map((link) => link.destPath),
   );
-  pruned.push(...await pruneManagedComponentLinks(join(projectRoot, ".opencode", "skills"), desiredOpenCodeLinks));
-  pruned.push(...await pruneManagedComponentLinks(join(projectRoot, ".opencode", "agents"), desiredOpenCodeLinks));
+  pruned.push(...await pruneManagedComponentLinks(layout.opencodeSkillsDir, desiredOpenCodeLinks));
+  pruned.push(...await pruneManagedComponentLinks(layout.opencodeAgentsDir, desiredOpenCodeLinks));
 
   const desiredPiLinks = new Set(
-    (await desiredComponentLinks("pi", agentIds, plugins, projectRoot, [])).map((link) => link.destPath),
+    (await desiredComponentLinks("pi", agentIds, plugins, layout, [])).map((link) => link.destPath),
   );
-  pruned.push(...await pruneManagedComponentLinks(join(projectRoot, ".agents", "skills"), desiredPiLinks));
+  pruned.push(...await pruneManagedComponentLinks(layout.piSkillsDir, desiredPiLinks));
 
-  const canonicalPluginDir = join(projectRoot, ".agents", "plugins");
+  const canonicalPluginDir = layout.canonicalPluginsDir;
   if (existsSync(canonicalPluginDir)) {
     const entries = await readdir(canonicalPluginDir, { withFileTypes: true });
     for (const target of NATIVE_PLUGIN_MANIFEST_TARGETS) {
@@ -232,11 +240,11 @@ export async function prunePluginOutputs(
 
 /** Mirrors a plugin bundle into Grok's plugin directory with a managed marker. */
 async function writeGrokProjection(
-  projectRoot: string,
+  layout: PluginRuntimeLayout,
   plugin: PluginDeclaration,
   warnings: PluginWriteWarning[],
 ): Promise<boolean> {
-  const dest = join(projectRoot, ".grok", "plugins", plugin.name);
+  const dest = join(layout.grokPluginsDir, plugin.name);
   if (existsSync(dest)) {
     if (await isManagedProjection(dest)) {
       await rm(dest, { recursive: true, force: true });
@@ -361,11 +369,11 @@ async function writeComponentProjections(
   agent: ComponentProjectionAgent,
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  layout: PluginRuntimeLayout,
   warnings: PluginWriteWarning[],
 ): Promise<number> {
   let written = 0;
-  for (const link of await desiredComponentLinks(agent, agentIds, plugins, projectRoot, warnings)) {
+  for (const link of await desiredComponentLinks(agent, agentIds, plugins, layout, warnings)) {
     if (await writeManagedComponentLink(link, warnings)) {written++;}
   }
   return written;
@@ -375,13 +383,13 @@ async function desiredComponentLinks(
   agent: ComponentProjectionAgent,
   agentIds: string[],
   plugins: PluginDeclaration[],
-  projectRoot: string,
+  layout: PluginRuntimeLayout,
   warnings: PluginWriteWarning[],
 ): Promise<ComponentLink[]> {
   const links = new Map<string, ComponentLink>();
   const selected = plugins.filter((plugin) => selectedAgentIds(agentIds, plugin).includes(agent));
   for (const plugin of selected) {
-    for (const link of await componentLinks(agent, projectRoot, plugin, warnings)) {
+    for (const link of await componentLinks(agent, layout, plugin, warnings)) {
       const existing = links.get(link.destPath);
       if (existing && existing.sourcePath !== link.sourcePath) {
         warnings.push({
@@ -399,15 +407,15 @@ async function desiredComponentLinks(
 
 async function componentLinks(
   agent: ComponentProjectionAgent,
-  projectRoot: string,
+  layout: PluginRuntimeLayout,
   plugin: PluginDeclaration,
   warnings: PluginWriteWarning[],
 ): Promise<ComponentLink[]> {
   const links: ComponentLink[] = [];
   for (const skillsDir of componentDirs(plugin, "skills", "skills", agent, warnings)) {
     const skillDestRoot = agent === "opencode"
-      ? join(projectRoot, ".opencode", "skills")
-      : join(projectRoot, ".agents", "skills");
+      ? layout.opencodeSkillsDir
+      : layout.piSkillsDir;
     links.push(...await skillComponentLinks(agent, plugin, skillsDir, skillDestRoot, warnings));
   }
 
@@ -417,7 +425,7 @@ async function componentLinks(
         agent,
         plugin,
         agentsDir,
-        join(projectRoot, ".opencode", "agents"),
+        layout.opencodeAgentsDir,
         warnings,
       ));
     }

--- a/packages/dotagents/src/plugins/store.test.ts
+++ b/packages/dotagents/src/plugins/store.test.ts
@@ -931,6 +931,9 @@ describe("plugin store", () => {
       await expect(discoverPlugins(sourceRoot)).rejects.toThrow(
         /Marketplace plugin "broken".*has no supported plugin manifest.*missing-manifest/,
       );
+      await expect(discoverPlugins(sourceRoot, ["broken"])).rejects.toThrow(
+        /Marketplace plugin "broken".*has no supported plugin manifest.*missing-manifest/,
+      );
     } finally {
       await rm(sourceRoot, { recursive: true, force: true });
     }

--- a/packages/dotagents/src/plugins/store.test.ts
+++ b/packages/dotagents/src/plugins/store.test.ts
@@ -507,6 +507,65 @@ describe("plugin store", () => {
     }
   });
 
+  it("prefers repository-root paths in nested Claude marketplaces", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
+    try {
+      const sourceRoot = join(projectRoot, "source");
+      const pluginDir = join(sourceRoot, "plugins", "frontend-design");
+      await mkdir(join(sourceRoot, ".claude-plugin"), { recursive: true });
+      await mkdir(join(pluginDir, ".claude-plugin"), { recursive: true });
+      await writeFile(
+        join(pluginDir, ".claude-plugin", "plugin.json"),
+        JSON.stringify({ name: "frontend-design" }),
+      );
+      await writeFile(
+        join(sourceRoot, ".claude-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "official",
+          plugins: [{ name: "frontend-design", source: "./plugins/frontend-design" }],
+        }),
+      );
+
+      const fromMarketplace = await resolvePlugin(
+        { name: "frontend-design", source: "path:source" },
+        { stateDir: join(projectRoot, "state"), projectRoot },
+      );
+      expect(fromMarketplace.plugin.pluginDir).toBe(pluginDir);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores unrelated marketplace failures during named discovery", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
+    try {
+      const pluginDir = join(sourceRoot, "plugins", "frontend-design");
+      await mkdir(join(sourceRoot, ".claude-plugin"), { recursive: true });
+      await mkdir(join(pluginDir, ".claude-plugin"), { recursive: true });
+      await writeFile(
+        join(pluginDir, ".claude-plugin", "plugin.json"),
+        JSON.stringify({ name: "frontend-design" }),
+      );
+      await writeFile(
+        join(sourceRoot, ".claude-plugin", "marketplace.json"),
+        JSON.stringify({
+          name: "official",
+          plugins: [
+            { name: "broken", source: "./plugins/broken" },
+            { name: "frontend-design", source: "./plugins/frontend-design" },
+          ],
+        }),
+      );
+
+      await expect(discoverPlugins(sourceRoot)).rejects.toThrow('Marketplace plugin "broken"');
+      await expect(discoverPlugins(sourceRoot, ["frontend-design"])).resolves.toMatchObject([
+        { name: "frontend-design", path: "plugins/frontend-design" },
+      ]);
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
   it("skips unsupported marketplace entries without dropping local entries", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "dotagents-plugin-store-"));
     try {

--- a/packages/dotagents/src/plugins/store.ts
+++ b/packages/dotagents/src/plugins/store.ts
@@ -612,14 +612,18 @@ async function discoverFromMarketplaces(
         continue;
       }
       if (!candidate) {
+        const error = new Error(
+          `Marketplace plugin "${entry.name}" in ${filePath} has no supported plugin manifest at ${path}.`,
+        );
         issues.push({
           name: entry.name,
           origin: "marketplace",
-          error: new Error(
-            `Marketplace plugin "${entry.name}" in ${filePath} has no supported plugin manifest at ${path}.`,
-          ),
-          blocksNamedResolution: false,
+          error,
+          blocksNamedResolution: true,
         });
+        const namedOutcomes = outcomes.get(entry.name) ?? [];
+        namedOutcomes.push({ error });
+        outcomes.set(entry.name, namedOutcomes);
         continue;
       }
       referencedDirs.add(resolve(pluginDir!));

--- a/packages/dotagents/src/plugins/store.ts
+++ b/packages/dotagents/src/plugins/store.ts
@@ -395,6 +395,13 @@ async function resolvePluginCandidate(
   }
 
   const catalog = await discoverPluginCatalog(sourceDir);
+  return resolveNamedPluginCandidate(catalog, config);
+}
+
+function resolveNamedPluginCandidate(
+  catalog: PluginCatalog,
+  config: Pick<PluginConfig, "name" | "source">,
+): PluginCandidate | null {
   const { candidates } = catalog;
   const canonicalPath = posix.join(".agents", "plugins", config.name);
   const canonical = candidates.find((candidate) => candidate.path === canonicalPath);
@@ -440,13 +447,28 @@ async function resolvePluginCandidate(
 }
 
 /** Discovers valid plugins from supported source locations. */
-export async function discoverPlugins(sourceDir: string): Promise<PluginCandidate[]> {
+export async function discoverPlugins(
+  sourceDir: string,
+  requestedNames?: string[],
+): Promise<PluginCandidate[]> {
   const catalog = await discoverPluginCatalog(sourceDir);
-  if (catalog.issues[0]) {throw catalog.issues[0].error;}
-  for (const candidate of catalog.candidates) {
+  let candidates = catalog.candidates;
+  if (requestedNames?.length) {
+    const requested: PluginCandidate[] = [];
+    for (const name of requestedNames) {
+      const candidate = resolveNamedPluginCandidate(catalog, { name, source: sourceDir });
+      if (candidate) {requested.push(candidate);}
+    }
+    if (requested.length > 0) {
+      candidates = await dedupeCandidates(requested);
+    }
+  } else if (catalog.issues[0]) {
+    throw catalog.issues[0].error;
+  }
+  for (const candidate of candidates) {
     await assertPluginBundleSymlinksContained(candidate.dir);
   }
-  return catalog.candidates;
+  return candidates;
 }
 
 async function discoverPluginCatalog(sourceDir: string): Promise<PluginCatalog> {
@@ -497,8 +519,9 @@ async function discoverPluginCatalog(sourceDir: string): Promise<PluginCatalog> 
 
 /**
  * Reads marketplace selector files and resolves only explicit local sources.
- * Relative paths are anchored at the marketplace file directory, plus any
- * marketplace-level `metadata.pluginRoot` prefix.
+ * Relative paths prefer the repository root used by current Claude
+ * marketplaces, then fall back to the marketplace file directory for legacy
+ * catalogs. Both forms remain contained by the source root.
  */
 async function discoverFromMarketplaces(
   sourceDir: string,
@@ -541,22 +564,40 @@ async function discoverFromMarketplaces(
         continue;
       }
       const marketplaceRoot = dirname(filePath);
-      let pluginDir: string;
+      let pluginDir: string | undefined;
       let candidate: PluginCandidate | null;
       try {
-        pluginDir = await resolveMarketplaceSource(
-          sourceDir,
-          marketplaceRoot,
-          join(root, path),
-          "Marketplace plugin source",
-        );
-        candidate = await loadPluginCandidate(
-          sourceDir,
-          pluginDir,
-          marketplaceManifestOverlay(entry),
-          "Marketplace plugin source",
-          "marketplace",
-        );
+        candidate = null;
+        const resolutionErrors: Error[] = [];
+        const anchors = [...new Set([sourceDir, marketplaceRoot])];
+        for (const anchor of anchors) {
+          let resolvedDir: string;
+          try {
+            resolvedDir = await resolveMarketplaceSource(
+              sourceDir,
+              anchor,
+              join(root, path),
+              "Marketplace plugin source",
+            );
+          } catch (err) {
+            resolutionErrors.push(err instanceof Error ? err : new Error(String(err)));
+            continue;
+          }
+          const resolvedCandidate = await loadPluginCandidate(
+            sourceDir,
+            resolvedDir,
+            marketplaceManifestOverlay(entry),
+            "Marketplace plugin source",
+            "marketplace",
+          );
+          if (!resolvedCandidate) {continue;}
+          pluginDir = resolvedDir;
+          candidate = resolvedCandidate;
+          break;
+        }
+        if (!candidate && resolutionErrors.length === anchors.length) {
+          throw resolutionErrors[0]!;
+        }
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         issues.push({
@@ -575,13 +616,13 @@ async function discoverFromMarketplaces(
           name: entry.name,
           origin: "marketplace",
           error: new Error(
-            `Marketplace plugin "${entry.name}" in ${filePath} has no supported plugin manifest at ${relativePath(sourceDir, pluginDir)}.`,
+            `Marketplace plugin "${entry.name}" in ${filePath} has no supported plugin manifest at ${path}.`,
           ),
           blocksNamedResolution: false,
         });
         continue;
       }
-      referencedDirs.add(resolve(pluginDir));
+      referencedDirs.add(resolve(pluginDir!));
       candidates.push(candidate);
       const namedOutcomes = outcomes.get(entry.name) ?? [];
       namedOutcomes.push({ candidate });

--- a/skills/dotagents-qa/Dockerfile
+++ b/skills/dotagents-qa/Dockerfile
@@ -22,9 +22,11 @@ RUN mkdir -p "$PNPM_HOME" "$COREPACK_HOME" \
 RUN npm install -g --no-audit --no-fund \
     @anthropic-ai/claude-code@latest \
     @openai/codex@latest \
+    @earendil-works/pi-coding-agent@latest \
     opencode-ai@latest \
   && claude --version \
   && codex --version \
+  && pi --version \
   && opencode --version
 
 WORKDIR /sandbox

--- a/skills/dotagents-qa/SKILL.md
+++ b/skills/dotagents-qa/SKILL.md
@@ -1,403 +1,123 @@
 ---
 name: dotagents-qa
-description: QA dotagents behavior changes in a Docker sandbox. Use when changes may affect dotagents install, sync, list, doctor, skill placement, agent symlinks, MCP or hook config generation, user scope, subagent runtime files, or package/runtime behavior.
+description: QA dotagents changes and published releases in Docker, including CLI lifecycles, user/global scope, real plugins, and Claude, Codex, OpenCode, or Pi projections. Use when behavior, packaging, scopes, or harness integration needs runtime proof.
+spec_hash: df3db16f11bb
 ---
 
 # dotagents QA
 
-Do real QA for the change in front of you. Docker is the safety boundary, not
-the test plan: use it so dotagents cannot write to host agent config, host home
-directories, or host cache state while you build fixtures that prove the
-changed behavior.
+Prove the requested behavior in Docker without touching host agent homes, caches, plugin registries, or credentials. Treat Docker as the safety boundary and the changed or released behavior as the test plan.
 
-Answer the practical question: "With this local dotagents build, does the
-changed behavior still install, sync, and wire the expected files?"
+## 1. Define the contract
 
-## 1. Understand The Change
+Before commands, state:
 
-Start from the diff and identify the behavior that could regress:
+- the exact subject: local checkout, packed local build, or published version;
+- the commands and semantics at risk;
+- project scope, user scope, or both;
+- the harnesses involved;
+- the fixture and evidence that constitute a pass.
 
-```bash
-git status --short
-git diff --stat
-git diff -- <paths>
-```
+For a published release, verify its registry metadata and install that exact version. Never silently test the local checkout instead. If you fix a discovered defect, report the release failure and packed-local-build pass separately.
 
-Write down the QA target before running commands:
-- Which command path changed: `install`, `sync`, `list`, `doctor`, `add`,
-  `remove`, `mcp`, `trust`, `init`, package runtime, or scope resolution.
-- Which surfaces must be inspected: `.agents/skills`, agent skill symlinks,
-  MCP config, hook config, subagent runtime files, lockfile, gitignore, CLI
-  output, or user scope.
-- Which fixture shape proves it: checked-in example, local skills, nested
-  skills, wildcard source, specific agents, MCP entries, hooks, existing
-  broken state, user-scope state, or remote source.
+Read the relevant references before acting:
 
-Read the targeted reference before running runtime-specific QA:
-- Core install/sync example: [references/core-agentic-qa.md](references/core-agentic-qa.md)
-- Plugin runtime verification matrix: [references/plugin-runtime.md](references/plugin-runtime.md)
-- Codex custom agents and plugin marketplace/install proof: [references/codex.md](references/codex.md)
-- Claude Code files, plugin validation, and runtime caveats: [references/claude.md](references/claude.md)
-- Cursor files/runtime caveats: [references/cursor.md](references/cursor.md)
-- Grok Build files/runtime caveats: [references/grok.md](references/grok.md)
-- OpenCode files/runtime caveats: [references/opencode.md](references/opencode.md)
+- Docker, non-root setup, exact release installation, and baseline commands: [references/docker-sandbox.md](references/docker-sandbox.md)
+- Ordinary install/sync behavior: [references/core-agentic-qa.md](references/core-agentic-qa.md)
+- Real plugins, full lifecycle, native clients, and user/global scope: [references/release-plugin-matrix.md](references/release-plugin-matrix.md)
+- Plugin adapters and automated proof: [references/plugin-runtime.md](references/plugin-runtime.md)
+- Harness details: [Claude](references/claude.md), [Codex](references/codex.md), [OpenCode](references/opencode.md), [Pi](references/pi.md), [Cursor](references/cursor.md), [Grok](references/grok.md)
 
-Run focused Vitest coverage for logic bugs. Use this skill for end-to-end QA
-evidence, not as a substitute for regression tests.
+Planning is part of acting: read the relevant references before proposing a command sequence, not only before executing it.
 
-## 2. Enter A Docker Sandbox
+## 2. Establish isolation
 
-Build the repo-local QA image when it is missing, when this Dockerfile changes,
-or when the repo `packageManager` pnpm version changes:
+Use the repo QA image. Rebuild it when the Dockerfile, pnpm version, or required current harness versions changed.
+
+Run package and runtime work as a non-root user. Keep these inside Docker or disposable directories:
 
 ```bash
-docker build \
-  -f skills/dotagents-qa/Dockerfile \
-  -t dotagents-qa:local \
-  skills/dotagents-qa
-```
-
-The image installs the latest npm-published Codex, Claude Code, and OpenCode
-CLIs (`codex`, `claude`, `opencode`). Use them for version checks, help-output
-checks, and optional isolated runtime probes. Their presence does not prove
-runtime discovery by itself; for plugins, prefer native dry-run/management
-commands where available: `claude plugin validate` for Claude plugin and
-marketplace shape, and `codex plugin marketplace add/list` plus
-`codex plugin add/list` for Codex marketplace installation. Authenticated
-model-backed checks are still explicit opt-ins. Keep runtime credentials out of
-fixtures and retained `/qa-out` artifacts.
-
-Use an interactive container so the QA steps stay change-specific:
-
-```bash
-REPO="$(pwd)"
-OUT="$(mktemp -d "${TMPDIR:-/tmp}/dotagents-qa.XXXXXX")"
-docker run --rm -it \
-  -v "$REPO:/host-repo:ro" \
-  -v "$OUT:/qa-out" \
-  dotagents-qa:local
-```
-
-If your tool environment is not attached to a TTY, use `-i` instead of `-it`
-and feed the same commands with a here-doc. Keep `-i`; without stdin attached,
-the container shell will receive no script.
-
-Inside the container:
-
-```bash
-set -euo pipefail
-export CI=1
 export HOME=/sandbox/home
 export DOTAGENTS_STATE_DIR=/sandbox/state
 export DOTAGENTS_HOME=/sandbox/user-agents
+export CODEX_HOME=/sandbox/codex-home
+export CLAUDE_CONFIG_DIR=/sandbox/claude-home
+```
 
-mkdir -p "$HOME" "$DOTAGENTS_STATE_DIR" "$DOTAGENTS_HOME" /sandbox/repo
-tar -C /host-repo \
-  --exclude=.git \
-  --exclude=node_modules \
-  --exclude=.turbo \
-  --exclude=coverage \
-  --exclude=core \
-  --exclude='*.tsbuildinfo' \
-  --exclude='packages/*/dist' \
-  -cf - . | tar -C /sandbox/repo -xf -
+Mount the host checkout read-only and copy it into the container without `.git`, `node_modules`, `dist`, coverage, or `*.tsbuildinfo`. Never point user-scope commands or client CLIs at the host's real home.
 
-cd /sandbox/repo
+Do not forward auth for file, validation, marketplace, or resource-discovery checks. Copy credentials only for a separately authorized model-backed proof, scrub them afterward, and never retain them in `/qa-out`.
+
+## 3. Run baseline validation
+
+For a local plugin/runtime change, normally run:
+
+```bash
 pnpm install --frozen-lockfile
-pnpm build
-```
-
-Run package commands as the non-root `node` user. Root can bypass chmod-based
-permission checks, which can mask or invert filesystem regression tests.
-
-For non-interactive QA, copy as root, then hand the repo to `node` before
-running package scripts:
-
-```bash
-chown -R node:node /sandbox
-su -s /bin/bash node -c '
-  set -euo pipefail
-  export CI=1
-  export HOME=/sandbox/home
-  export DOTAGENTS_STATE_DIR=/sandbox/state
-  export DOTAGENTS_HOME=/sandbox/user-agents
-  cd /sandbox/repo
-  pnpm install --frozen-lockfile
-  pnpm build
-  pnpm check
-  pnpm qa:example
-'
-```
-
-Run `pnpm check` inside Docker unless the change requires a narrower target or
-the check is already known to be unrelated. If `build` or `check` fails, treat
-that as a QA finding and stop before fixture work unless you are explicitly
-isolating the playbook mechanics. If skipped or bypassed, report why.
-
-## 3. Prefer The Checked-In Agentic QA
-
-Use the checked-in example QA for ordinary install/sync QA:
-
-```bash
+pnpm check
 pnpm qa:example
-```
-
-The QA runner builds the local CLI, copies `examples/full/` to a temp project, and
-asserts:
-- `install`, `list`, `doctor --fix`, and `doctor` complete successfully
-- managed skills under `.agents/skills/`
-- Claude/Cursor skill symlink behavior
-- MCP files for Claude, Cursor, Codex, and OpenCode
-- hook files for Claude and Cursor
-- canonical installed subagent under `.agents/agents/`
-- generated subagent runtime files for Claude, Cursor, Codex, and OpenCode
-- canonical installed plugin bundle under `.agents/plugins/`
-- Codex repo-scoped plugin marketplace under `.agents/plugins/marketplace.json`
-- generated plugin runtime files for Claude, Cursor, Codex, Grok, and OpenCode component projections
-- `sync` repair after deleting representative generated files
-
-Use `node skills/dotagents-qa/scripts/qa-example.mjs all --keep` when you need
-to inspect the temp project; the script prints the retained path.
-
-For automatic real-client plugin proof, run:
-
-```bash
 pnpm qa:plugins
 ```
 
-This runs every installed no-auth client proof in a fresh single-target fixture:
-Claude validates, adds, installs, and lists the plugin, then verifies one skill,
-zero leaked client-extension agents, and both portable MCP servers. Codex adds
-the generated marketplace and installs/lists the plugin. Grok Build runs
-`plugin list` and `plugin details` when available. Missing client CLIs are
-reported and skipped; the command fails if none are installed.
+Add focused regression tests for every confirmed logic bug. A failing baseline is a finding; do not bypass it silently. If a check is irrelevant or unavailable, record why.
 
-Cursor currently has no plugin validation or marketplace command in its desktop
-CLI, so Cursor remains covered by the isolated per-harness integration contract rather
-than being mislabeled as client-level E2E. The OpenCode proof remains available
-as an explicit task but is not part of the automatic client set.
+## 4. Exercise complete lifecycles
 
-For paid Codex runtime proof of generated custom agents, run the runtime proof
-outside Docker only when the branch affects Codex custom agents or when
-reporting that Codex itself works:
+Use the CLI from a fresh fixture and inspect output plus files:
 
 ```bash
-node skills/dotagents-qa/scripts/qa-example.mjs codex-runtime --keep
+dotagents init --agents claude,codex,opencode,pi
+dotagents add <source> [name]
+dotagents list --json
+dotagents doctor
+dotagents install
 ```
 
-That mode copies Codex auth/config into a temp `CODEX_HOME`, marks only the
-temp example project trusted, and asserts that Codex can spawn the generated
-`.codex/agents/code-reviewer.toml` agent. See
-[references/codex.md](references/codex.md) before changing or running this
-path.
+Inspect `agents.toml`, `agents.lock`, canonical skills/plugins, ownership markers, marketplaces, manifests, harness projections, and warnings. Delete representative managed artifacts, run `dotagents sync`, and prove exact repair. Run `dotagents remove <name>` and prove canonical and generated cleanup.
 
-## 4. Build A Manual Fixture Only When Needed
+Invoke every lifecycle command named by the contract. In particular, run `dotagents install` explicitly even though `add` also installs, and assert the config and lockfile paths directly rather than inferring them from `list` output.
 
-Create a temp project manually only when the checked-in example does not cover
-the changed behavior. Start from this shape and add only what the diff needs.
+Cover an unambiguous skill source as well as plugins so plugin-first discovery still falls back correctly. Use `--all` only with a controlled small catalog.
 
-```bash
-fixture=/sandbox/fixture
-mkdir -p "$fixture/local-skills" "$fixture/local-agents/agents"
-for skill in review commit; do
-  mkdir -p "$fixture/local-skills/$skill"
-  printf -- "---\nname: %s\ndescription: Fixture %s skill.\n---\n\n%s fixture.\n" \
-    "$skill" "$skill" "$skill" > "$fixture/local-skills/$skill/SKILL.md"
-done
+For user plugins, test both `--user` and `--global`. Isolate `HOME` and `DOTAGENTS_HOME`; inspect global Claude, Codex, OpenCode, and Pi paths; repair with one flag spelling and remove with the other.
 
-cat > "$fixture/local-agents/agents/code-reviewer.md" <<'EOF'
----
-name: code-reviewer
-description: Review code for correctness.
----
+## 5. Test representative plugins
 
-Review the current diff and return findings with file references.
-EOF
+When plugin compatibility is in scope, inspect current manifests and test:
 
-cat > "$fixture/agents.toml" <<'EOF'
-version = 1
-agents = ["claude", "cursor", "codex", "opencode"]
+- `getsentry/agent-plugin`;
+- `vercel/vercel-plugin`;
+- a selected plugin such as `frontend-design` from `anthropics/claude-plugins-official`.
 
-[[skills]]
-name = "review"
-source = "path:./local-skills/review"
+In a proposed compatibility plan, name all three repositories and explain that selectors, versions, commits, and component counts come from manifest inspection at execution time.
 
-[[skills]]
-name = "commit"
-source = "path:./local-skills/commit"
+Use a fresh project per source. Record source commits. Do not guess repository names, selectors, versions, component counts, or layouts.
 
-[[mcp]]
-name = "fixture"
-command = "node"
-args = ["-e", "process.exit(0)"]
+## 6. Prove harnesses independently
 
-[[hooks]]
-event = "Stop"
-command = "echo fixture"
+Keep per-harness fixtures isolated. In particular, do not enable Pi in the OpenCode proof: OpenCode can read Pi's shared `.agents/skills` links and create a false pass.
 
-[[subagents]]
-name = "code-reviewer"
-source = "path:./local-agents"
-EOF
-```
+- Claude: validate generated plugin and marketplace manifests, then marketplace add, install, list, and details.
+- Codex: add the project or user marketplace root, list available plugins, install, and list enabled plugins.
+- OpenCode: run the exact command `opencode debug skill` and assert exact projected skill names and locations.
+- Pi: in a separate Pi-only fixture, verify expected skill links, resolved targets, and `.dotagents-managed/<skill>` ownership markers.
 
-Useful fixture changes:
-- Skill resolution: nested `skills/` layouts, wildcard sources, duplicate
-  names, local paths outside `.agents`, or the exact `path:` shape touched.
-- Agent placement: include only affected agents, or include all supported
-  agents when shared config or registry behavior changed.
-- MCP and hooks: use the exact command, URL, headers, env refs, hook event, or
-  matcher affected by the diff.
-- Subagents: include a portable Markdown fixture under `agents/`, assert the
-  installed canonical file in `.agents/agents/`, assert generated runtime files
-  for Claude/Cursor/Codex/OpenCode, and inspect `agents.lock`.
-- Plugins: include a local plugin fixture with representative components,
-  assert the installed canonical bundle in `.agents/plugins/`, assert generated
-  runtime files for Claude/Cursor/Codex/Grok/OpenCode, and inspect `agents.lock`.
-- Sync and doctor: pre-create broken or legacy state, then prove repair and
-  diagnostics.
-- User scope: set both `HOME` and `DOTAGENTS_HOME`, pass `--user`, and inspect
-  generated files under those temp directories; never use the host home
-  directory.
-- Package/runtime: run the built CLI as above, or pack/install the package only
-  when the packaging path itself changed.
-- Remote sources: use `getsentry/skills`; avoid remotes for ordinary
-  install-location checks.
+These no-auth checks prove validation, registration, installation, or resource discovery. They do not prove model-backed invocation. Never claim a plugin skill or subagent executed without a model interaction and visible evidence.
 
-## 5. Exercise The CLI
+## 7. Report
 
-Run the built local CLI from the fixture. Capture output and inspect generated
-files, not just exit codes.
+Include:
 
-```bash
-cli=(node /sandbox/repo/packages/dotagents/dist/cli/index.js)
-cd "$fixture"
+- exact dotagents and harness versions;
+- Docker image/setup and non-root user;
+- fixture shapes and source commits;
+- commands and inspected paths;
+- assertions that passed;
+- confirmed defects and their regression tests;
+- release results versus local-fix results;
+- skipped authenticated checks and residual risk;
+- retained `/qa-out` location, if any.
 
-"${cli[@]}" install | tee /qa-out/install.out
-"${cli[@]}" list | tee /qa-out/list.out
-"${cli[@]}" doctor --fix | tee /qa-out/doctor-fix.out
-"${cli[@]}" doctor | tee /qa-out/doctor.out
-```
+Reporting is lossless. Enumerate every supplied command, version, source commit, and inspected path, even when repetitive. A category summary such as “state and marketplaces” is insufficient; do not invent missing values.
 
-Assert what matters for this change. Examples:
-
-```bash
-grep -q "review" /qa-out/list.out
-grep -q "commit" /qa-out/list.out
-test -f .agents/skills/review/SKILL.md
-test -f .agents/skills/commit/SKILL.md
-test -L .claude/skills
-test -f .mcp.json
-test -f .cursor/mcp.json
-test -f .codex/config.toml
-test -f .opencode/opencode.jsonc
-test -f .claude/settings.json
-test -f .cursor/hooks.json
-test -f .agents/agents/code-reviewer.md
-test -f .claude/agents/code-reviewer.md
-test -f .cursor/agents/code-reviewer.md
-test -f .codex/agents/code-reviewer.toml
-test -f .opencode/agents/code-reviewer.md
-test -f .agents/plugins/qa-tools/plugin.json
-test -f .agents/plugins/marketplace.json
-test -f .claude-plugin/marketplace.json
-test -f .cursor-plugin/marketplace.json
-test -f .agents/plugins/qa-tools/.claude-plugin/plugin.json
-test -f .agents/plugins/qa-tools/.cursor-plugin/plugin.json
-test -f .agents/plugins/qa-tools/.codex-plugin/plugin.json
-test -f .grok/plugins/qa-tools/.dotagents-managed
-test -L .opencode/skills/plugin-qa
-test -f .opencode/skills/.dotagents-managed/plugin-qa
-test ! -e .opencode/agents/plugin-reviewer.md
-grep -q "code-reviewer" agents.lock
-grep -q "qa-tools" agents.lock
-grep -q "Generated by dotagents" .claude/agents/code-reviewer.md
-grep -q "Generated by dotagents" .codex/agents/code-reviewer.toml
-```
-
-For `sync` or subagent writer changes, break the generated state in the way the
-diff claims to repair, then verify the repair:
-
-```bash
-rm .mcp.json .claude/skills .claude/agents/code-reviewer.md .codex/agents/code-reviewer.toml
-rm .agents/plugins/marketplace.json .claude-plugin/marketplace.json .agents/plugins/qa-tools/.claude-plugin/plugin.json
-rm .cursor-plugin/marketplace.json .agents/plugins/qa-tools/.cursor-plugin/plugin.json
-rm .agents/plugins/qa-tools/.codex-plugin/plugin.json
-rm -rf .grok/plugins/qa-tools
-rm .opencode/skills/plugin-qa
-"${cli[@]}" sync | tee /qa-out/sync.out
-test -f .mcp.json
-test -L .claude/skills
-test -f .claude/agents/code-reviewer.md
-test -f .codex/agents/code-reviewer.toml
-test -f .agents/plugins/marketplace.json
-test -f .claude-plugin/marketplace.json
-test -f .cursor-plugin/marketplace.json
-test -f .agents/plugins/qa-tools/.claude-plugin/plugin.json
-test -f .agents/plugins/qa-tools/.cursor-plugin/plugin.json
-test -f .agents/plugins/qa-tools/.codex-plugin/plugin.json
-test -f .grok/plugins/qa-tools/.dotagents-managed
-test -L .opencode/skills/plugin-qa
-test -f .opencode/skills/.dotagents-managed/plugin-qa
-test ! -e .opencode/agents/plugin-reviewer.md
-```
-
-For user-scope changes:
-
-```bash
-cd /sandbox
-"${cli[@]}" --user install | tee /qa-out/user-install.out
-test -f "$DOTAGENTS_HOME/agents.toml"
-test -d "$DOTAGENTS_HOME/skills"
-```
-
-Copy useful evidence before leaving the container:
-
-```bash
-cp -a "$fixture" /qa-out/fixture
-cp -a "$DOTAGENTS_HOME" /qa-out/user-agents 2>/dev/null || true
-```
-
-## 6. Real Agent Clients
-
-Use real clients only when discovery or registration in Claude, Cursor, Codex,
-VS Code, or OpenCode changed. Docker proves generated files and symlinks; it
-does not prove an installed host client notices them.
-
-Keep host-client checks isolated with explicit temp homes/config dirs where
-the client supports it. If a client cannot run without reading host state, say
-so and report the Docker-generated files you inspected instead.
-
-Inside the QA image, start with cheap client availability checks:
-
-```bash
-codex --version
-claude --version
-opencode --version
-```
-
-Codex subagents need real runtime proof before claiming Codex loaded them. Use
-`node skills/dotagents-qa/scripts/qa-example.mjs codex-runtime --keep`;
-`codex debug prompt-input` is not enough unless it visibly includes the
-generated agent name or instructions. Project-scoped `.codex/agents/` load only
-when Codex trusts the project. See [references/codex.md](references/codex.md).
-
-Claude has no cheap dry-run skill list. If auth/network/model cost is
-acceptable, run a minimal non-interactive prompt from the temp project;
-otherwise report it as skipped.
-
-Provider and gateway checks are runtime-specific. Before claiming model-backed
-runtime proof, run the check inside Docker and report the exact provider config
-used with secret values redacted.
-
-## 7. Report Evidence
-
-Report:
-- the changed behavior you targeted
-- Docker image and setup used
-- fixture shape and why it matched the diff
-- commands run
-- generated files or command output inspected
-- assertions that passed
-- `/qa-out` host path if retained for debugging
-- skipped checks and residual risk
+Keep the report candid: filesystem proof, native management proof, resource-discovery proof, and model-backed execution are different confidence levels.

--- a/skills/dotagents-qa/SOURCES.md
+++ b/skills/dotagents-qa/SOURCES.md
@@ -5,35 +5,37 @@
 | Source | Contribution |
 |--------|--------------|
 | `AGENTS.md` | pnpm and validation conventions |
-| `package.json` | `pnpm build` and `pnpm check` scripts |
-| `specs/SPEC.md` | canonical `.agents/skills/`, agent symlink, MCP, hook, install, sync, list, and doctor behavior |
-| `packages/dotagents/src/targets/definitions/claude.ts` | Claude project skills and generated config paths |
-| `packages/dotagents/src/targets/definitions/cursor.ts` | Cursor shares `.claude/skills` and writes Cursor-specific MCP/hook config |
-| `packages/dotagents/src/targets/definitions/vscode.ts` | VS Code reads `.agents/skills` natively and writes `.vscode/mcp.json` plus shared Claude-style hooks |
-| `packages/dotagents/src/targets/definitions/codex.ts` | Codex reads `.agents/skills` natively and writes `.codex/config.toml` |
-| `packages/dotagents/src/targets/definitions/opencode.ts` | OpenCode reads `.agents/skills` natively and writes `.opencode/opencode.jsonc` with legacy path fallback |
-| `packages/dotagents/src/cli/cache.ts` | `DOTAGENTS_STATE_DIR` cache isolation |
-| `packages/dotagents/src/cli/update-notifier.ts` | `HOME` isolation for update-check cache |
-| `skills/dotagents/SKILL.md` | sibling skill layout |
-| `/Users/dcramer/src/sentry-mcp/.agents/skills/mcp-qa/SKILL.md` | Numbered QA flow, primary path guidance, optional client checks, and pass criteria structure |
-| local `codex debug prompt-input` probe | verifies Codex can expose `.agents/skills` metadata without a model call |
+| `package.json` | `pnpm check`, `pnpm qa:example`, and `pnpm qa:plugins` scripts |
+| `specs/SPEC.md` | canonical skills, scopes, lifecycle commands, and generated harness behavior |
+| `specs/plugins.md` | plugin discovery, storage, targeting, projection, and CLI semantics |
+| `packages/dotagents/src/scope.ts` | project and user root/path resolution, including `DOTAGENTS_HOME` |
+| `packages/dotagents/src/cli/main.ts` | global `--user` and `--global` flag parsing |
+| `packages/dotagents/src/cli/commands/{add,install,sync,remove,doctor}.ts` | complete plugin lifecycle behavior and repair surfaces |
+| `packages/dotagents/src/plugins/store.ts` | plugin discovery, source resolution, canonical install, and installed-bundle loading |
+| `packages/dotagents/src/plugins/runtime/layout.ts` | project versus user/global runtime destinations |
+| `packages/dotagents/src/plugins/runtime/{marketplace,writer}.ts` | generated marketplaces, manifests, projections, verification, and pruning |
+| `skills/dotagents-qa/Dockerfile` | non-root QA image and installed Claude, Codex, OpenCode, and Pi CLIs |
+| `skills/dotagents-qa/scripts/qa-example.mjs` | checked-in deterministic example and plugin harness assertions |
 
 ## Decisions
 
-- Keep the runtime skill as a guided QA playbook rather than a broad QA matrix or fixed all-in-one harness.
-- Provide a repo-local Dockerfile for the sandbox/toolchain only; keep fixture design and assertions manual.
+- Keep the runtime skill as a guided QA playbook, with a representative release-plugin matrix rather than an exhaustive catalog.
+- Use the repo-local Dockerfile as the isolation boundary and install all four primary harness CLIs in it.
 - Keep the Dockerfile's prepared pnpm version aligned with the root `packageManager`.
 - Mount the host checkout read-only and do dependency install/build inside Docker to avoid host system-file writes and host binary assumptions.
 - Exclude `*.tsbuildinfo` with `dist` so TypeScript project references rebuild cleanly instead of reusing stale host incremental state.
 - Document `-i` for non-TTY Docker runs because stdin must stay attached when an agent feeds commands through a here-doc.
-- Make agents derive the fixture from the diff first, then use local `path:` skills, specific agents, MCP entries, hooks, broken state, user scope, or remote sources as needed.
-- Run `pnpm check` and `pnpm build` inside Docker when appropriate, then run `packages/dotagents/dist/cli/index.js` from inside the fixture project.
+- Distinguish exact published-package evidence from a later packed-local-build fix.
+- Require project and user/global lifecycle coverage when plugin scope behavior changes, including both flag spellings.
+- Test Sentry, Vercel, and one selected Anthropic marketplace plugin as the high-signal compatibility set.
+- Keep OpenCode and Pi proofs isolated because both can observe `.agents/skills` and contaminate one another.
+- Use native no-auth Claude/Codex management commands, OpenCode resource discovery, and Pi link inspection without claiming model invocation.
+- Run focused regressions plus `pnpm check`, `pnpm qa:example`, and `pnpm qa:plugins` for plugin/runtime changes.
 - Require inspection of generated files and command output that demonstrate the changed behavior, not only exit codes.
-- Expose the skill through `.agents/skills/dotagents-qa` so existing Claude/Cursor symlinks discover it.
-- Keep agent CLI registration and remote-source checks optional because they add auth, network, or tool-version variance.
+- Keep authentication out of ordinary QA; model-backed invocation is a separate, explicitly authorized layer.
 
 ## Trigger Notes
 
-Should trigger for requests like "QA this dotagents install change", "test dotagents in a temp project", "verify skill placement", and "make sure sync still repairs generated files".
+Should trigger for requests like "QA this dotagents install change", "test the published release in Docker", "verify global plugins", and "prove the plugin works in Claude, Codex, OpenCode, and Pi".
 
 Should not trigger for general dotagents usage help or unrelated project QA.

--- a/skills/dotagents-qa/SPEC.md
+++ b/skills/dotagents-qa/SPEC.md
@@ -1,41 +1,92 @@
-# dotagents QA Specification
+# dotagents QA
 
 ## Intent
 
-Provide a concise, Docker-sandboxed playbook for performing change-specific dotagents QA without writing to host agent config or host home directories.
+Provide change-specific and release-specific QA for dotagents inside an isolated Docker environment. The skill produces evidence that CLI lifecycle operations and generated harness integrations work without reading or writing the host's agent homes, credentials, or caches.
 
-## Scope
+## Triggers
 
-In scope:
-- building and running the local dotagents CLI
-- designing disposable project fixtures inside Docker based on the changed behavior
-- verifying `.agents/skills/`, agent skills symlinks, MCP configs, hook configs, `list`, `doctor`, and `sync`
-- verifying `--user` behavior with `DOTAGENTS_HOME` inside Docker
-- optionally checking agent CLI registration when discovery paths changed
-- optionally using `getsentry/skills` for remote source behavior
-- isolating home and cache state from the host
+- **SHOULD** apply when a dotagents change or release may affect install, add, remove, sync, list, doctor, scope resolution, package behavior, skills, plugins, MCP, hooks, subagents, or harness projections.
+- **SHOULD** apply when the user asks for Docker QA, real plugin compatibility, published-package verification, or native Claude/Codex/OpenCode/Pi proof.
+- **SHOULD NOT** apply to ordinary dotagents usage questions, architecture explanation without runtime validation, or unrelated repository QA.
 
-Out of scope:
-- release publishing
-- network-backed source testing for ordinary install-location changes
-- replacing focused Vitest regression coverage for logic bugs
-- treating a fixed all-in-one QA task as sufficient for behavior-specific changes
+## Behaviors
 
-## Runtime Contract
+### Behavior: Define the QA contract
 
-- Start from the changed dotagents behavior and state the behavior being proved before running commands.
-- Use the repo-local QA Dockerfile for a stable Node/pnpm/system-tool baseline.
-- Mount the host checkout read-only and copy it into a throwaway container before installing dependencies or building.
-- Exclude host build artifacts and TypeScript build-info files from the container copy.
-- Support both interactive Docker sessions and stdin-attached non-TTY runs.
-- Run the built CLI from inside the container fixture project so project scope resolves correctly.
-- Inspect generated files and command output that demonstrate the changed behavior, not just exit codes.
-- Keep `HOME`, `DOTAGENTS_STATE_DIR`, and `DOTAGENTS_HOME` inside Docker for user-scope checks.
-- Report fixture shape, commands, assertions, skipped checks, and residual risk.
+The agent SHALL identify the exact build or published version under test, the behavior at risk, the fixture shape, the harnesses and scopes involved, and the evidence required before running runtime commands.
 
-## Maintenance
+#### Scenario: Published release request
 
-- Keep `SKILL.md` focused on guided, change-specific Docker QA.
-- Keep examples editable and illustrative; do not turn the skill into a fixed all-in-one harness.
-- Keep the Dockerfile pnpm version aligned with the root `packageManager`.
-- Update examples when dotagents changes config fields, generated file locations, or supported agents.
+- **WHEN** the user asks to test `@sentry/dotagents@2.0.0`
+- **THEN** the agent verifies and installs that registry version in Docker and distinguishes its results from any later local-build fix validation
+
+### Behavior: Enforce Docker isolation
+
+The agent SHALL run package and runtime QA as a non-root user with `HOME`, `DOTAGENTS_STATE_DIR`, `DOTAGENTS_HOME`, and harness-specific config homes contained in Docker or disposable directories.
+
+#### Scenario: User scope plugin QA
+
+- **WHEN** testing `dotagents --user` or `dotagents --global`
+- **THEN** the agent proves the resolved paths are inside the sandbox and does not copy host authentication unless a separately authorized model-backed proof requires it
+
+### Behavior: Run proportionate baseline validation
+
+The agent SHALL run the repository checks and checked-in QA tasks relevant to the changed surface, and SHALL treat a failure as a finding rather than bypassing it silently.
+
+#### Scenario: Plugin runtime change
+
+- **WHEN** plugin installation or projection code changed
+- **THEN** the agent runs focused regression tests plus `pnpm check`, `pnpm qa:example`, and `pnpm qa:plugins`, or reports a concrete reason for each skipped check
+
+### Behavior: Exercise complete CLI lifecycles
+
+The agent SHALL use CLI commands to cover initialization, add or declaration, install, list, doctor, sync repair, and remove cleanup for each relevant scope, while inspecting config, lockfile, canonical artifacts, and generated outputs.
+
+#### Scenario: Global plugin lifecycle
+
+- **WHEN** validating user-scope plugin support
+- **THEN** the agent tests both `--user` and `--global`, verifies global harness paths, deletes representative managed outputs, proves `sync` repairs them, and proves `remove` cleans them up
+
+### Behavior: Test representative real plugins
+
+The agent SHALL validate canonical Sentry and Vercel plugins plus one high-signal marketplace-style source when plugin compatibility is in scope, resolving current repositories and plugin names from their manifests rather than guessing.
+
+#### Scenario: Major plugin compatibility pass
+
+- **WHEN** the user asks whether popular plugins work
+- **THEN** the agent tests `getsentry/agent-plugin`, `vercel/vercel-plugin`, and a selected plugin from `anthropics/claude-plugins-official`, unless a source is unavailable and that limitation is reported
+
+### Behavior: Prove each harness independently
+
+The agent SHALL isolate Claude, Codex, OpenCode, and Pi evidence so one harness's shared skill projection cannot make another harness appear to pass, and SHALL use no-auth native management or debug commands when available.
+
+#### Scenario: Four-harness plugin matrix
+
+- **WHEN** a plugin targets Claude, Codex, OpenCode, and Pi
+- **THEN** Claude validates and installs its generated marketplace, Codex adds and installs its generated marketplace, OpenCode reports projected skills through `opencode debug skill`, and Pi receives separately verified skill links without claiming model invocation
+
+### Behavior: Report evidence and limits
+
+The agent SHALL report commands, versions, inspected paths, passed assertions, confirmed defects, skipped authenticated checks, and residual risk, clearly separating published-release findings from local fixes.
+
+#### Scenario: Release reveals defects
+
+- **WHEN** published-package QA fails but a local change later passes
+- **THEN** the report identifies the release failure and the local fix validation as separate results
+
+## Constraints
+
+### Constraint: No host state leakage
+
+The agent MUST NOT run user-scope or harness QA against the host's real home, config, cache, plugin registry, or credentials.
+
+### Constraint: No false runtime claims
+
+The agent MUST NOT claim model-backed plugin or subagent execution from filesystem checks, schema validation, marketplace installation, or resource listing alone.
+
+### Constraint: No fixed-source guessing
+
+The agent MUST NOT invent plugin repository names, marketplace selectors, or component counts when current manifests can be inspected.
+
+<!-- skillet-version: 1.7.0 -->

--- a/skills/dotagents-qa/evals/cases/define-the-qa-contract.yaml
+++ b/skills/dotagents-qa/evals/cases/define-the-qa-contract.yaml
@@ -1,0 +1,5 @@
+behavior: define-the-qa-contract
+prompt: |
+  We just published @sentry/dotagents@2.0.0. Before anyone starts the potentially long Docker run, give me the precise QA contract you would use. If that release fails and we patch it, explain how the follow-up build is tracked without mixing the evidence. Do not execute the plan yet.
+checks:
+  - judge: The proposed contract explicitly identifies the exact registry package as the initial subject, defines scopes, harnesses, isolated fixtures, and pass evidence, and keeps any later packed-local-build validation distinct from the published-release result.

--- a/skills/dotagents-qa/evals/cases/enforce-docker-isolation.yaml
+++ b/skills/dotagents-qa/evals/cases/enforce-docker-isolation.yaml
@@ -1,0 +1,5 @@
+behavior: enforce-docker-isolation
+prompt: |
+  I want to verify global Sentry plugins without risking anything in my actual Claude, Codex, OpenCode, or Pi setup. I have not provided a checkout yet, so show me the exact isolated Docker setup and safety boundaries you will use. Do not run it yet.
+checks:
+  - judge: The plan uses a non-root Docker user, a read-only checkout mount, and disposable HOME, DOTAGENTS_STATE_DIR, DOTAGENTS_HOME, CODEX_HOME, and CLAUDE_CONFIG_DIR paths; it avoids host auth/config state for no-auth checks.

--- a/skills/dotagents-qa/evals/cases/exercise-complete-cli-lifecycles.yaml
+++ b/skills/dotagents-qa/evals/cases/exercise-complete-cli-lifecycles.yaml
@@ -1,0 +1,5 @@
+behavior: exercise-complete-cli-lifecycles
+prompt: |
+  Design the exact CLI lifecycle test for --user and --global plugins, including recovery and uninstall. I will provide the checkout afterward; for now, give me the executable test sequence and assertions without running it.
+checks:
+  - judge: The sequence covers init, add, install, list, doctor, deliberate managed-output damage, sync repair, and remove cleanup; uses both flag spellings interchangeably; and asserts config, lockfile, canonical bundle, marketplace, and global harness projection paths.

--- a/skills/dotagents-qa/evals/cases/prove-each-harness-independently.yaml
+++ b/skills/dotagents-qa/evals/cases/prove-each-harness-independently.yaml
@@ -1,0 +1,5 @@
+behavior: prove-each-harness-independently
+prompt: |
+  Before I hand over the generated plugin fixture, design the no-auth proof for Claude Code, Codex, OpenCode, and Pi. I care especially about avoiding cross-harness false positives. Do not run commands yet.
+checks:
+  - judge: The plan gives Claude and Codex separate native validation or marketplace/install/list proof, uses OpenCode debug skill with exact locations, uses a separate Pi fixture with managed-link and marker proof, prevents OpenCode/Pi contamination, and does not claim model invocation.

--- a/skills/dotagents-qa/evals/cases/report-evidence-and-limits.yaml
+++ b/skills/dotagents-qa/evals/cases/report-evidence-and-limits.yaml
@@ -1,0 +1,13 @@
+behavior: report-evidence-and-limits
+prompt: |
+  Turn these recorded results into a release decision summary. Do not run anything else:
+
+  - Docker image dotagents-qa:local, non-root node user, disposable homes under /sandbox
+  - Published @sentry/dotagents@2.0.0; Sentry source commit abc123; Claude 2.1.226
+  - `dotagents --user add getsentry/agent-plugin` failed because user plugins were unsupported
+  - Packed local artifact /qa-out/sentry-dotagents-2.0.0.tgz from branch feat/user-scope-plugins; same source commit and fixture
+  - `dotagents --user add getsentry/agent-plugin`, `dotagents --global list --json`, `dotagents --user doctor`, deliberate damage plus `dotagents --global sync`, and `dotagents --user remove sentry -y` passed
+  - Inspected /sandbox/user-agents/agents.toml, /sandbox/user-agents/agents.lock, /sandbox/user-agents/plugins/sentry/plugin.json, /sandbox/user-agents/.claude-plugin/marketplace.json, /sandbox/user-agents/.agents/plugins/marketplace.json, /sandbox/home/.config/opencode/skills/sentry, and /sandbox/user-agents/skills/sentry
+  - No credentials were copied; native management and filesystem discovery passed, but no model-backed invocation was attempted
+checks:
+  - judge: The report clearly separates the published-release failure from the packed-local-fix pass and includes the supplied versions, commands, paths, source commit, assertions, confirmed defect, skipped authenticated/model-backed checks, residual risk, and an actionable release recommendation without inventing results.

--- a/skills/dotagents-qa/evals/cases/run-proportionate-baseline-validation.yaml
+++ b/skills/dotagents-qa/evals/cases/run-proportionate-baseline-validation.yaml
@@ -1,0 +1,5 @@
+behavior: run-proportionate-baseline-validation
+prompt: |
+  I changed plugin installation and runtime projection code. Give me the bounded repository-validation command set and failure policy you would use before opening the PR. The checkout will arrive later, so do not execute anything yet.
+checks:
+  - judge: The plan includes focused regression coverage plus pnpm check, pnpm qa:example, and pnpm qa:plugins, requires a concrete task-specific reason for any omission, and treats failures as findings rather than bypassing them.

--- a/skills/dotagents-qa/evals/cases/test-representative-real-plugins.yaml
+++ b/skills/dotagents-qa/evals/cases/test-representative-real-plugins.yaml
@@ -1,0 +1,5 @@
+behavior: test-representative-real-plugins
+prompt: |
+  Plan a small, high-signal real-plugin compatibility pass for the new flow. Use Sentry, Vercel, and one other major source, but do not start network or Docker work until I provide the checkout.
+checks:
+  - judge: The plan resolves current manifests before choosing selectors and covers getsentry/agent-plugin, vercel/vercel-plugin, and one selected plugin from anthropics/claude-plugins-official, with a clear availability policy and no invented names, selectors, versions, or component counts.

--- a/skills/dotagents-qa/legacy-SPEC.md
+++ b/skills/dotagents-qa/legacy-SPEC.md
@@ -1,0 +1,41 @@
+# dotagents QA Specification
+
+## Intent
+
+Provide a concise, Docker-sandboxed playbook for performing change-specific dotagents QA without writing to host agent config or host home directories.
+
+## Scope
+
+In scope:
+- building and running the local dotagents CLI
+- designing disposable project fixtures inside Docker based on the changed behavior
+- verifying `.agents/skills/`, agent skills symlinks, MCP configs, hook configs, `list`, `doctor`, and `sync`
+- verifying `--user` behavior with `DOTAGENTS_HOME` inside Docker
+- optionally checking agent CLI registration when discovery paths changed
+- optionally using `getsentry/skills` for remote source behavior
+- isolating home and cache state from the host
+
+Out of scope:
+- release publishing
+- network-backed source testing for ordinary install-location changes
+- replacing focused Vitest regression coverage for logic bugs
+- treating a fixed all-in-one QA task as sufficient for behavior-specific changes
+
+## Runtime Contract
+
+- Start from the changed dotagents behavior and state the behavior being proved before running commands.
+- Use the repo-local QA Dockerfile for a stable Node/pnpm/system-tool baseline.
+- Mount the host checkout read-only and copy it into a throwaway container before installing dependencies or building.
+- Exclude host build artifacts and TypeScript build-info files from the container copy.
+- Support both interactive Docker sessions and stdin-attached non-TTY runs.
+- Run the built CLI from inside the container fixture project so project scope resolves correctly.
+- Inspect generated files and command output that demonstrate the changed behavior, not just exit codes.
+- Keep `HOME`, `DOTAGENTS_STATE_DIR`, and `DOTAGENTS_HOME` inside Docker for user-scope checks.
+- Report fixture shape, commands, assertions, skipped checks, and residual risk.
+
+## Maintenance
+
+- Keep `SKILL.md` focused on guided, change-specific Docker QA.
+- Keep examples editable and illustrative; do not turn the skill into a fixed all-in-one harness.
+- Keep the Dockerfile pnpm version aligned with the root `packageManager`.
+- Update examples when dotagents changes config fields, generated file locations, or supported agents.

--- a/skills/dotagents-qa/references/docker-sandbox.md
+++ b/skills/dotagents-qa/references/docker-sandbox.md
@@ -1,0 +1,89 @@
+# Docker Sandbox Setup
+
+Use this reference whenever starting dotagents QA.
+
+## Build the image
+
+Rebuild when the image is missing, the Dockerfile changed, the root pnpm version changed, or current harness CLIs matter:
+
+```bash
+docker build --pull \
+  -f skills/dotagents-qa/Dockerfile \
+  -t dotagents-qa:local \
+  skills/dotagents-qa
+```
+
+The image includes Node, pnpm, Git, jq, ripgrep, Claude Code, Codex, OpenCode, and Pi. Record their versions before client-specific claims.
+
+## Isolate the checkout and homes
+
+Mount the host checkout read-only, copy it into the container, and run package commands as a non-root user. Keep every runtime home and cache inside Docker:
+
+```bash
+REPO="$(pwd)"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/dotagents-qa.XXXXXX")"
+docker run --rm -it \
+  -v "$REPO:/host-repo:ro" \
+  -v "$OUT:/qa-out" \
+  dotagents-qa:local
+```
+
+Inside the container:
+
+```bash
+set -euo pipefail
+export CI=1
+export HOME=/sandbox/home
+export DOTAGENTS_STATE_DIR=/sandbox/state
+export DOTAGENTS_HOME=/sandbox/user-agents
+export CODEX_HOME=/sandbox/codex-home
+export CLAUDE_CONFIG_DIR=/sandbox/claude-home
+
+mkdir -p "$HOME" "$DOTAGENTS_STATE_DIR" "$DOTAGENTS_HOME" \
+  "$CODEX_HOME" "$CLAUDE_CONFIG_DIR" /sandbox/repo
+tar -C /host-repo \
+  --exclude=.git \
+  --exclude=node_modules \
+  --exclude=.turbo \
+  --exclude=coverage \
+  --exclude=core \
+  --exclude='*.tsbuildinfo' \
+  --exclude='packages/*/dist' \
+  -cf - . | tar -C /sandbox/repo -xf -
+
+chown -R node:node /sandbox
+su -s /bin/bash node
+cd /sandbox/repo
+pnpm install --frozen-lockfile
+```
+
+For non-TTY orchestration use `docker run -i`, not a detached shell with no stdin.
+
+## Local build versus published release
+
+For a local change, run the built CLI:
+
+```bash
+pnpm build
+cli=(node /sandbox/repo/packages/dotagents/dist/cli/index.js)
+```
+
+For release QA, verify and install the exact registry version instead:
+
+```bash
+npm view @sentry/dotagents@2.0.0 version dist.tarball
+npm install -g --no-audit --no-fund @sentry/dotagents@2.0.0
+dotagents --version
+```
+
+Never silently substitute the local checkout for the published artifact. If a defect is fixed during QA, rerun the failing case with a packed local build and report the release result and fix result separately.
+
+## Baseline
+
+```bash
+pnpm check
+pnpm qa:example
+pnpm qa:plugins
+```
+
+Run focused Vitest regression files as well when a logic bug was found. A skipped baseline command needs a concrete reason in the report.

--- a/skills/dotagents-qa/references/pi.md
+++ b/skills/dotagents-qa/references/pi.md
@@ -1,0 +1,23 @@
+# Pi QA
+
+Use this reference when plugin targets include `pi` or Pi discovery is part of a compatibility claim.
+
+Pi reads shared `.agents/skills/` locations rather than a separate dotagents plugin marketplace. A Pi-targeted plugin therefore projects each valid plugin skill into `.agents/skills/<skill>` with a dotagents ownership marker.
+
+Keep Pi in a separate fixture from OpenCode. OpenCode also reads `.agents/skills/`, so a combined fixture can make OpenCode appear to pass through Pi's projection.
+
+File-level proof:
+
+```bash
+pi --version
+find .agents/skills -maxdepth 1 -type l -print
+for link in .agents/skills/<expected-skill>; do
+  test -L "$link"
+  test -f "$link/SKILL.md"
+  test -f ".agents/skills/.dotagents-managed/$(basename "$link")"
+done
+```
+
+For user scope, the corresponding links live in `$DOTAGENTS_HOME/skills/`.
+
+Pi does not currently expose a no-auth command equivalent to `opencode debug skill`. File and symlink proof establishes projection only. Do not claim that Pi loaded or invoked a skill without an authenticated runtime interaction and a visible sentinel.

--- a/skills/dotagents-qa/references/release-plugin-matrix.md
+++ b/skills/dotagents-qa/references/release-plugin-matrix.md
@@ -1,0 +1,121 @@
+# Release and Real Plugin Matrix
+
+Use this reference for release QA, plugin CLI changes, real plugin compatibility, or user/global plugin scope.
+
+## Select current sources
+
+Inspect manifests before testing; do not guess names or layouts. The default high-signal set is:
+
+- `getsentry/agent-plugin` — standalone Agent Plugins v1 bundle
+- `vercel/vercel-plugin` — large native Claude plugin with skills, hooks, MCP, commands, and agents
+- `anthropics/claude-plugins-official frontend-design` — a plugin selected from a large nested marketplace
+
+Confirm current manifests and repository activity with `gh api`, `gh search code`, or cloned files. Use fewer plugins only when a source is unavailable and report that limitation.
+
+## Standard CLI lifecycle
+
+Use a fresh git project per source and initialize every relevant full agent plus Pi:
+
+```bash
+mkdir -p /sandbox/cases/sentry
+cd /sandbox/cases/sentry
+git init -q
+dotagents init --agents claude,codex,opencode,pi
+dotagents add getsentry/agent-plugin
+dotagents list --json
+dotagents doctor
+```
+
+Inspect `agents.toml`, `agents.lock`, `.agents/.gitignore`, the canonical plugin bundle, generated marketplaces/manifests, and component links. Delete representative managed outputs, run `dotagents sync`, and verify repair. Run `dotagents remove <name>` and verify canonical files, marketplaces, markers, and links are pruned.
+
+Also cover a skill-only source or fixture so plugin-first detection still falls back to skill behavior. Test `--all` with a small controlled catalog, not a hundreds-entry public marketplace.
+
+## Isolate each harness
+
+Do not put OpenCode and Pi in the same proof fixture: OpenCode can read `.agents/skills`, so Pi links could create a false OpenCode pass.
+
+### Claude
+
+```bash
+claude plugin validate .agents/plugins/<name>/.claude-plugin/plugin.json
+claude plugin validate .claude-plugin/marketplace.json
+claude plugin marketplace add ./ --scope project
+claude plugin install <name>@dotagents --scope project
+claude plugin list
+claude plugin details <name>@dotagents
+```
+
+Validation and component inventory are no-auth proof, not model invocation.
+
+### Codex
+
+```bash
+export CODEX_HOME=/sandbox/codex-home
+mkdir -p "$CODEX_HOME"
+codex plugin marketplace add ./ --json
+codex plugin list --marketplace dotagents-local --available --json
+codex plugin add <name>@dotagents-local --json
+codex plugin list --json
+```
+
+The local marketplace source must be the project directory, not the marketplace JSON file or its containing `.agents/plugins` directory.
+
+### OpenCode
+
+Use an OpenCode-only plugin target, then run:
+
+```bash
+opencode debug skill > /qa-out/opencode-skills.json
+jq '[.[] | select(.location | contains("/.opencode/skills/"))] | map(.name)' \
+  /qa-out/opencode-skills.json
+```
+
+Assert exact projected locations and skill names.
+
+### Pi
+
+Use a Pi-only target and verify each managed link in `.agents/skills/` resolves to the canonical plugin skill and has its ownership marker. Pi has no equivalent no-auth skill inventory command, so do not claim model-backed loading from link proof alone.
+
+## User and global scope
+
+Test both flag spellings with isolated homes:
+
+```bash
+export HOME=/sandbox/home
+export DOTAGENTS_HOME="$HOME/.agents"
+dotagents --global init --agents claude,codex,opencode,pi
+dotagents --user add getsentry/agent-plugin
+dotagents --global list --json
+dotagents --user doctor
+```
+
+Expected default-home outputs:
+
+- canonical bundle: `$HOME/.agents/plugins/<name>/`
+- Claude marketplace: `$HOME/.agents/.claude-plugin/marketplace.json`
+- Codex marketplace: `$HOME/.agents/plugins/marketplace.json`
+- OpenCode skills: `$HOME/.config/opencode/skills/<skill>`
+- Pi skills: `$HOME/.agents/skills/<skill>`
+
+Native user proof:
+
+```bash
+cd "$DOTAGENTS_HOME"
+claude plugin marketplace add ./ --scope user
+claude plugin install <name>@dotagents --scope user
+
+cd "$HOME"
+codex plugin marketplace add ./ --json
+codex plugin add <name>@dotagents-local --json
+
+cd /sandbox/neutral-project
+opencode debug skill
+```
+
+When `DOTAGENTS_HOME` is not `$HOME/.agents`, add the Codex marketplace from `$DOTAGENTS_HOME`; dotagents emits its adapter catalog below `$DOTAGENTS_HOME/.agents/plugins/` so Codex can discover it.
+
+Delete one marketplace and one component link, run `dotagents --user sync`, and prove repair. Remove the plugin using the other flag spelling and prove all canonical and generated state is gone.
+
+## Reporting
+
+Record exact dotagents and harness versions, source commits, commands, generated paths, native-client results, sync/remove results, skipped authenticated checks, and residual risk. Keep published-release failures separate from later packed-local-build passes.

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -269,7 +269,7 @@ compatibility implementation (see the remaining gaps in `specs/plugins.md`):
 
 Generated plugin JSON is stable: keys are sorted, plugin entries are sorted by name, and files end with one trailing newline. Generated marketplaces and Claude/Cursor/Codex manifests use adjacent `.dotagents-managed` sidecars; OpenCode/Pi component symlinks use marker files in reserved sibling `.dotagents-managed/` directories. This keeps ownership explicit without changing client-owned JSON or consuming a valid component name. Legacy `metadata.managedBy` output remains recognizable during migration. Managed Grok copies and component symlinks are pruned when their plugin or target is removed. Plugin sources that resolve to this project's `.agents/plugins/<name>/` install destination are rejected so dotagents never installs a same-repo plugin onto itself. Existing plugin install destinations are overwritten only when their on-disk `.dotagents-managed` marker proves ownership.
 
-Plugins are currently project-scope only. `install --user` rejects `[[plugins]]` entries because user-scope runtime plugin projections are not generated yet.
+User scope installs canonical plugins into `~/.agents/plugins/<name>/`. It generates Claude and Cursor marketplaces below `~/.agents/`, a Codex marketplace at `~/.agents/plugins/marketplace.json` whose local paths are rooted at the user's home, OpenCode skill and legacy-agent projections below `~/.config/opencode/`, and Pi skill projections below `~/.agents/skills/`.
 
 #### Supported Agents
 
@@ -508,7 +508,7 @@ dotagents install
    b. Discover skill within the repo
    c. Copy skill directory into `.agents/skills/<name>/`
 3. Resolve configured subagents
-4. Resolve and install configured project-scope plugins into `.agents/plugins/<name>/`; reject user-scope plugin declarations
+4. Resolve and install configured plugins into `.agents/plugins/<name>/` for project scope or `~/.agents/plugins/<name>/` for user scope
 5. Write `agents.lock` with the current configured skills, subagents, and plugins
 6. Install configured subagents into `.agents/agents/`
 7. Regenerate `.agents/.gitignore`
@@ -560,11 +560,12 @@ dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
    - Reject local plugin sources that overlap the project's managed `.agents/plugins` directory before changing config
 7. Append explicit `[[plugins]]` entries (including the exact safe `path`, with `.` for a source-root plugin) or the selected `[[skills]]` entries
 8. Run install exactly once and update `agents.lock`
+   - If config mutation or installation fails, restore the pre-add `agents.toml` content so a failed add does not leave a declaration behind
 
-Plugins are project-only. If user scope is active and plugin discovery succeeds,
-`add` exits before changing user configuration, the lockfile, installed files,
-or generated runtime state. Mixed plugin-and-skill selection from one source is
-intentionally unsupported; plugin presence wins for the whole source.
+User scope uses the same discovery and lifecycle as project scope, with canonical
+bundles and runtime projections rooted in the user paths described above. Mixed
+plugin-and-skill selection from one source is intentionally unsupported; plugin
+presence wins for the whole source.
 
 **Flags:**
 - `--ref <ref>`: Pin to a specific tag/branch/commit
@@ -678,7 +679,8 @@ dotagents doctor [--fix]
 6. `.agents/skills/` directory exists
 7. All declared skills are installed
 8. All declared plugins are installed
-9. Symlinks are intact
+9. Generated plugin runtime artifacts are intact
+10. Symlinks are intact
 
 **Flags:**
 - `--fix`: Auto-fix issues where possible (add gitignore entries, remove legacy fields, create missing `.agents/.gitignore`)

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -299,7 +299,9 @@ their validated source-relative `path` (`.` for a source-root plugin), so
 subsequent installs select the same directory even if the repository gains more plugins.
 There is no plugin wildcard: `add --all` records a snapshot of every plugin
 currently discovered, while skill `--all` retains its dynamic wildcard meaning.
-CLI plugin add is project-scope only.
+CLI plugin add supports both project and user scope. User scope stores canonical
+bundles in `~/.agents/plugins/` and projects each target into its global runtime
+location.
 Local plugin sources that overlap the project's managed `.agents/plugins`
 directory are rejected before configuration changes.
 


### PR DESCRIPTION
Add the complete plugin lifecycle to user scope, with `--global` as an alias for `--user`. Canonical bundles and generated Claude, Cursor, Codex, OpenCode, Pi, and Grok outputs now resolve through scope-aware runtime layouts, so add, install, list, doctor, sync, and remove behave consistently outside a project.

This closes the largest gap found while validating 2.0.0: plugin support otherwise looked complete but stopped at project scope. The change also accepts Pi and Grok during init, makes named marketplace discovery tolerate unrelated malformed entries without falling back to skills for a malformed requested plugin, restores `agents.toml` when add-time installation fails, and lets doctor detect missing plugin projections.

The existing plugin-first automatic detection remains the CLI model; users do not need a separate plugin command or explicit type selection. MCP remains part of the plugin bundle: validated portable MCP configuration is retained and referenced from generated Claude, Cursor, and Codex manifests, while native runtime configuration remains intact. User scope only relocates the canonical bundle and generated adapters.

A packed-build Docker pass at `8cb7043` covered `getsentry/agent-plugin` (`727107f`, 8 skills), `vercel/vercel-plugin` (`12d0770`, 32 skills), and Anthropic's `frontend-design` selector (`99d5013`, 1 skill). Claude and Codex natively registered, installed, and listed every plugin as enabled; OpenCode discovered every projected skill through `opencode debug skill`; isolated Pi fixtures verified every skill link and ownership marker. Claude's installed inventory resolved the Sentry and Vercel HTTPS MCP servers, and the portable MCP fixture passed native Claude and Codex installation with both HTTP and stdio servers present. Project and user/global add, list, doctor, install, damage/sync repair, remove, skill fallback, and both scope aliases together all passed. No authenticated model invocation was performed.

The repository QA skill is consolidated around this Docker workflow so published-versus-packed builds, representative real plugins, user/global scope, MCP components, and independent harness evidence stay part of release validation.
