### PR TITLE
fix: remove nested mcp tables

### DIFF
--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -378,6 +378,62 @@ describe("writer", () => {
       }]);
     });
 
+    it.each([
+      ["whitespace around the dotted key", "[mcp . headers]"],
+      ["a quoted root key", "[\"mcp\".headers]"],
+    ])("removes nested headers with %s", async (_description, headersTable) => {
+      const input = `version = 1
+
+[[mcp]]
+name = "remove-me"
+url = "https://remove.example.test/mcp"
+
+${headersTable}
+Authorization = "\${REMOVE_TOKEN}"
+
+[[mcp]]
+name = "keep-me"
+command = "keep-command"
+`;
+      await writeFile(configPath, input);
+
+      await removeMcpFromConfig(configPath, "remove-me");
+
+      const config = await loadConfig(configPath);
+      expect(config.mcp).toEqual([{
+        name: "keep-me",
+        command: "keep-command",
+        env: [],
+      }]);
+    });
+
+    it("does not use a nested header name to select a server", async () => {
+      const input = `version = 1
+
+[[mcp]]
+"name" = "keep-me"
+url = "https://keep.example.test/mcp"
+
+[mcp.headers]
+name = "remove-me"
+
+[[mcp]]
+name = "remove-me"
+command = "remove-command"
+`;
+      await writeFile(configPath, input);
+
+      await removeMcpFromConfig(configPath, "remove-me");
+
+      const config = await loadConfig(configPath);
+      expect(config.mcp).toEqual([{
+        name: "keep-me",
+        url: "https://keep.example.test/mcp",
+        headers: { name: "remove-me" },
+        env: [],
+      }]);
+    });
+
     it("does not affect skills with same name", async () => {
       await addSkillToConfig(configPath, "github", {
         source: "org/github-skill",

--- a/packages/dotagents/src/config/writer.test.ts
+++ b/packages/dotagents/src/config/writer.test.ts
@@ -353,6 +353,31 @@ describe("writer", () => {
       expect(after).toBe(before);
     });
 
+    it("removes nested headers without changing another server", async () => {
+      await addMcpToConfig(configPath, {
+        name: "remove-me",
+        url: "https://remove.example.test/mcp",
+        headers: { Authorization: "${REMOVE_TOKEN}" },
+        env: [],
+      });
+      await addMcpToConfig(configPath, {
+        name: "keep-me",
+        url: "https://keep.example.test/mcp",
+        headers: { Authorization: "${KEEP_TOKEN}" },
+        env: [],
+      });
+
+      await removeMcpFromConfig(configPath, "remove-me");
+
+      const config = await loadConfig(configPath);
+      expect(config.mcp).toEqual([{
+        name: "keep-me",
+        url: "https://keep.example.test/mcp",
+        headers: { Authorization: "${KEEP_TOKEN}" },
+        env: [],
+      }]);
+    });
+
     it("does not affect skills with same name", async () => {
       await addSkillToConfig(configPath, "github", {
         source: "org/github-skill",

--- a/packages/dotagents/src/config/writer.ts
+++ b/packages/dotagents/src/config/writer.ts
@@ -1,12 +1,16 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { stringify } from "smol-toml";
+import { parse as parseTOML, stringify } from "smol-toml";
 import type {
   WildcardSkillDependency,
   TrustConfig,
   McpConfig,
   PluginConfig,
 } from "./schema.js";
-import { sourcesMatch, type SerializedObject } from "@sentry/dotagents-lib";
+import {
+  isSerializedObject,
+  sourcesMatch,
+  type SerializedObject,
+} from "@sentry/dotagents-lib";
 
 export interface DefaultConfigOptions {
   agents?: string[];
@@ -222,10 +226,27 @@ function extractTomlStringValue(line: string, key: string): string | undefined {
   return match?.[1] ?? match?.[2];
 }
 
-/** Half-open table range ending before its separator blank lines or the next header. */
+/** Half-open table range, with fields ending before the first nested table. */
 interface ArrayTableSpan {
   start: number;
+  fieldsEnd: number;
   end: number;
+}
+
+function classifyTableHeader(
+  line: string,
+  nestedTableName?: string,
+): "nested" | "other" | undefined {
+  if (!line.startsWith("[")) {return undefined;}
+
+  try {
+    const parsed = parseTOML(line);
+    const root = nestedTableName ? parsed[nestedTableName] : undefined;
+    const definesNestedTable = isSerializedObject(root) && Object.keys(root).length > 0;
+    return definesNestedTable ? "nested" : "other";
+  } catch {
+    return undefined;
+  }
 }
 
 function findArrayTables(
@@ -234,9 +255,6 @@ function findArrayTables(
   nestedTableName?: string,
 ): ArrayTableSpan[] {
   const spans: ArrayTableSpan[] = [];
-  const nestedTablePrefixes = nestedTableName
-    ? [`[${nestedTableName}.`, `[[${nestedTableName}.`]
-    : [];
   let i = 0;
   while (i < lines.length) {
     if (lines[i]!.trim() !== header) {
@@ -245,20 +263,18 @@ function findArrayTables(
     }
 
     const start = i;
+    let fieldsEnd: number | undefined;
     i++;
     while (i < lines.length) {
       const line = lines[i]!.trim();
-      if (
-        line.startsWith("[")
-        && !nestedTablePrefixes.some((prefix) => line.startsWith(prefix))
-      ) {
-        break;
-      }
+      const tableHeader = classifyTableHeader(line, nestedTableName);
+      if (tableHeader === "other") {break;}
+      if (tableHeader === "nested") {fieldsEnd ??= i;}
       i++;
     }
     let end = i;
     while (end > start + 1 && lines[end - 1]!.trim() === "") {end--;}
-    spans.push({ start, end });
+    spans.push({ start, fieldsEnd: fieldsEnd ?? end, end });
   }
   return spans;
 }
@@ -269,7 +285,7 @@ function findFieldLine(
   key: string,
 ): number | undefined {
   const assignment = new RegExp(`^${key}\\s*=`);
-  for (let i = span.start + 1; i < span.end; i++) {
+  for (let i = span.start + 1; i < span.fieldsEnd; i++) {
     const trimmed = lines[i]!.trim();
     if (assignment.test(trimmed)) {return i;}
   }

--- a/packages/dotagents/src/config/writer.ts
+++ b/packages/dotagents/src/config/writer.ts
@@ -213,7 +213,7 @@ export async function removeMcpFromConfig(
   name: string,
 ): Promise<void> {
   const content = await readFile(filePath, "utf-8");
-  await writeFile(filePath, removeBlockByHeader(content, "[[mcp]]", name), "utf-8");
+  await writeFile(filePath, removeBlockByHeader(content, "[[mcp]]", name, "mcp"), "utf-8");
 }
 
 /** Extract a TOML string value from a line like `key = "value"` or `key = 'value'`. */
@@ -228,8 +228,15 @@ interface ArrayTableSpan {
   end: number;
 }
 
-function findArrayTables(lines: string[], header: string): ArrayTableSpan[] {
+function findArrayTables(
+  lines: string[],
+  header: string,
+  nestedTableName?: string,
+): ArrayTableSpan[] {
   const spans: ArrayTableSpan[] = [];
+  const nestedTablePrefixes = nestedTableName
+    ? [`[${nestedTableName}.`, `[[${nestedTableName}.`]
+    : [];
   let i = 0;
   while (i < lines.length) {
     if (lines[i]!.trim() !== header) {
@@ -239,7 +246,16 @@ function findArrayTables(lines: string[], header: string): ArrayTableSpan[] {
 
     const start = i;
     i++;
-    while (i < lines.length && !lines[i]!.trim().startsWith("[")) {i++;}
+    while (i < lines.length) {
+      const line = lines[i]!.trim();
+      if (
+        line.startsWith("[")
+        && !nestedTablePrefixes.some((prefix) => line.startsWith(prefix))
+      ) {
+        break;
+      }
+      i++;
+    }
     let end = i;
     while (end > start + 1 && lines[end - 1]!.trim() === "") {end--;}
     spans.push({ start, end });
@@ -275,8 +291,9 @@ function removeArrayTables(
   lines: string[],
   header: string,
   shouldRemove: (span: ArrayTableSpan) => boolean,
+  nestedTableName?: string,
 ): string {
-  const spans = findArrayTables(lines, header).filter(shouldRemove);
+  const spans = findArrayTables(lines, header, nestedTableName).filter(shouldRemove);
   for (const span of spans.toReversed()) {
     let start = span.start;
     while (start > 0 && lines[start - 1]!.trim() === "") {start--;}
@@ -285,12 +302,18 @@ function removeArrayTables(
   return lines.join("\n");
 }
 
-function removeBlockByHeader(content: string, header: string, name: string): string {
+function removeBlockByHeader(
+  content: string,
+  header: string,
+  name: string,
+  nestedTableName?: string,
+): string {
   const lines = content.split("\n");
   return removeArrayTables(
     lines,
     header,
     (span) => getStringField(lines, span, "name") === name,
+    nestedTableName,
   );
 }
 


### PR DESCRIPTION
`dotagents mcp remove` now removes the selected `[[mcp]]` declaration together with every nested table that belongs to it, while preserving sibling servers and their headers.

The scanner parses table-header lines so equivalent valid TOML forms—including quoted keys and whitespace around dotted keys—are handled consistently. It also keeps the parent field range separate from the full deletion range, preventing a nested header named `name` from selecting an unrelated server. Regression coverage exercises generated HTTP entries, alternate table spellings, and that field-name collision.

Fixes #172.
