### PR TITLE
docs(mcp): Recommend Streamable HTTP

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -117,12 +117,12 @@ command = "npx"
 args = ["-y", "@modelcontextprotocol/server-github"]
 env = ["GITHUB_TOKEN"]
 
-# HTTP MCP server
+# Streamable HTTP MCP server
 [[mcp]]
 name = "remote-api"
-url = "https://mcp.example.com/sse"
+url = "https://mcp.example.com/mcp"
 
-# HTTP server with secrets via env vars
+# Streamable HTTP server with secrets via env vars
 [[mcp]]
 name = "authed-api"
 url = "https://${API_HOST}/mcp"
@@ -200,7 +200,7 @@ Wildcards are expanded during `install`. Each discovered skill gets its own lock
 
 ### MCP Servers
 
-Each `[[mcp]]` entry requires `name` and either `command` (stdio) or `url` (HTTP), not both.
+Each `[[mcp]]` entry requires `name` and either `command` (stdio) or `url` (Streamable HTTP), not both.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -413,14 +413,14 @@ npx @sentry/dotagents mcp add <name> --command "<cmd> [args...]" [--env <VAR>...
 npx @sentry/dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
 ```
 
-Add an MCP server declaration to `agents.toml` and run `install` to generate agent configs. Specify exactly one transport: `--command` for stdio or `--url` for HTTP.
+Add an MCP server declaration to `agents.toml` and run `install` to generate agent configs. Specify exactly one transport: `--command` for stdio or `--url` for Streamable HTTP.
 
 Put stdio command arguments inside the `--command` string. dotagents splits that string into `command` and `args` in `agents.toml`.
 
 | Flag | Description |
 |------|-------------|
 | `--command "<cmd> [args...]"` | Command string to execute (stdio transport) |
-| `--url <url>` | Server URL (HTTP transport) |
+| `--url <url>` | Server URL (Streamable HTTP transport) |
 | `--header <Key:Value>` | HTTP header (repeatable, url servers only) |
 | `--env <VAR>` | Environment variable name to pass through (repeatable) |
 

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -193,13 +193,13 @@ dotagents mcp add <name> --url <url> [--header <Key:Value>...] [--env <VAR>...]
 
 Add an MCP server declaration to `agents.toml` and run `install` to generate
 agent configs. Specify exactly one transport: `--command` for stdio or `--url`
-for HTTP.
+for Streamable HTTP.
 
 Options:
 
 - `--command "<cmd> [args...]"` is the command string to execute for stdio
   transport.
-- `--url <url>` is the server URL for HTTP transport.
+- `--url <url>` is the server URL for Streamable HTTP transport.
 - `--header <Key:Value>` adds an HTTP header. Repeatable. URL servers only.
 - `--env <VAR>` passes through an environment variable. Repeatable.
 
@@ -209,8 +209,8 @@ Examples:
 # Stdio server
 dotagents mcp add github --command "npx -y @modelcontextprotocol/server-github" --env GITHUB_TOKEN
 
-# HTTP server with auth header
-dotagents mcp add remote --url https://mcp.example.com/sse --header "Authorization:Bearer tok"
+# Streamable HTTP server with auth header
+dotagents mcp add remote --url https://mcp.example.com/mcp --header "Authorization:Bearer tok"
 ```
 
 <a id="mcp-remove"></a>

--- a/docs/src/content/docs/guide.mdx
+++ b/docs/src/content/docs/guide.mdx
@@ -196,10 +196,10 @@ command = "npx"
 args = ["-y", "@modelcontextprotocol/server-github"]
 env = ["GITHUB_TOKEN"]
 
-# MCP server (HTTP with OAuth)
+# MCP server (Streamable HTTP with OAuth)
 [[mcp]]
 name = "remote-api"
-url = "https://mcp.example.com/sse"
+url = "https://mcp.example.com/mcp"
 
 # Hooks
 [[hooks]]

--- a/packages/dotagents/src/cli/commands/mcp.test.ts
+++ b/packages/dotagents/src/cli/commands/mcp.test.ts
@@ -92,14 +92,14 @@ describe("mcp", () => {
       await runMcpAdd({
         scope,
         name: "remote",
-        url: "https://mcp.example.com/sse",
+        url: "https://mcp.example.com/mcp",
         headers: ["Authorization:Bearer tok"],
         env: ["API_KEY"],
       });
 
       const config = await loadConfig(scope.configPath);
       expect(config.mcp).toHaveLength(1);
-      expect(config.mcp[0]!.url).toBe("https://mcp.example.com/sse");
+      expect(config.mcp[0]!.url).toBe("https://mcp.example.com/mcp");
       expect(config.mcp[0]!.headers).toEqual({ Authorization: "Bearer tok" });
     });
 

--- a/packages/dotagents/src/cli/commands/mcp.ts
+++ b/packages/dotagents/src/cli/commands/mcp.ts
@@ -154,7 +154,7 @@ async function mcpAddInteractive(name: string | undefined, scope: ScopeRoot): Pr
     message: "Transport",
     options: [
       { label: "Command (stdio)", value: "stdio" as const },
-      { label: "URL (HTTP)", value: "http" as const },
+      { label: "URL (Streamable HTTP)", value: "http" as const },
     ],
   });
   if (clack.isCancel(transport)) {throw new McpCancelledError();}
@@ -180,7 +180,7 @@ async function mcpAddInteractive(name: string | undefined, scope: ScopeRoot): Pr
   } else {
     const urlInput = await clack.text({
       message: "URL",
-      placeholder: "https://mcp.example.com/sse",
+      placeholder: "https://mcp.example.com/mcp",
       validate: (v) => {
         if (!v?.trim()) {return "URL is required.";}
       },

--- a/packages/dotagents/src/cli/commands/sync.test.ts
+++ b/packages/dotagents/src/cli/commands/sync.test.ts
@@ -555,7 +555,7 @@ env = ["GITHUB_TOKEN"]
 
 [[mcp]]
 name = "remote"
-url = "https://mcp.example.com/sse"
+url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer tok" }
 `,
     );
@@ -585,7 +585,7 @@ headers = { Authorization = "Bearer tok" }
         },
         remote: {
           type: "http",
-          url: "https://mcp.example.com/sse",
+          url: "https://mcp.example.com/mcp",
           headers: { Authorization: "Bearer tok" },
         },
       },

--- a/packages/dotagents/src/cli/help.test.ts
+++ b/packages/dotagents/src/cli/help.test.ts
@@ -30,6 +30,13 @@ describe("getCommandHelp", () => {
     );
   });
 
+  it("describes remote MCP servers as Streamable HTTP", () => {
+    const help = getCommandHelp("mcp", ["add", "--help"]);
+
+    expect(help).toContain("Streamable HTTP server URL");
+    expect(help).not.toContain("SSE");
+  });
+
   it("does not intercept normal command arguments", () => {
     expect(getCommandHelp("add", ["getsentry/skills", "find-bugs"])).toBeUndefined();
   });

--- a/packages/dotagents/src/cli/help.ts
+++ b/packages/dotagents/src/cli/help.ts
@@ -68,7 +68,7 @@ Add an MCP server declaration to agents.toml.
 
 Options:
   --command <cmd>       Stdio command including arguments
-  --url <url>           HTTP or SSE server URL
+  --url <url>           Streamable HTTP server URL
   --header <Key:Value>  HTTP header; repeatable and URL transport only
   --env <VAR>           Environment variable name; repeatable
   --help, -h            Show this help message`,

--- a/packages/dotagents/src/config/schema.test.ts
+++ b/packages/dotagents/src/config/schema.test.ts
@@ -444,11 +444,11 @@ describe("agentsConfigSchema", () => {
     it("accepts an http MCP server", () => {
       const result = agentsConfigSchema.safeParse({
         version: 1,
-        mcp: [{ name: "remote", url: "https://mcp.example.com/sse" }],
+        mcp: [{ name: "remote", url: "https://mcp.example.com/mcp" }],
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.mcp[0]!.url).toBe("https://mcp.example.com/sse");
+        expect(result.data.mcp[0]!.url).toBe("https://mcp.example.com/mcp");
       }
     });
 

--- a/packages/dotagents/src/config/schema.ts
+++ b/packages/dotagents/src/config/schema.ts
@@ -131,7 +131,7 @@ const projectConfigSchema = z.object({
 export type ProjectConfig = z.infer<typeof projectConfigSchema>;
 
 /**
- * MCP server declaration: either stdio (command+args) or HTTP (url).
+ * MCP server declaration: either stdio (command+args) or Streamable HTTP (url).
  * env is an array of environment variable names (values come from the user's env).
  */
 const mcpSchema = z
@@ -148,7 +148,7 @@ const mcpSchema = z
       const hasStdio = !!m.command;
       const hasHttp = !!m.url;
       return (hasStdio || hasHttp) && !(hasStdio && hasHttp);
-    }, "MCP server must have either command (stdio) or url (http), but not both"),
+    }, "MCP server must have either command (stdio) or url (Streamable HTTP), but not both"),
   );
 
 export type McpConfig = z.infer<typeof mcpSchema>;

--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -326,7 +326,7 @@ describe("writer", () => {
       });
       await addMcpToConfig(configPath, {
         name: "remote",
-        url: "https://mcp.example.com/sse",
+        url: "https://mcp.example.com/mcp",
         headers: { Authorization: "Bearer tok" },
         env: [],
       });
@@ -339,7 +339,7 @@ describe("writer", () => {
         env: ["GITHUB_TOKEN"],
       });
       expect(config.mcp.find((server) => server.name === "remote")).toMatchObject({
-        url: "https://mcp.example.com/sse",
+        url: "https://mcp.example.com/mcp",
         headers: { Authorization: "Bearer tok" },
       });
     });

--- a/packages/dotagents/src/plugins/schema.test.ts
+++ b/packages/dotagents/src/plugins/schema.test.ts
@@ -283,6 +283,17 @@ describe("plugin MCP schema", () => {
     }
   });
 
+  it("accepts legacy SSE declarations required by Agent Plugins v1", () => {
+    const config = parsePluginMcp({
+      $schema: AGENT_PLUGIN_MCP_SCHEMA,
+      mcpServers: {
+        legacy: { type: "sse", url: "https://example.com/events" },
+      },
+    }, "mcp.json");
+
+    expect(config.mcpServers["legacy"]?.type).toBe("sse");
+  });
+
   it("retains valid MCP servers beside invalid siblings", () => {
     const parsed = parsePluginMcpBestEffort({
       $schema: AGENT_PLUGIN_MCP_SCHEMA,

--- a/packages/dotagents/src/targets/mcp-writer.test.ts
+++ b/packages/dotagents/src/targets/mcp-writer.test.ts
@@ -24,7 +24,7 @@ const STDIO_SERVER: McpDeclaration = {
 
 const HTTP_SERVER: McpDeclaration = {
   name: "remote",
-  url: "https://mcp.example.com/sse",
+  url: "https://mcp.example.com/mcp",
   headers: { Authorization: "Bearer tok" },
 };
 
@@ -238,14 +238,14 @@ describe("writeMcpConfigs", () => {
     const claude = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
     expect(claude.mcpServers.remote).toEqual({
       type: "http",
-      url: "https://mcp.example.com/sse",
+      url: "https://mcp.example.com/mcp",
       headers: { Authorization: "Bearer tok" },
     });
 
     // Cursor
     const cursor = JSON.parse(await readFile(join(dir, ".cursor", "mcp.json"), "utf-8"));
     expect(cursor.mcpServers.remote).toEqual({
-      url: "https://mcp.example.com/sse",
+      url: "https://mcp.example.com/mcp",
       headers: { Authorization: "Bearer tok" },
     });
 
@@ -253,7 +253,7 @@ describe("writeMcpConfigs", () => {
     const vscode = JSON.parse(await readFile(join(dir, ".vscode", "mcp.json"), "utf-8"));
     expect(vscode.servers.remote).toEqual({
       type: "http",
-      url: "https://mcp.example.com/sse",
+      url: "https://mcp.example.com/mcp",
       headers: { Authorization: "Bearer tok" },
     });
 
@@ -263,7 +263,7 @@ describe("writeMcpConfigs", () => {
     );
     expect(opencode.mcp.remote).toEqual({
       type: "remote",
-      url: "https://mcp.example.com/sse",
+      url: "https://mcp.example.com/mcp",
       headers: { Authorization: "Bearer tok" },
     });
 
@@ -271,7 +271,7 @@ describe("writeMcpConfigs", () => {
     const raw = await readFile(join(dir, ".codex", "config.toml"), "utf-8");
     const codex = parseTOML(raw) as Record<string, Record<string, SerializedObject>>;
     expect(codex["mcp_servers"]!["remote"]).toEqual({
-      url: "https://mcp.example.com/sse",
+      url: "https://mcp.example.com/mcp",
       http_headers: { Authorization: "Bearer tok" },
     });
   });
@@ -589,7 +589,7 @@ describe("verifyMcpConfigs", () => {
         },
         remote: {
           type: "http",
-          url: "https://mcp.example.com/sse",
+          url: "https://mcp.example.com/mcp",
           headers: { Authorization: "Bearer tok" },
         },
       },

--- a/packages/dotagents/src/targets/types.ts
+++ b/packages/dotagents/src/targets/types.ts
@@ -3,15 +3,16 @@ import type { SubagentConfigSpec } from "../subagents/types.js";
 import type { SerializedObject, SerializedValue } from "@sentry/dotagents-lib";
 
 /**
- * Universal MCP server declaration from agents.toml [[mcp]] sections.
- * Represents either a stdio or HTTP server.
+ * Universal MCP server declaration used by target serializers. Top-level
+ * [[mcp]] entries use stdio or Streamable HTTP; plugin adapters may retain
+ * legacy SSE endpoints required by Agent Plugins v1.
  */
 export interface McpDeclaration {
   name: string;
   /** For stdio servers */
   command?: string;
   args?: string[];
-  /** For HTTP servers */
+  /** For remote HTTP servers */
   url?: string;
   headers?: Record<string, string>;
   /** Whether target-native environment references should be generated in HTTP values. */

--- a/skills/dotagents/references/cli-reference.md
+++ b/skills/dotagents/references/cli-reference.md
@@ -209,13 +209,13 @@ Add an MCP server declaration.
 
 ```bash
 npx @sentry/dotagents mcp add github --command "npx -y @modelcontextprotocol/server-github" --env GITHUB_TOKEN
-npx @sentry/dotagents mcp add remote-api --url https://mcp.example.com/sse --header "Authorization:Bearer token"
+npx @sentry/dotagents mcp add remote-api --url https://mcp.example.com/mcp --header "Authorization:Bearer token"
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--command "<cmd> [args...]"` | Command to run (stdio transport), including optional arguments |
-| `--url <url>` | HTTP endpoint URL (HTTP transport) |
+| `--url <url>` | Streamable HTTP endpoint URL |
 | `--header <Key:Value>` | HTTP headers (repeatable) |
 | `--env <VAR>` | Environment variable names to pass through (repeatable) |
 

--- a/skills/dotagents/references/config-schema.md
+++ b/skills/dotagents/references/config-schema.md
@@ -116,12 +116,12 @@ args = ["-y", "@modelcontextprotocol/server-github"]  # Optional
 env = ["GITHUB_TOKEN"]             # Optional, env vars to pass through
 ```
 
-### HTTP Transport
+### Streamable HTTP Transport
 
 ```toml
 [[mcp]]
 name = "remote-api"                 # Required, unique server name
-url = "https://mcp.example.com/sse" # Required for HTTP
+url = "https://mcp.example.com/mcp" # Required for Streamable HTTP
 ```
 
 | Field | Type | Required | Description |
@@ -130,7 +130,7 @@ url = "https://mcp.example.com/sse" # Required for HTTP
 | `command` | string | Stdio only | Command to execute |
 | `args` | string[] | No | Command arguments |
 | `env` | string[] | No | Environment variable names to pass through |
-| `url` | string | HTTP only | Server URL |
+| `url` | string | Streamable HTTP only | Server URL |
 | `headers` | table | No | HTTP headers |
 
 ## Hooks Section

--- a/skills/dotagents/references/configuration.md
+++ b/skills/dotagents/references/configuration.md
@@ -91,10 +91,10 @@ command = "npx"
 args = ["-y", "@modelcontextprotocol/server-github"]
 env = ["GITHUB_TOKEN"]
 
-# HTTP transport
+# Streamable HTTP transport
 [[mcp]]
 name = "remote-api"
-url = "https://mcp.example.com/sse"
+url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer token" }
 ```
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -64,10 +64,10 @@ env = ["GITHUB_TOKEN"]
 
 [[mcp]]
 name = "remote-api"
-url = "https://mcp.example.com/sse"
+url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer tok" }
 
-# HTTP server with secrets via env vars
+# Streamable HTTP server with secrets via env vars
 [[mcp]]
 name = "authed-api"
 url = "https://${API_HOST}/mcp"
@@ -175,11 +175,11 @@ MCP server declarations. Each entry defines an MCP server that dotagents will co
 | `name` | Yes | Server name (used as key in generated config files). |
 | `command` | Conditional | Command to run (stdio transport). Required if `url` is not set. |
 | `args` | No | Arguments for the command. Defaults to `[]`. |
-| `url` | Conditional | URL for HTTP/SSE transport. Required if `command` is not set. |
+| `url` | Conditional | URL for Streamable HTTP transport. Required if `command` is not set. |
 | `headers` | No | HTTP headers (only for `url` servers). Supports `${VAR}` syntax for env var interpolation. |
 | `env` | No | Array of environment variable names. Values are referenced from the user's environment. Defaults to `[]`. |
 
-A server must have either `command` (stdio) or `url` (HTTP), but not both.
+A server must have either `command` (stdio) or `url` (Streamable HTTP), but not both.
 
 **Environment variable interpolation.** Use `${VAR}` in header values and `url` to reference secrets from the environment (e.g. `headers = { X-Api-Key = "${API_KEY}" }`). Write `${VAR}` in `agents.toml` — dotagents translates it to each agent's native syntax when generating config files:
 

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -223,7 +223,9 @@ Rules:
    `plugin.json`; a mismatch disables MCP for the plugin but does not invalidate
    its skills.
 2. `mcpServers` is a required object. Its member names identify servers.
-3. Each server has a required `type`: `stdio`, `streamable-http`, or `sse`.
+3. Each server has a required `type`: `stdio`, `streamable-http`, or legacy
+   `sse`. New remote declarations should use `streamable-http`; `sse` remains
+   accepted for Agent Plugins v1 compatibility.
 4. A stdio `command` is one bare executable token or a plugin-relative path
    beginning with `./`. Placeholder expansion does not apply to `command`.
 5. `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` are the only portable placeholders.


### PR DESCRIPTION
Recommend Streamable HTTP for URL-based MCP declarations across CLI help,
interactive prompts, specs, maintained docs, and examples. Legacy `/sse`
samples now use `/mcp`.

The [2026-07-28 MCP revision](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
deprecates HTTP+SSE. dotagents does not speak the MCP wire protocol, so generated
client config shapes and existing user URLs remain unchanged. Agent Plugins v1
`sse` parsing remains supported and has regression coverage.
