### PR TITLE
fix(cli): Refresh existing dependencies on add

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ npx @sentry/dotagents add getsentry/skills --all
 npx @sentry/dotagents add getsentry/agent-plugins review-tools
 ```
 
-`add` is safe to repeat for the same dependency declaration. If it is already
-configured, dotagents keeps `agents.toml` unchanged and refreshes the installed
-skills, plugins, lockfile, and generated runtime files.
-
 This creates `~/.agents/agents.toml` and `~/.agents/agents.lock`, making the dependencies available across projects.
 
 Run `install` again whenever you want to refresh global managed state:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npx @sentry/dotagents add getsentry/skills --all
 npx @sentry/dotagents add getsentry/agent-plugins review-tools
 ```
 
+`add` is safe to repeat for the same dependency declaration. If it is already
+configured, dotagents keeps `agents.toml` unchanged and refreshes the installed
+skills, plugins, lockfile, and generated runtime files.
+
 This creates `~/.agents/agents.toml` and `~/.agents/agents.lock`, making the dependencies available across projects.
 
 Run `install` again whenever you want to refresh global managed state:
@@ -67,7 +71,7 @@ Project commands other than `init` require `agents.toml` and never fall back to 
 | Command | Description |
 |---------|-------------|
 | `init` | Create `agents.toml` and `.agents/skills/` |
-| `add <source> [names...]` | Discover and add plugins, otherwise skills |
+| `add <source> [names...]` | Discover and add plugins, otherwise skills; exact repeats refresh installation |
 | `remove <name\|source> [-y]` | Remove a skill, plugin, or all dependencies from a source |
 | `install` | Install all dependencies from `agents.toml` |
 | `list` | Show declared skills, plugins, and their status |

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -379,7 +379,9 @@ Add and install plugins or skills. Git and local sources are classified once: if
 
 When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds support project and global scope.
 
-When adding multiple dependencies, names already declared for that kind are skipped with a warning. The command fails if all specified names already exist. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
+Re-adding an exact dependency declaration (same kind, name, source, ref, and plugin path) succeeds without changing `agents.toml` and runs the normal install refresh. This updates the lockfile, canonical files, and generated runtime projections. A single-name collision from a different source, ref, or plugin path remains an error.
+
+When adding multiple dependencies, names already declared for that kind are skipped with a warning. If every requested declaration is an exact duplicate, the command refreshes installation successfully; conflicting all-duplicate requests still fail. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
 
 Plugin declarations persist the exact discovered source path (`.` for a source-root plugin), preventing later source inventory changes from changing selection. If config mutation or installation fails, `add` restores the previous `agents.toml` content so the failed dependency is not left declared.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -379,9 +379,7 @@ Add and install plugins or skills. Git and local sources are classified once: if
 
 When a source has one dependency of the selected kind, it is added automatically. Multiple dependencies use a picker in a TTY or are listed with selection guidance in non-interactive mode. Plugin adds support project and global scope.
 
-Re-adding an exact dependency declaration (same kind, name, source, ref, and plugin path) succeeds without changing `agents.toml` and runs the normal install refresh. This updates the lockfile, canonical files, and generated runtime projections. A single-name collision from a different source, ref, or plugin path remains an error.
-
-When adding multiple dependencies, names already declared for that kind are skipped with a warning. If every requested declaration is an exact duplicate, the command refreshes installation successfully; conflicting all-duplicate requests still fail. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
+When adding multiple dependencies, names already declared for that kind are skipped with a warning. Exact repeats leave `agents.toml` unchanged and refresh installation; conflicting declarations still error. Positional names and `--name`/`--skill` flags cannot be mixed. Plugin `--all` is a snapshot of current candidates; skill `--all` remains a wildcard that can include future upstream skills.
 
 Plugin declarations persist the exact discovered source path (`.` for a source-root plugin), preventing later source inventory changes from changing selection. If config mutation or installation fails, `add` restores the previous `agents.toml` content so the failed dependency is not left declared.
 

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -329,6 +329,24 @@ describe("runAdd", () => {
     expect(install).toHaveBeenCalledOnce();
   });
 
+  it("reports only conflicting skills in a mixed duplicate request", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n\n[[skills]]\nname = "review"\nsource = "other/repo"\n`,
+    );
+
+    const error = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: `git:${repoDir}`,
+      names: ["pdf", "review"],
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(AddError);
+    expect((error as Error).message).toBe(
+      "Skills already exist in agents.toml with a different source or ref: review.",
+    );
+  });
+
   it("throws when --all is used with names", async () => {
     const scope = resolveScope("project", projectRoot);
     await expect(
@@ -916,6 +934,40 @@ describe("runAdd (local sources)", () => {
     });
     expect(result).toEqual(["beta"]);
     expect(install).toHaveBeenCalledOnce();
+  });
+
+  it("reports only conflicting plugins in a mixed duplicate request", async () => {
+    const sourceDir = join(projectRoot, "plugin-conflicts");
+    await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
+    await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      [
+        "version = 1",
+        "",
+        "[[plugins]]",
+        'name = "alpha"',
+        'source = "path:plugin-conflicts"',
+        'path = "plugins/alpha"',
+        "",
+        "[[plugins]]",
+        'name = "beta"',
+        'source = "path:plugin-conflicts"',
+        'path = "different/path"',
+        "",
+      ].join("\n"),
+    );
+
+    const error = await runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: "path:plugin-conflicts",
+      names: ["alpha", "beta"],
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(AddError);
+    expect((error as Error).message).toBe(
+      "Plugins already exist in agents.toml with a different source, ref, or path: beta.",
+    );
   });
 
   it("adds user-scope plugins and runs installation", async () => {

--- a/packages/dotagents/src/cli/commands/add.test.ts
+++ b/packages/dotagents/src/cli/commands/add.test.ts
@@ -261,20 +261,37 @@ describe("runAdd", () => {
     expect(toml).not.toContain('name = "pdf"');
   });
 
-  it("preserves the single-name duplicate error", async () => {
+  it("refreshes an exactly matching single skill", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
     );
 
     const scope = resolveScope("project", projectRoot);
-    await expect(
-      runAdd({
-        scope,
-        specifier: `git:${repoDir}`,
-        names: ["pdf"],
-      }),
-    ).rejects.toThrow(AddError);
+    const install = mockRunInstall();
+    await expect(runAdd({
+      scope,
+      specifier: `git:${repoDir}`,
+      names: ["pdf"],
+    })).resolves.toBe("pdf");
+
+    expect(install).toHaveBeenCalledOnce();
+    expect(await readFile(join(projectRoot, "agents.toml"), "utf-8")).toBe(
+      `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n`,
+    );
+  });
+
+  it("rejects a single skill with the same name from a different source", async () => {
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      'version = 1\n\n[[skills]]\nname = "pdf"\nsource = "other/repo"\n',
+    );
+
+    await expect(runAdd({
+      scope: resolveScope("project", projectRoot),
+      specifier: `git:${repoDir}`,
+      names: ["pdf"],
+    })).rejects.toThrow("different source or ref");
   });
 
   it("skips existing skills only for a multi-name request", async () => {
@@ -296,20 +313,20 @@ describe("runAdd", () => {
     expect(toml).toContain('name = "review"');
   });
 
-  it("throws when all specified skills already exist", async () => {
+  it("refreshes when all specified skills already exist exactly", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "pdf"\nsource = "git:${repoDir}"\n\n[[skills]]\nname = "review"\nsource = "git:${repoDir}"\n`,
     );
 
     const scope = resolveScope("project", projectRoot);
-    await expect(
-      runAdd({
-        scope,
-        specifier: `git:${repoDir}`,
-        names: ["pdf", "review"],
-      }),
-    ).rejects.toThrow(AddError);
+    const install = mockRunInstall();
+    await expect(runAdd({
+      scope,
+      specifier: `git:${repoDir}`,
+      names: ["pdf", "review"],
+    })).resolves.toEqual(["pdf", "review"]);
+    expect(install).toHaveBeenCalledOnce();
   });
 
   it("throws when --all is used with names", async () => {
@@ -324,22 +341,20 @@ describe("runAdd", () => {
     ).rejects.toThrow("Cannot use --all with --name. Use one or the other.");
   });
 
-  it("rejects an existing wildcard after source classification", async () => {
+  it("refreshes an existing wildcard after source classification", async () => {
     await writeFile(
       join(projectRoot, "agents.toml"),
       `version = 1\n\n[[skills]]\nname = "*"\nsource = "git:${repoDir}"\n`,
     );
 
     const scope = resolveScope("project", projectRoot);
-    await expect(
-      runAdd({
-        scope,
-        specifier: `git:${repoDir}`,
-        all: true,
-      }),
-    ).rejects.toThrow(
-      `A wildcard entry for "git:${repoDir}" already exists in agents.toml.`,
-    );
+    const install = mockRunInstall();
+    await expect(runAdd({
+      scope,
+      specifier: `git:${repoDir}`,
+      all: true,
+    })).resolves.toBe("*");
+    expect(install).toHaveBeenCalledOnce();
   });
 
   it("validates trust against expanded source, not raw shorthand", async () => {
@@ -876,7 +891,7 @@ describe("runAdd (local sources)", () => {
     expect(install).toHaveBeenCalledOnce();
   });
 
-  it("preserves single and multi-name duplicate behavior for plugins", async () => {
+  it("refreshes an exact plugin duplicate and still adds new requested plugins", async () => {
     const sourceDir = join(projectRoot, "plugin-duplicates");
     await writePlugin(join(sourceDir, "plugins", "alpha"), "alpha");
     await writePlugin(join(sourceDir, "plugins", "beta"), "beta");
@@ -885,13 +900,15 @@ describe("runAdd (local sources)", () => {
       'version = 1\n\n[[plugins]]\nname = "alpha"\nsource = "path:plugin-duplicates"\npath = "plugins/alpha"\n',
     );
 
+    const install = mockRunInstall();
     await expect(runAdd({
       scope: resolveScope("project", projectRoot),
       specifier: "path:plugin-duplicates",
       names: ["alpha"],
-    })).rejects.toThrow('Plugin "alpha" already exists');
+    })).resolves.toBe("alpha");
+    expect(install).toHaveBeenCalledOnce();
 
-    const install = mockRunInstall();
+    install.mockClear();
     const result = await runAdd({
       scope: resolveScope("project", projectRoot),
       specifier: "path:plugin-duplicates",
@@ -921,6 +938,35 @@ describe("runAdd (local sources)", () => {
 
     expect(await readFile(scope.configPath, "utf-8")).toContain('name = "project-only"');
     expect(install).toHaveBeenCalledWith({ scope });
+  });
+
+  it("reinstalls an exact local plugin duplicate without changing config", async () => {
+    const sourceDir = join(projectRoot, "plugin-refresh");
+    await writePlugin(sourceDir, "refresh-tools");
+    await writeFile(join(sourceDir, "README.md"), "version one\n");
+    const scope = resolveScope("project", projectRoot);
+
+    await runAdd({ scope, specifier: "path:plugin-refresh" });
+    const configBefore = await readFile(scope.configPath, "utf-8");
+    expect(
+      await readFile(
+        join(projectRoot, ".agents", "plugins", "refresh-tools", "README.md"),
+        "utf-8",
+      ),
+    ).toBe("version one\n");
+
+    await writeFile(join(sourceDir, "README.md"), "version two\n");
+    await expect(
+      runAdd({ scope, specifier: "path:plugin-refresh" }),
+    ).resolves.toBe("refresh-tools");
+
+    expect(await readFile(scope.configPath, "utf-8")).toBe(configBefore);
+    expect(
+      await readFile(
+        join(projectRoot, ".agents", "plugins", "refresh-tools", "README.md"),
+        "utf-8",
+      ),
+    ).toBe("version two\n");
   });
 
   it("restores agents.toml when plugin installation fails", async () => {
@@ -1067,6 +1113,30 @@ describe("add() CLI parsing", () => {
     } finally {
       process.chdir(origCwd);
     }
+  });
+
+  it("reports an existing plugin as refreshed without setting an error", async () => {
+    await writePlugin(join(projectRoot, "plugin-source"), "cli-plugin");
+    await writeFile(
+      join(projectRoot, "agents.toml"),
+      'version = 1\n\n[[plugins]]\nname = "cli-plugin"\nsource = "path:plugin-source"\npath = "."\n',
+    );
+    const install = mockRunInstall();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await add(["path:plugin-source"], {
+      scope: resolveScope("project", projectRoot),
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(install).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Plugin "cli-plugin" is already configured. Refreshed installation.',
+      ),
+    );
   });
 
   it("shows phase progress only in an interactive terminal", async () => {

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -524,6 +524,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
 
     const toAdd: string[] = [];
     const exactDuplicates: string[] = [];
+    const conflictingDuplicates: string[] = [];
     for (const name of selection.names) {
       const existing = config.skills.find((skill) => skill.name === name);
       if (existing) {
@@ -532,6 +533,8 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           existing.ref === effectiveRef
         ) {
           exactDuplicates.push(name);
+        } else {
+          conflictingDuplicates.push(name);
         }
         if (selection.duplicatePolicy === "specified") {
           console.warn(
@@ -547,11 +550,8 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         await persistAndInstall(async () => {});
         return { kind: "skill", result: exactDuplicates, action: "refreshed" };
       }
-      const qualifier = selection.duplicatePolicy === "selected"
-        ? "selected"
-        : "specified";
       throw new AddError(
-        `All ${qualifier} skills already exist in agents.toml with a different source or ref.`,
+        `Skills already exist in agents.toml with a different source or ref: ${conflictingDuplicates.join(", ")}.`,
       );
     }
     await persistAndInstall(async () => {
@@ -599,6 +599,7 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
 
     const toAdd: PluginCandidate[] = [];
     const exactDuplicates: PluginCandidate[] = [];
+    const conflictingDuplicates: PluginCandidate[] = [];
     for (const candidate of selection.candidates) {
       const existing = existingByName.get(candidate.name);
       if (existing) {
@@ -608,6 +609,8 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           (existing.path || ".") === (candidate.path || ".")
         ) {
           exactDuplicates.push(candidate);
+        } else {
+          conflictingDuplicates.push(candidate);
         }
         if (selection.duplicatePolicy === "specified") {
           console.warn(
@@ -627,11 +630,8 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           action: "refreshed",
         };
       }
-      const qualifier = selection.duplicatePolicy === "selected"
-        ? "selected"
-        : "specified";
       throw new AddError(
-        `All ${qualifier} plugins already exist in agents.toml with a different source, ref, or path.`,
+        `Plugins already exist in agents.toml with a different source, ref, or path: ${conflictingDuplicates.map((candidate) => candidate.name).join(", ")}.`,
       );
     }
     await persistAndInstall(async () => {

--- a/packages/dotagents/src/cli/commands/add.ts
+++ b/packages/dotagents/src/cli/commands/add.ts
@@ -96,7 +96,7 @@ type SkillSelection =
   | {
       type: "skills";
       names: string[];
-      /** Single names reject duplicates; specified names warn; prompted selections skip silently. */
+      /** Exact duplicates refresh; specified names warn; prompted selections skip silently. */
       duplicatePolicy: DuplicatePolicy;
     };
 
@@ -108,6 +108,7 @@ interface PluginSelection {
 interface DetailedAddResult {
   kind: "skill" | "plugin";
   result: string | string[];
+  action: "added" | "refreshed";
 }
 
 function containsPath(parentDir: string, childDir: string): boolean {
@@ -474,16 +475,19 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
 
   async function persistSkills(selection: SkillSelection): Promise<DetailedAddResult> {
     if (selection.type === "wildcard") {
-      if (
-        config.skills.some(
-          (skill) =>
-            isWildcardDep(skill) &&
-            sourcesMatch(skill.source, sourceForStorage),
-        )
-      ) {
-        throw new AddError(
-          `A wildcard entry for "${sourceForStorage}" already exists in agents.toml.`,
-        );
+      const existing = config.skills.find(
+        (skill) =>
+          isWildcardDep(skill) &&
+          sourcesMatch(skill.source, sourceForStorage),
+      );
+      if (existing) {
+        if (existing.ref !== effectiveRef) {
+          throw new AddError(
+            `A wildcard entry for "${sourceForStorage}" already exists in agents.toml with a different ref. Remove it first to re-add.`,
+          );
+        }
+        await persistAndInstall(async () => {});
+        return { kind: "skill", result: "*", action: "refreshed" };
       }
       await persistAndInstall(async () => {
         await addWildcardToConfig(configPath, sourceForStorage, {
@@ -491,15 +495,23 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           exclude: [],
         });
       });
-      return { kind: "skill", result: "*" };
+      return { kind: "skill", result: "*", action: "added" };
     }
 
     if (selection.duplicatePolicy === "single") {
       const name = selection.names[0]!;
-      if (config.skills.some((skill) => skill.name === name)) {
-        throw new AddError(
-          `Skill "${name}" already exists in agents.toml. Remove it first to re-add.`,
-        );
+      const existing = config.skills.find((skill) => skill.name === name);
+      if (existing) {
+        if (
+          !sourcesMatch(existing.source, sourceForStorage) ||
+          existing.ref !== effectiveRef
+        ) {
+          throw new AddError(
+            `Skill "${name}" already exists in agents.toml with a different source or ref. Remove it first to re-add.`,
+          );
+        }
+        await persistAndInstall(async () => {});
+        return { kind: "skill", result: name, action: "refreshed" };
       }
       await persistAndInstall(async () => {
         await addSkillToConfig(configPath, name, {
@@ -507,12 +519,20 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           ...refOpts,
         });
       });
-      return { kind: "skill", result: name };
+      return { kind: "skill", result: name, action: "added" };
     }
 
     const toAdd: string[] = [];
+    const exactDuplicates: string[] = [];
     for (const name of selection.names) {
-      if (config.skills.some((skill) => skill.name === name)) {
+      const existing = config.skills.find((skill) => skill.name === name);
+      if (existing) {
+        if (
+          sourcesMatch(existing.source, sourceForStorage) &&
+          existing.ref === effectiveRef
+        ) {
+          exactDuplicates.push(name);
+        }
         if (selection.duplicatePolicy === "specified") {
           console.warn(
             chalk.yellow(`Skipping "${name}": already exists in agents.toml`),
@@ -523,11 +543,15 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
       toAdd.push(name);
     }
     if (toAdd.length === 0) {
+      if (exactDuplicates.length === selection.names.length) {
+        await persistAndInstall(async () => {});
+        return { kind: "skill", result: exactDuplicates, action: "refreshed" };
+      }
       const qualifier = selection.duplicatePolicy === "selected"
         ? "selected"
         : "specified";
       throw new AddError(
-        `All ${qualifier} skills already exist in agents.toml.`,
+        `All ${qualifier} skills already exist in agents.toml with a different source or ref.`,
       );
     }
     await persistAndInstall(async () => {
@@ -538,17 +562,28 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         });
       }
     });
-    return { kind: "skill", result: toAdd };
+    return { kind: "skill", result: toAdd, action: "added" };
   }
 
   async function persistPlugins(selection: PluginSelection): Promise<DetailedAddResult> {
-    const existingNames = new Set(config.plugins.map((plugin) => plugin.name));
+    const existingByName = new Map(
+      config.plugins.map((plugin) => [plugin.name, plugin]),
+    );
     if (selection.duplicatePolicy === "single") {
       const candidate = selection.candidates[0]!;
-      if (existingNames.has(candidate.name)) {
-        throw new AddError(
-          `Plugin "${candidate.name}" already exists in agents.toml. Remove it first to re-add.`,
-        );
+      const existing = existingByName.get(candidate.name);
+      if (existing) {
+        if (
+          !sourcesMatch(existing.source, sourceForStorage) ||
+          existing.ref !== effectiveRef ||
+          (existing.path || ".") !== (candidate.path || ".")
+        ) {
+          throw new AddError(
+            `Plugin "${candidate.name}" already exists in agents.toml with a different source, ref, or path. Remove it first to re-add.`,
+          );
+        }
+        await persistAndInstall(async () => {});
+        return { kind: "plugin", result: candidate.name, action: "refreshed" };
       }
       await persistAndInstall(async () => {
         await addPluginsToConfig(configPath, [{
@@ -559,12 +594,21 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
           path: candidate.path || ".",
         }]);
       });
-      return { kind: "plugin", result: candidate.name };
+      return { kind: "plugin", result: candidate.name, action: "added" };
     }
 
     const toAdd: PluginCandidate[] = [];
+    const exactDuplicates: PluginCandidate[] = [];
     for (const candidate of selection.candidates) {
-      if (existingNames.has(candidate.name)) {
+      const existing = existingByName.get(candidate.name);
+      if (existing) {
+        if (
+          sourcesMatch(existing.source, sourceForStorage) &&
+          existing.ref === effectiveRef &&
+          (existing.path || ".") === (candidate.path || ".")
+        ) {
+          exactDuplicates.push(candidate);
+        }
         if (selection.duplicatePolicy === "specified") {
           console.warn(
             chalk.yellow(`Skipping "${candidate.name}": already exists in agents.toml`),
@@ -575,10 +619,20 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
       toAdd.push(candidate);
     }
     if (toAdd.length === 0) {
+      if (exactDuplicates.length === selection.candidates.length) {
+        await persistAndInstall(async () => {});
+        return {
+          kind: "plugin",
+          result: exactDuplicates.map((candidate) => candidate.name),
+          action: "refreshed",
+        };
+      }
       const qualifier = selection.duplicatePolicy === "selected"
         ? "selected"
         : "specified";
-      throw new AddError(`All ${qualifier} plugins already exist in agents.toml.`);
+      throw new AddError(
+        `All ${qualifier} plugins already exist in agents.toml with a different source, ref, or path.`,
+      );
     }
     await persistAndInstall(async () => {
       await addPluginsToConfig(
@@ -591,7 +645,11 @@ async function executeAdd(opts: AddOptions): Promise<DetailedAddResult> {
         })),
       );
     });
-    return { kind: "plugin", result: toAdd.map((candidate) => candidate.name) };
+    return {
+      kind: "plugin",
+      result: toAdd.map((candidate) => candidate.name),
+      action: "added",
+    };
   }
 
   progress?.start(`Resolving ${specifier}`);
@@ -735,7 +793,7 @@ export default async function add(
     const progress = process.stdout.isTTY === true
       ? clack.spinner({ indicator: "timer" })
       : undefined;
-    const { kind, result } = await executeAdd({
+    const { kind, result, action } = await executeAdd({
       scope,
       specifier,
       ref: values["ref"],
@@ -744,6 +802,28 @@ export default async function add(
       interactive,
       progress,
     });
+    if (action === "refreshed") {
+      if (Array.isArray(result)) {
+        console.log(
+          chalk.green(
+            `${kind === "skill" ? "Skills" : "Plugins"} already configured: ${result.join(", ")}. Refreshed installation.`,
+          ),
+        );
+      } else if (kind === "skill" && result === "*") {
+        console.log(
+          chalk.green(
+            `All skills from ${specifier} are already configured. Refreshed installation.`,
+          ),
+        );
+      } else {
+        console.log(
+          chalk.green(
+            `${kind === "skill" ? "Skill" : "Plugin"} "${result}" is already configured. Refreshed installation.`,
+          ),
+        );
+      }
+      return;
+    }
     if (kind === "skill" && result === "*") {
       console.log(chalk.green(`Added all skills from ${specifier}`));
     } else if (Array.isArray(result)) {

--- a/packages/dotagents/src/cli/help.ts
+++ b/packages/dotagents/src/cli/help.ts
@@ -17,6 +17,7 @@ Options:
   add: `Usage: npx @sentry/dotagents [--project|--global|--user] add <source> [name...] [options]
 
 Discover plugins first, otherwise skills, then add and install the selected dependencies.
+Re-adding an identical declaration refreshes its installation successfully.
 
 Options:
   --name <name>   Dependency name to add; repeatable

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -580,10 +580,10 @@ dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
    - Multiple dependencies use an interactive picker or non-interactive selection guidance
    - Plugin `--all` selects every current plugin explicitly
    - Skill `--all` keeps the wildcard entry that can include future upstream skills
-6. Preflight every requested name and duplicate before changing config. An exact duplicate (same kind, name, source, ref, and plugin path) leaves config unchanged and refreshes installation successfully. Conflicting single-name duplicates still error; multi-name additions skip existing names, and refresh when every requested declaration is an exact duplicate.
+6. Preflight duplicates before changing config. Exact declarations refresh installation; conflicting declarations error when nothing can be added.
    - Reject local plugin sources that overlap the project's managed `.agents/plugins` directory before changing config
 7. Append explicit `[[plugins]]` entries (including the exact safe `path`, with `.` for a source-root plugin) or the selected `[[skills]]` entries
-8. Run install exactly once and update `agents.lock`, including for an exact duplicate
+8. Run install exactly once and update `agents.lock`
    - If config mutation or installation fails, restore the pre-add `agents.toml` content so a failed add does not leave a declaration behind
 
 Global scope uses the same discovery and lifecycle as project scope, with canonical

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -580,10 +580,10 @@ dotagents add myorg/single-skill-repo   # auto-detects if repo has one skill
    - Multiple dependencies use an interactive picker or non-interactive selection guidance
    - Plugin `--all` selects every current plugin explicitly
    - Skill `--all` keeps the wildcard entry that can include future upstream skills
-6. Preflight every requested name and duplicate before changing config. A single duplicate errors; multi-name additions skip duplicates and fail only when all are already declared.
+6. Preflight every requested name and duplicate before changing config. An exact duplicate (same kind, name, source, ref, and plugin path) leaves config unchanged and refreshes installation successfully. Conflicting single-name duplicates still error; multi-name additions skip existing names, and refresh when every requested declaration is an exact duplicate.
    - Reject local plugin sources that overlap the project's managed `.agents/plugins` directory before changing config
 7. Append explicit `[[plugins]]` entries (including the exact safe `path`, with `.` for a source-root plugin) or the selected `[[skills]]` entries
-8. Run install exactly once and update `agents.lock`
+8. Run install exactly once and update `agents.lock`, including for an exact duplicate
    - If config mutation or installation fails, restore the pre-add `agents.toml` content so a failed add does not leave a declaration behind
 
 Global scope uses the same discovery and lifecycle as project scope, with canonical


### PR DESCRIPTION
Make `dotagents add` idempotent when the requested dependency exactly matches
an existing declaration. Repeating the command now leaves `agents.toml`
unchanged, runs the normal install refresh, and reports that the dependency was
already configured instead of exiting with an error.

Conflicting declarations from another source, ref, or plugin path remain
errors. The same refresh behavior applies to skills, plugins, wildcard skills,
and all-duplicate multi-selection requests so scripted setup can safely rerun
without requiring a remove/re-add cycle.
