### PR TITLE
fix(codex): pass through stdio MCP environment variables

### DIFF
--- a/packages/dotagents/src/targets/definitions/codex.ts
+++ b/packages/dotagents/src/targets/definitions/codex.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import type { AgentDefinition } from "../types.js";
 import { UnsupportedFeature } from "../errors.js";
 import claude from "./claude.js";
-import { envRecord, extractCodexHeaders } from "./helpers.js";
+import { extractCodexHeaders } from "./helpers.js";
 import { markManagedTomlSubagent, serializeCodexSubagent } from "../../subagents/format.js";
 
 const codex: AgentDefinition = {
@@ -31,8 +31,12 @@ const codex: AgentDefinition = {
         ...(envHttpHeaders && { env_http_headers: envHttpHeaders }),
       }];
     }
-    const env = envRecord(s.env, (k) => `\${${k}}`, s.envValues);
-    return [s.name, { command: s.command, args: s.args ?? [], ...(env && { env }) }];
+    return [s.name, {
+      command: s.command,
+      args: s.args ?? [],
+      ...(s.envValues && { env: s.envValues }),
+      ...(s.env?.length && { env_vars: s.env }),
+    }];
   },
   hooks: undefined,
   serializeHooks() {

--- a/packages/dotagents/src/targets/mcp-writer.test.ts
+++ b/packages/dotagents/src/targets/mcp-writer.test.ts
@@ -103,12 +103,21 @@ describe("writeMcpConfigs", () => {
     });
   });
 
-  it("writes codex .codex/config.toml", async () => {
-    await writeMcpConfigs(["codex"], [STDIO_SERVER], projectMcpResolver(dir));
+  it("writes codex stdio environment names and literal values in their native fields", async () => {
+    await writeMcpConfigs(["codex"], [{
+      ...STDIO_SERVER,
+      envValues: { PLUGIN_ROOT: "/plugins/github" },
+    }], projectMcpResolver(dir));
 
-    const raw = await readFile(join(dir, ".codex", "config.toml"), "utf-8");
-    expect(raw).toContain("mcp_servers");
-    expect(raw).toContain("github");
+    const content = parseTomlObject(
+      await readFile(join(dir, ".codex", "config.toml"), "utf-8"),
+    );
+    expect(childObject(content, "mcp_servers")["github"]).toEqual({
+      command: "npx",
+      args: ["-y", "@mcp/server-github"],
+      env: { PLUGIN_ROOT: "/plugins/github" },
+      env_vars: ["GITHUB_TOKEN"],
+    });
   });
 
   it("writes .opencode/opencode.jsonc by default", async () => {


### PR DESCRIPTION
Codex stdio MCP declarations now serialize inherited environment names to `env_vars`, while adapter-provided literal values remain under `env`.

Codex treats `env` values literally, so the previous `${VAR}` output passed that text to child processes instead of inheriting the variable. The Codex writer coverage now asserts the complete parsed server shape, including both native fields.

Fixes #158
