### PR TITLE
build: Add ast-grep lint rules

### DIFF
--- a/ast-grep/rule-tests/no-direct-child-process-test.yml
+++ b/ast-grep/rule-tests/no-direct-child-process-test.yml
@@ -1,0 +1,6 @@
+id: no-direct-child-process
+valid:
+  - import { exec } from "@sentry/dotagents-lib"
+invalid:
+  - import { execFile } from "node:child_process"
+  - const childProcess = await import("node:child_process")

--- a/ast-grep/rule-tests/no-lib-host-dependencies-test.yml
+++ b/ast-grep/rule-tests/no-lib-host-dependencies-test.yml
@@ -1,0 +1,7 @@
+id: no-lib-host-dependencies
+valid:
+  - import { parseSource } from "@sentry/dotagents-lib"
+invalid:
+  - import { main } from "@sentry/dotagents"
+  - export { main } from "@sentry/dotagents/cli"
+  - const host = await import("@sentry/dotagents")

--- a/ast-grep/rule-tests/no-library-stdio-test.yml
+++ b/ast-grep/rule-tests/no-library-stdio-test.yml
@@ -1,0 +1,6 @@
+id: no-library-stdio
+valid:
+  - onWarning?.("invalid input")
+invalid:
+  - console.log("loaded")
+  - process.stderr.write("failed")

--- a/ast-grep/rule-tests/no-process-exit-test.yml
+++ b/ast-grep/rule-tests/no-process-exit-test.yml
@@ -1,0 +1,5 @@
+id: no-process-exit
+valid:
+  - process.exitCode = 1
+invalid:
+  - process.exit(1)

--- a/ast-grep/rule-tests/subprocess-needs-timeout-test.yml
+++ b/ast-grep/rule-tests/subprocess-needs-timeout-test.yml
@@ -1,0 +1,8 @@
+id: subprocess-needs-timeout
+valid:
+  - |
+    execFile(command, args, { timeout: timeoutMs }, callback)
+invalid:
+  - execFile(command, args, callback)
+  - |
+    spawn(command, args, { stdio: "pipe" })

--- a/ast-grep/rules/no-direct-child-process.yml
+++ b/ast-grep/rules/no-direct-child-process.yml
@@ -1,0 +1,25 @@
+id: no-direct-child-process
+language: TypeScript
+severity: error
+message: Use the @sentry/dotagents-lib exec wrapper instead of accessing node:child_process directly.
+files:
+  - packages/*/src/**/*.ts
+ignores:
+  - packages/dotagents-lib/src/utils/exec.ts
+  - "**/*.test.ts"
+rule:
+  any:
+    - all:
+        - kind: import_statement
+        - has:
+            kind: string
+            regex: '^["'']node:child_process["'']$'
+    - all:
+        - kind: export_statement
+        - has:
+            kind: string
+            regex: '^["'']node:child_process["'']$'
+    - pattern: import($MODULE)
+constraints:
+  MODULE:
+    regex: '^["'']node:child_process["'']$'

--- a/ast-grep/rules/no-lib-host-dependencies.yml
+++ b/ast-grep/rules/no-lib-host-dependencies.yml
@@ -1,0 +1,22 @@
+id: no-lib-host-dependencies
+language: TypeScript
+severity: error
+message: '@sentry/dotagents-lib must not depend on the @sentry/dotagents host package.'
+files:
+  - packages/dotagents-lib/src/**/*.ts
+rule:
+  any:
+    - all:
+        - kind: import_statement
+        - has:
+            kind: string
+            regex: '^["'']@sentry/dotagents(?:/[^"'']*)?["'']$'
+    - all:
+        - kind: export_statement
+        - has:
+            kind: string
+            regex: '^["'']@sentry/dotagents(?:/[^"'']*)?["'']$'
+    - pattern: import($MODULE)
+constraints:
+  MODULE:
+    regex: '^["'']@sentry/dotagents(?:/[^"'']*)?["'']$'

--- a/ast-grep/rules/no-library-stdio.yml
+++ b/ast-grep/rules/no-library-stdio.yml
@@ -1,0 +1,13 @@
+id: no-library-stdio
+language: TypeScript
+severity: error
+message: Reusable library code must return data or use callbacks instead of writing directly to process streams.
+files:
+  - packages/dotagents-lib/src/**/*.ts
+ignores:
+  - "**/*.test.ts"
+rule:
+  any:
+    - pattern: console.$METHOD($$$ARGS)
+    - pattern: process.stdout.write($$$ARGS)
+    - pattern: process.stderr.write($$$ARGS)

--- a/ast-grep/rules/no-process-exit.yml
+++ b/ast-grep/rules/no-process-exit.yml
@@ -1,0 +1,8 @@
+id: no-process-exit
+language: TypeScript
+severity: error
+message: Set process.exitCode instead of calling process.exit so cleanup and output flushing can complete.
+files:
+  - packages/*/src/**/*.ts
+rule:
+  pattern: process.exit($$$ARGS)

--- a/ast-grep/rules/subprocess-needs-timeout.yml
+++ b/ast-grep/rules/subprocess-needs-timeout.yml
@@ -1,0 +1,18 @@
+id: subprocess-needs-timeout
+language: TypeScript
+severity: error
+message: Subprocess calls must pass a timeout option so a stalled command cannot hang dotagents indefinitely.
+files:
+  - packages/dotagents-lib/src/utils/exec.ts
+rule:
+  any:
+    - pattern: execFile($$$ARGS)
+    - pattern: execFileSync($$$ARGS)
+    - pattern: spawn($$$ARGS)
+    - pattern: spawnSync($$$ARGS)
+  not:
+    has:
+      pattern:
+        context: "({ timeout: $TIMEOUT })"
+        selector: pair
+      stopBy: end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
-    "lint": "pnpm -r lint",
+    "lint": "pnpm -r lint && pnpm lint:ast-grep",
+    "lint:ast-grep": "ast-grep scan && ast-grep test --skip-snapshot-tests",
     "typecheck": "pnpm -r typecheck",
     "check": "pnpm lint && pnpm typecheck && pnpm test",
     "dev": "pnpm --filter @sentry/dotagents dev",
@@ -29,6 +30,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.44.1",
     "@types/node": "^25.2.1",
     "lint-staged": "^16.2.7",
     "oxlint": "^1.43.0",
@@ -38,10 +40,6 @@
     "vite": "^7.3.6",
     "vitest": "^4.1.10"
   },
-  "onlyBuiltDependencies": [
-    "esbuild",
-    "simple-git-hooks"
-  ],
   "pnpm": {
     "overrides": {
       "esbuild": "^0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: ^0.44.1
+        version: 0.44.1
       '@types/node':
         specifier: ^25.2.1
         version: 25.2.1
@@ -65,6 +68,55 @@ importers:
         version: 2.8.3
 
 packages:
+
+  '@ast-grep/cli-darwin-arm64@0.44.1':
+    resolution: {integrity: sha512-wOzb+IqFy4Pdhvs+PeaHdQJ1VemsI1SgoOGJf+x0J0KBSJ+s/hUg2n1fVJwfsrw/XDIbz9m7PGKTGCLxsgYa1g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.44.1':
+    resolution: {integrity: sha512-X3OzzsnO9Q3ISQ4qO3jasWk8EZhJA03xfmJHhuS9rGJZZCbNEuqjicrwrDMKK8EgEGJ7MG4oL0BE5qUcn3twLw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.44.1':
+    resolution: {integrity: sha512-2F1YBRd9tQnfrGX+4BlkfXWLb2jqNgTmjp0ETLNRLMmSDinR905QsZn2A55qcAZxhQDU982mEzzgT4NduPXIGg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.44.1':
+    resolution: {integrity: sha512-d5UNoDLT2i6xV4GGqcPnrAR6CB3H078+v3BiqjKxZdZMHFnDe46+i+DxfH1IK6yvJqViqv2F611+wiAAn/s7qw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.44.1':
+    resolution: {integrity: sha512-r6K49Z14BLOeJdBSmaoK+TdgtPRqJfJ562F0n0KvRi0qH3o8is8N2dXtEMYKynYm/tdOd65i69Mc1WKSuIeWyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.44.1':
+    resolution: {integrity: sha512-AusXTP5SfUQEL/EkF0fhHoA4H30M7hsVgvsVEZ7PeZrxB69trzUcqKnHC8pBDYTmgIsJsr9dtXjTPDcBauaPiA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.44.1':
+    resolution: {integrity: sha512-gDMHT17Edmp/tXTDdMSQHd9vJki2Y2WSXq9ycrvjziHwpmnsnc6xlCQ7SEOGA1987vepSpkOkqBCPliP2TVW0w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.44.1':
+    resolution: {integrity: sha512-wSjtu0/9xSYzzo/EW31w5pf1qB33tejYKmKXb2nBAlZ5PpYtOqwFmk9H1nywhjzO913beugsKAZYxrwciqW9AQ==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@clack/core@1.0.1':
     resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
@@ -911,6 +963,39 @@ packages:
 
 snapshots:
 
+  '@ast-grep/cli-darwin-arm64@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli@0.44.1':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.44.1
+      '@ast-grep/cli-darwin-x64': 0.44.1
+      '@ast-grep/cli-linux-arm64-gnu': 0.44.1
+      '@ast-grep/cli-linux-x64-gnu': 0.44.1
+      '@ast-grep/cli-win32-arm64-msvc': 0.44.1
+      '@ast-grep/cli-win32-ia32-msvc': 0.44.1
+      '@ast-grep/cli-win32-x64-msvc': 0.44.1
+
   '@clack/core@1.0.1':
     dependencies:
       picocolors: 1.1.1
@@ -1190,8 +1275,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   emoji-regex@10.6.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - packages/*
+allowBuilds:
+  "@ast-grep/cli": true
+  esbuild: true
+  simple-git-hooks: true

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - ast-grep/rules
+testConfigs:
+  - testDir: ast-grep/rule-tests


### PR DESCRIPTION
Add ast-grep to the root lint pipeline with five tested structural rules covering process exits, subprocess access and timeouts, library stdio, and the dependency direction between the reusable library and host CLI.

These invariants are important to dotagents but are not expressible through the existing oxlint configuration. Keeping them as declarative ast-grep rules makes violations fail in the same local and CI lint path, while rule fixtures guard the checks themselves against regressions.

The subprocess rules deliberately centralize child-process access in the existing library wrapper instead of broadly banning template literals, since dotagents uses argument arrays without shell evaluation. The pnpm build allowlist also moves to the current workspace-level format so ast-grep installs its platform binary without runtime fallback warnings.