### PR TITLE
fix(pi): Discover nested plugin skills

### DIFF
--- a/packages/dotagents/src/plugins/runtime/writer.test.ts
+++ b/packages/dotagents/src/plugins/runtime/writer.test.ts
@@ -1058,6 +1058,30 @@ describe("plugin writer", () => {
     );
   });
 
+  it("projects nested native plugin skills into Pi's agentskills location", async () => {
+    const alpha = await plugin("alpha-tools", {
+      nativeSource: "claude",
+      manifest: {
+        name: "alpha-tools",
+        skills: ["./skills/engineering/code-review"],
+      },
+    });
+    const skillDir = join(alpha.pluginDir, "skills", "engineering", "code-review");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: code-review\ndescription: Review code\n---\n",
+      "utf-8",
+    );
+
+    const result = await writePluginOutputs(["pi"], [alpha], root);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.written).toBe(1);
+    await expectSymlinkTarget(join(root, ".agents", "skills", "code-review"), skillDir);
+    await expect(projectedPiSkillNames(["pi"], [alpha])).resolves.toEqual(["code-review"]);
+  });
+
   it("warns and skips invalid Pi plugin skill names", async () => {
     const alpha = await plugin("alpha-tools");
     await mkdir(join(alpha.pluginDir, "skills", "bad"), { recursive: true });

--- a/packages/dotagents/src/plugins/runtime/writer.ts
+++ b/packages/dotagents/src/plugins/runtime/writer.ts
@@ -713,7 +713,12 @@ async function discoverSkillComponents(
     if (!entry.isDirectory() && !entry.isSymbolicLink()) {continue;}
     const sourcePath = join(skillsDir, entry.name);
     const skillMd = join(sourcePath, "SKILL.md");
-    if (!existsSync(skillMd)) {continue;}
+    if (!existsSync(skillMd)) {
+      if (entry.isDirectory()) {
+        skills.push(...await discoverSkillComponents(agent, plugin, sourcePath, warnings));
+      }
+      continue;
+    }
     if (
       !await isContainedPluginPath(plugin.pluginDir, sourcePath) ||
       !await isContainedPluginPath(plugin.pluginDir, skillMd)

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -167,13 +167,14 @@ interpret them.
 
 ## Skills
 
-Every direct child of `skills/` that contains a valid `SKILL.md` is a plugin
-skill:
+Every directory below `skills/` that contains a valid `SKILL.md` is a plugin
+skill. Category directories may group skills:
 
 ```text
 skills/
-|-- code-review/
-|   `-- SKILL.md
+|-- engineering/
+|   `-- code-review/
+|       `-- SKILL.md
 `-- explain-failure/
     `-- SKILL.md
 ```


### PR DESCRIPTION
Plugin skill projection now descends through real category directories below `skills/` before linking valid leaf skills. This lets Pi expose nested skills from native bundles such as `mattpocock/skills`; OpenCode's shared projection receives the same valid Agent Skills. Existing name validation, containment checks, and managed-link ownership remain unchanged, and category symlinks are not recursively followed.

Fixes #162
